### PR TITLE
Exploration direction

### DIFF
--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -26,7 +26,7 @@ function stateWithApplicableFilters(dashboardState, steps) {
 }
 
 function toJourney(steps) {
-  steps.map((s) => { name: s.name, pathname: s.pathname })
+  return steps.map((s) => ({ name: s.name, pathname: s.pathname }))
 }
 
 function fetchColumnData(site, dashboardState, steps, filter, direction) {

--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -317,7 +317,9 @@ export function FunnelExploration() {
           </button>
         </div>
       </div>
-      <div className="flex gap-3">
+      <div
+        className={`flex gap-3 ${direction === 'backward' ? 'flex-row-reverse' : ''}`}
+      >
         {Array.from({ length: numColumns }, (_, i) => (
           <ExplorationColumn
             key={i}

--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -64,10 +64,6 @@ function ExplorationColumn({
   const [loading, setLoading] = useState(steps !== null)
   const [results, setResults] = useState([])
   const [filter, setFilter] = useState('')
-  const stepsFingerprint =
-    steps === null
-      ? null
-      : steps.map((step) => `${step.name}:${step.pathname}`).join(';')
 
   const debouncedOnSearchInputChange = useDebounce((event) =>
     setFilter(event.target.value)
@@ -111,7 +107,14 @@ function ExplorationColumn({
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dashboardState, stepsFingerprint, filter, direction, site, selected])
+  }, [
+    dashboardState,
+    steps === null ? null : steps.join('|||'),
+    filter,
+    direction,
+    site,
+    selected
+  ])
 
   const maxVisitors = results.length > 0 ? results[0].visitors : 1
 

--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -82,6 +82,10 @@ function ExplorationColumn({
   )
 
   useEffect(() => {
+    if (selected) {
+      return
+    }
+
     if (steps === null) {
       setFilter('')
       setResults([])

--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -64,6 +64,10 @@ function ExplorationColumn({
   const [loading, setLoading] = useState(steps !== null)
   const [results, setResults] = useState([])
   const [filter, setFilter] = useState('')
+  const stepsFingerprint =
+    steps === null
+      ? null
+      : steps.map((step) => `${step.name}:${step.pathname}`).join(';')
 
   const debouncedOnSearchInputChange = useDebounce((event) =>
     setFilter(event.target.value)
@@ -107,14 +111,7 @@ function ExplorationColumn({
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    dashboardState,
-    steps === null ? null : steps.join('|||'),
-    filter,
-    direction,
-    site,
-    selected
-  ])
+  }, [dashboardState, stepsFingerprint, filter, direction, site, selected])
 
   const maxVisitors = results.length > 0 ? results[0].visitors : 1
 

--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -7,18 +7,27 @@ import { useDashboardStateContext } from '../dashboard-state-context'
 import { numberShortFormatter } from '../util/number-formatter'
 
 const PAGE_FILTER_KEYS = ['page', 'entry_page', 'exit_page']
+const EXPLORATION_DIRECTIONS = {
+  FORWARD: 'forward',
+  BACKWARD: 'backward'
+}
 
-function fetchColumnData(site, dashboardState, steps, filter) {
+function stateWithApplicableFilters(dashboardState, steps) {
+  if (steps.length === 0) {
+    return dashboardState
+  }
+
+  return {
+    ...dashboardState,
+    filters: dashboardState.filters.filter(
+      ([_op, key]) => !PAGE_FILTER_KEYS.includes(key)
+    )
+  }
+}
+
+function fetchColumnData(site, dashboardState, steps, filter, direction) {
   // Page filters only apply to the first step — strip them for subsequent columns
-  const stateToUse =
-    steps.length > 0
-      ? {
-          ...dashboardState,
-          filters: dashboardState.filters.filter(
-            ([_op, key]) => !PAGE_FILTER_KEYS.includes(key)
-          )
-        }
-      : dashboardState
+  const stateToUse = stateWithApplicableFilters(dashboardState, steps)
 
   const journey = []
   if (steps.length > 0) {
@@ -29,7 +38,24 @@ function fetchColumnData(site, dashboardState, steps, filter) {
 
   return api.get(url.apiPath(site, '/exploration/next'), stateToUse, {
     journey: JSON.stringify(journey),
-    search_term: filter
+    search_term: filter,
+    direction
+  })
+}
+
+function fetchFunnelData(site, dashboardState, steps, direction) {
+  const stateToUse = stateWithApplicableFilters(dashboardState, steps)
+
+  const journey = []
+  if (steps.length > 0) {
+    for (const s of steps) {
+      journey.push({ name: s.name, pathname: s.pathname })
+    }
+  }
+
+  return api.get(url.apiPath(site, '/exploration/funnel'), stateToUse, {
+    journey: JSON.stringify(journey),
+    direction
   })
 }
 
@@ -37,13 +63,19 @@ function ExplorationColumn({
   header,
   steps,
   selected,
+  selectedVisitors,
   onSelect,
-  dashboardState
+  dashboardState,
+  direction
 }) {
   const site = useSiteContext()
   const [loading, setLoading] = useState(steps !== null)
   const [results, setResults] = useState([])
   const [filter, setFilter] = useState('')
+  const stepsFingerprint =
+    steps === null
+      ? null
+      : steps.map((step) => `${step.name}:${step.pathname}`).join(';')
 
   const debouncedOnSearchInputChange = useDebounce((event) =>
     setFilter(event.target.value)
@@ -64,18 +96,30 @@ function ExplorationColumn({
     setLoading(true)
     setResults([])
 
-    fetchColumnData(site, dashboardState, steps, filter)
+    let cancelled = false
+
+    fetchColumnData(site, dashboardState, steps, filter, direction)
       .then((response) => {
-        setResults(response || [])
+        if (!cancelled) {
+          setResults(response || [])
+        }
       })
       .catch(() => {
-        setResults([])
+        if (!cancelled) {
+          setResults([])
+        }
       })
       .finally(() => {
-        setLoading(false)
+        if (!cancelled) {
+          setLoading(false)
+        }
       })
+
+    return () => {
+      cancelled = true
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dashboardState, steps, filter])
+  }, [dashboardState, stepsFingerprint, filter, direction, site, selected])
 
   const maxVisitors = results.length > 0 ? results[0].visitors : 1
 
@@ -126,11 +170,15 @@ function ExplorationColumn({
             : results.slice(0, 10)
           ).map(({ step, visitors }) => {
             const label = `${step.name} ${step.pathname}`
-            const pct = Math.round((visitors / maxVisitors) * 100)
             const isSelected =
               !!selected &&
               step.name === selected.name &&
               step.pathname === selected.pathname
+            const visitorsToShow =
+              isSelected && selectedVisitors !== null
+                ? selectedVisitors
+                : visitors
+            const pct = Math.round((visitorsToShow / maxVisitors) * 100)
 
             return (
               <li key={label}>
@@ -154,7 +202,7 @@ function ExplorationColumn({
                       {label}
                     </span>
                     <span className="ml-2 shrink-0 text-gray-500 dark:text-gray-400 tabular-nums">
-                      {numberShortFormatter(visitors)}
+                      {numberShortFormatter(visitorsToShow)}
                     </span>
                   </div>
                   <div className="h-1 rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden">
@@ -177,14 +225,22 @@ function ExplorationColumn({
   )
 }
 
-function columnHeader(index) {
-  if (index === 0) return 'Start'
-  return `${index} step${index === 1 ? '' : 's'} after`
+function columnHeader(index, direction) {
+  if (index === 0) {
+    return direction === EXPLORATION_DIRECTIONS.BACKWARD ? 'End' : 'Start'
+  }
+
+  return `${index} step${index === 1 ? '' : 's'} ${
+    direction === EXPLORATION_DIRECTIONS.BACKWARD ? 'before' : 'after'
+  }`
 }
 
 export function FunnelExploration() {
+  const site = useSiteContext()
   const { dashboardState } = useDashboardStateContext()
   const [steps, setSteps] = useState([])
+  const [direction, setDirection] = useState(EXPLORATION_DIRECTIONS.FORWARD)
+  const [funnel, setFunnel] = useState([])
 
   function handleSelect(columnIndex, selected) {
     if (selected === null) {
@@ -194,22 +250,84 @@ export function FunnelExploration() {
     }
   }
 
+  function handleDirectionSelect(nextDirection) {
+    if (nextDirection === direction) return
+    setDirection(nextDirection)
+    setSteps([])
+    setFunnel([])
+  }
+
+  useEffect(() => {
+    if (steps.length === 0) {
+      setFunnel([])
+      return
+    }
+
+    let cancelled = false
+
+    fetchFunnelData(site, dashboardState, steps, direction)
+      .then((response) => {
+        if (!cancelled) {
+          setFunnel(response || [])
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFunnel([])
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [site, dashboardState, steps, direction])
+
   const numColumns = Math.max(steps.length + 1, 3)
 
   return (
     <div className="p-4">
-      <h4 className="mt-2 mb-4 text-base font-semibold dark:text-gray-100">
-        Explore user journeys
-      </h4>
+      <div className="mt-2 mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h4 className="text-base font-semibold dark:text-gray-100">
+          Explore user journeys
+        </h4>
+        <div className="flex shrink-0 rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <button
+            onClick={() =>
+              handleDirectionSelect(EXPLORATION_DIRECTIONS.FORWARD)
+            }
+            className={`px-3 py-1 text-xs font-semibold transition-colors ${
+              direction === EXPLORATION_DIRECTIONS.FORWARD
+                ? 'bg-indigo-500 text-white'
+                : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300'
+            }`}
+          >
+            Forward
+          </button>
+          <button
+            onClick={() =>
+              handleDirectionSelect(EXPLORATION_DIRECTIONS.BACKWARD)
+            }
+            className={`px-3 py-1 text-xs font-semibold transition-colors border-l border-gray-200 dark:border-gray-700 ${
+              direction === EXPLORATION_DIRECTIONS.BACKWARD
+                ? 'bg-indigo-500 text-white'
+                : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300'
+            }`}
+          >
+            Backward
+          </button>
+        </div>
+      </div>
       <div className="flex gap-3">
         {Array.from({ length: numColumns }, (_, i) => (
           <ExplorationColumn
             key={i}
-            header={columnHeader(i)}
+            header={columnHeader(i, direction)}
             steps={steps.length >= i ? steps.slice(0, i) : null}
             selected={steps[i] || null}
+            selectedVisitors={funnel[i]?.visitors ?? null}
             onSelect={(selected) => handleSelect(i, selected)}
             dashboardState={dashboardState}
+            direction={direction}
           />
         ))}
       </div>

--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -82,10 +82,6 @@ function ExplorationColumn({
   )
 
   useEffect(() => {
-    if (selected) {
-      return
-    }
-
     if (steps === null) {
       setFilter('')
       setResults([])

--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -25,16 +25,14 @@ function stateWithApplicableFilters(dashboardState, steps) {
   }
 }
 
+function toJourney(steps) {
+  steps.map((s) => { name: s.name, pathname: s.pathname })
+}
+
 function fetchColumnData(site, dashboardState, steps, filter, direction) {
   // Page filters only apply to the first step — strip them for subsequent columns
   const stateToUse = stateWithApplicableFilters(dashboardState, steps)
-
-  const journey = []
-  if (steps.length > 0) {
-    for (const s of steps) {
-      journey.push({ name: s.name, pathname: s.pathname })
-    }
-  }
+  const journey = toJourney(steps)
 
   return api.get(url.apiPath(site, '/exploration/next'), stateToUse, {
     journey: JSON.stringify(journey),
@@ -45,13 +43,7 @@ function fetchColumnData(site, dashboardState, steps, filter, direction) {
 
 function fetchFunnelData(site, dashboardState, steps, direction) {
   const stateToUse = stateWithApplicableFilters(dashboardState, steps)
-
-  const journey = []
-  if (steps.length > 0) {
-    for (const s of steps) {
-      journey.push({ name: s.name, pathname: s.pathname })
-    }
-  }
+  const journey = toJourney(steps)
 
   return api.get(url.apiPath(site, '/exploration/funnel'), stateToUse, {
     journey: JSON.stringify(journey),

--- a/lib/plausible/stats/exploration.ex
+++ b/lib/plausible/stats/exploration.ex
@@ -39,7 +39,8 @@ defmodule Plausible.Stats.Exploration do
 
   @spec next_steps(Query.t(), journey(), String.t(), direction()) ::
           {:ok, [next_step()]}
-          def next_steps(query, journey, search_term \\ "", direction \\ :forward) when is_direction(direction) do
+  def next_steps(query, journey, search_term \\ "", direction \\ :forward)
+      when is_direction(direction) do
     query
     |> Base.base_event_query()
     |> next_steps_query(journey, search_term, direction)

--- a/lib/plausible/stats/exploration.ex
+++ b/lib/plausible/stats/exploration.ex
@@ -21,6 +21,9 @@ defmodule Plausible.Stats.Exploration do
   alias Plausible.Stats.Query
 
   @type journey() :: [Journey.Step.t()]
+  @type direction() :: :forward | :backward
+
+  defguard is_direction(value) when value in [:forward, :backward]
 
   @type next_step() :: %{
           step: Journey.Step.t(),
@@ -34,32 +37,34 @@ defmodule Plausible.Stats.Exploration do
           dropoff_percentage: String.t()
         }
 
-  @spec next_steps(Query.t(), journey(), String.t()) ::
+  @spec next_steps(Query.t(), journey(), String.t(), direction()) ::
           {:ok, [next_step()]}
-  def next_steps(query, journey, search_term \\ "") do
+          def next_steps(query, journey, search_term \\ "", direction \\ :forward) when is_direction(direction) do
     query
     |> Base.base_event_query()
-    |> next_steps_query(journey, search_term)
+    |> next_steps_query(journey, search_term, direction)
     |> ClickhouseRepo.all()
     |> then(&{:ok, &1})
   end
 
-  @spec journey_funnel(Query.t(), journey()) ::
+  @spec journey_funnel(Query.t(), journey(), direction()) ::
           {:ok, [funnel_step()]} | {:error, :empty_journey}
-  def journey_funnel(_query, []), do: {:error, :empty_journey}
+  def journey_funnel(query, journey, direction \\ :forward)
 
-  def journey_funnel(query, journey) do
+  def journey_funnel(_query, [], _direction), do: {:error, :empty_journey}
+
+  def journey_funnel(query, journey, direction) when is_direction(direction) do
     query
     |> Base.base_event_query()
-    |> journey_funnel_query(journey)
+    |> journey_funnel_query(journey, direction)
     |> ClickhouseRepo.all()
     |> to_funnel(journey)
     |> then(&{:ok, &1})
   end
 
-  defp next_steps_query(query, steps, search_term) do
+  defp next_steps_query(query, steps, search_term, direction) do
     next_step_idx = length(steps) + 1
-    q_steps = steps_query(query, next_step_idx)
+    q_steps = steps_query(query, next_step_idx, direction)
 
     next_name = :"name#{next_step_idx}"
     next_pathname = :"pathname#{next_step_idx}"
@@ -96,8 +101,8 @@ defmodule Plausible.Stats.Exploration do
     end)
   end
 
-  defp journey_funnel_query(query, steps) do
-    q_steps = steps_query(query, length(steps))
+  defp journey_funnel_query(query, steps, direction) do
+    q_steps = steps_query(query, length(steps), direction)
 
     [first_step | steps] = steps
 
@@ -129,10 +134,16 @@ defmodule Plausible.Stats.Exploration do
     end)
   end
 
-  defp steps_query(query, steps) when is_integer(steps) do
+  defp steps_query(query, steps, direction) when is_integer(steps) do
+    event_ordering =
+      case direction do
+        :backward -> [desc: :timestamp]
+        _ -> [asc: :timestamp]
+      end
+
     q_steps =
       from(e in query,
-        windows: [step_window: [partition_by: e.user_id, order_by: e.timestamp]],
+        windows: [step_window: [partition_by: e.user_id, order_by: ^event_ordering]],
         select: %{
           user_id: e.user_id,
           _sample_factor: e._sample_factor,
@@ -140,7 +151,7 @@ defmodule Plausible.Stats.Exploration do
           pathname1: e.pathname
         },
         where: e.name != "engagement",
-        order_by: e.timestamp
+        order_by: ^event_ordering
       )
 
     if steps > 1 do

--- a/lib/plausible/stats/exploration.ex
+++ b/lib/plausible/stats/exploration.ex
@@ -55,11 +55,14 @@ defmodule Plausible.Stats.Exploration do
   def journey_funnel(_query, [], _direction), do: {:error, :empty_journey}
 
   def journey_funnel(query, journey, direction) when is_direction(direction) do
+    journey_for_query = journey_for_query(journey, direction)
+
     query
     |> Base.base_event_query()
-    |> journey_funnel_query(journey, direction)
+    |> journey_funnel_query(journey_for_query)
     |> ClickhouseRepo.all()
-    |> to_funnel(journey)
+    |> to_funnel(journey_for_query)
+    |> maybe_reverse_funnel(direction)
     |> then(&{:ok, &1})
   end
 
@@ -102,8 +105,8 @@ defmodule Plausible.Stats.Exploration do
     end)
   end
 
-  defp journey_funnel_query(query, steps, direction) do
-    q_steps = steps_query(query, length(steps), direction)
+  defp journey_funnel_query(query, steps) do
+    q_steps = steps_query(query, length(steps), :forward)
 
     [first_step | steps] = steps
 
@@ -217,4 +220,10 @@ defmodule Plausible.Stats.Exploration do
     |> Map.fetch!(:funnel)
     |> Enum.reverse()
   end
+
+  defp journey_for_query(journey, :backward), do: Enum.reverse(journey)
+  defp journey_for_query(journey, :forward), do: journey
+
+  defp maybe_reverse_funnel(funnel, :backward), do: Enum.reverse(funnel)
+  defp maybe_reverse_funnel(funnel, :forward), do: funnel
 end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -345,9 +345,6 @@ defmodule PlausibleWeb.Api.StatsController do
          {:ok, next_steps} <- Exploration.next_steps(query, journey, search_term, direction) do
       json(conn, next_steps)
     else
-      {:error, :invalid_direction} ->
-        bad_request(conn, "Invalid value for direction. Accepted values are: forward, backward")
-
       _ ->
         bad_request(conn, "There was an error with your request")
     end
@@ -362,9 +359,6 @@ defmodule PlausibleWeb.Api.StatsController do
          {:ok, funnel} <- Exploration.journey_funnel(query, journey, direction) do
       json(conn, funnel)
     else
-      {:error, :invalid_direction} ->
-        bad_request(conn, "Invalid value for direction. Accepted values are: forward, backward")
-
       {:error, :empty_journey} ->
         bad_request(
           conn,

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -340,10 +340,14 @@ defmodule PlausibleWeb.Api.StatsController do
     search_term = params["search_term"] || ""
 
     with {:ok, journey} <- parse_journey(steps),
+         {:ok, direction} <- parse_exploration_direction(params["direction"]),
          query = Query.from(site, params, debug_metadata: debug_metadata(conn)),
-         {:ok, next_steps} <- Exploration.next_steps(query, journey, search_term) do
+         {:ok, next_steps} <- Exploration.next_steps(query, journey, search_term, direction) do
       json(conn, next_steps)
     else
+      {:error, :invalid_direction} ->
+        bad_request(conn, "Invalid value for direction. Accepted values are: forward, backward")
+
       _ ->
         bad_request(conn, "There was an error with your request")
     end
@@ -353,10 +357,14 @@ defmodule PlausibleWeb.Api.StatsController do
     site = conn.assigns.site
 
     with {:ok, journey} <- parse_journey(steps),
+         {:ok, direction} <- parse_exploration_direction(params["direction"]),
          query = Query.from(site, params, debug_metadata: debug_metadata(conn)),
-         {:ok, funnel} <- Exploration.journey_funnel(query, journey) do
+         {:ok, funnel} <- Exploration.journey_funnel(query, journey, direction) do
       json(conn, funnel)
     else
+      {:error, :invalid_direction} ->
+        bad_request(conn, "Invalid value for direction. Accepted values are: forward, backward")
+
       {:error, :empty_journey} ->
         bad_request(
           conn,
@@ -381,6 +389,10 @@ defmodule PlausibleWeb.Api.StatsController do
       pathname: pathname
     }
   end
+
+  defp parse_exploration_direction("backward"), do: {:ok, :backward}
+  defp parse_exploration_direction("forward"), do: {:ok, :forward}
+  defp parse_exploration_direction(_), do: {:ok, :forward}
 
   on_ee do
     def funnel(conn, %{"id" => funnel_id} = params) do

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -129,6 +129,32 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert {:error, :empty_journey} = Exploration.journey_funnel(query, [])
     end
+
+    test "supports backward journey funnel", %{site: site} do
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/logout"},
+        %Exploration.Journey.Step{name: "pageview", pathname: "/login"},
+        %Exploration.Journey.Step{name: "pageview", pathname: "/home"}
+      ]
+
+      assert {:ok, [step1, step2, step3]} =
+               Exploration.journey_funnel(query, journey, :backward)
+
+      assert step1.step.pathname == "/logout"
+      assert step1.visitors == 2
+      assert step1.dropoff == 0
+      assert step1.dropoff_percentage == "0"
+      assert step2.step.pathname == "/login"
+      assert step2.visitors == 1
+      assert step2.dropoff == 1
+      assert step2.dropoff_percentage == "50"
+      assert step3.step.pathname == "/home"
+      assert step3.visitors == 1
+      assert step3.dropoff == 0
+      assert step3.dropoff_percentage == "0"
+    end
   end
 
   describe "next_steps" do
@@ -198,6 +224,22 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert next_step.step.pathname == "/docs"
       assert next_step.visitors == 1
+    end
+
+    test "supports backward exploration", %{site: site} do
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/logout"}
+      ]
+
+      assert {:ok, [next_step1, next_step2]} =
+               Exploration.next_steps(query, journey, "", :backward)
+
+      assert next_step1.step.pathname == "/docs"
+      assert next_step1.visitors == 1
+      assert next_step2.step.pathname == "/login"
+      assert next_step2.visitors == 1
     end
   end
 end

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -143,15 +143,15 @@ defmodule Plausible.Stats.ExplorationTest do
                Exploration.journey_funnel(query, journey, :backward)
 
       assert step1.step.pathname == "/logout"
-      assert step1.visitors == 2
-      assert step1.dropoff == 0
-      assert step1.dropoff_percentage == "0"
+      assert step1.visitors == 1
+      assert step1.dropoff == 1
+      assert step1.dropoff_percentage == "50"
       assert step2.step.pathname == "/login"
-      assert step2.visitors == 1
-      assert step2.dropoff == 1
-      assert step2.dropoff_percentage == "50"
+      assert step2.visitors == 2
+      assert step2.dropoff == 0
+      assert step2.dropoff_percentage == "0"
       assert step3.step.pathname == "/home"
-      assert step3.visitors == 1
+      assert step3.visitors == 2
       assert step3.dropoff == 0
       assert step3.dropoff_percentage == "0"
     end

--- a/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
@@ -168,15 +168,15 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
         assert [step1, step2, step3] = resp
 
         assert step1["step"]["pathname"] == "/logout"
-        assert step1["visitors"] == 2
-        assert step1["dropoff"] == 0
-        assert step1["dropoff_percentage"] == "0"
+        assert step1["visitors"] == 1
+        assert step1["dropoff"] == 1
+        assert step1["dropoff_percentage"] == "50"
         assert step2["step"]["pathname"] == "/login"
-        assert step2["visitors"] == 1
-        assert step2["dropoff"] == 1
-        assert step2["dropoff_percentage"] == "50"
+        assert step2["visitors"] == 2
+        assert step2["dropoff"] == 0
+        assert step2["dropoff_percentage"] == "0"
         assert step3["step"]["pathname"] == "/home"
-        assert step3["visitors"] == 1
+        assert step3["visitors"] == 2
         assert step3["dropoff"] == 0
         assert step3["dropoff_percentage"] == "0"
       end

--- a/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
@@ -101,6 +101,23 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
         assert next_step["step"]["pathname"] == "/docs"
         assert next_step["visitors"] == 1
       end
+
+      test "it supports backward direction", %{conn: conn, site: site} do
+        journey = Jason.encode!([%{name: "pageview", pathname: "/logout"}])
+
+        resp =
+          conn
+          |> get(
+            "/api/stats/#{site.domain}/exploration/next/?journey=#{journey}&direction=backward&period=24h"
+          )
+          |> json_response(200)
+
+        assert [next_step1, next_step2] = resp
+        assert next_step1["step"]["pathname"] == "/docs"
+        assert next_step1["visitors"] == 1
+        assert next_step2["step"]["pathname"] == "/login"
+        assert next_step2["visitors"] == 1
+      end
     end
 
     describe "exploration_funnel/2" do
@@ -131,6 +148,37 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
         assert step3["visitors"] == 1
         assert step3["dropoff"] == 1
         assert step3["dropoff_percentage"] == "50"
+      end
+
+      test "it supports backward direction", %{conn: conn, site: site} do
+        journey =
+          Jason.encode!([
+            %{name: "pageview", pathname: "/logout"},
+            %{name: "pageview", pathname: "/login"},
+            %{name: "pageview", pathname: "/home"}
+          ])
+
+        resp =
+          conn
+          |> get(
+            "/api/stats/#{site.domain}/exploration/funnel/?journey=#{journey}&direction=backward&period=24h"
+          )
+          |> json_response(200)
+
+        assert [step1, step2, step3] = resp
+
+        assert step1["step"]["pathname"] == "/logout"
+        assert step1["visitors"] == 2
+        assert step1["dropoff"] == 0
+        assert step1["dropoff_percentage"] == "0"
+        assert step2["step"]["pathname"] == "/login"
+        assert step2["visitors"] == 1
+        assert step2["dropoff"] == 1
+        assert step2["dropoff_percentage"] == "50"
+        assert step3["step"]["pathname"] == "/home"
+        assert step3["visitors"] == 1
+        assert step3["dropoff"] == 0
+        assert step3["dropoff_percentage"] == "0"
       end
     end
   end


### PR DESCRIPTION
### Changes

This PR adds support for exploration direction - so the journey can be built top-bottom or bottom-up depending on user preference.
For now every change fires two requests - next steps followed by exploration funnel.
In a follow-up PR an attempt will be made to fire funnel query within single HTTP request and only if necessary (that is, only when a step is selected, not when refreshing suggestions).


<img width="2298" height="996" alt="image" src="https://github.com/user-attachments/assets/57fe6734-40ea-48c8-8880-29a9b8c87612" />

