### PR TITLE
Treat a sequence of events with same name/path as a single step

### DIFF
--- a/lib/plausible/stats/exploration.ex
+++ b/lib/plausible/stats/exploration.ex
@@ -145,8 +145,30 @@ defmodule Plausible.Stats.Exploration do
         _ -> [asc: :timestamp]
       end
 
-    q_steps =
+    q_pairs =
       from(e in query,
+        windows: [
+          session_window: [
+            partition_by: e.user_id,
+            order_by: [asc: e.timestamp]
+          ]
+        ],
+        select: %{
+          site_id: e.site_id,
+          user_id: e.user_id,
+          _sample_factor: e._sample_factor,
+          prev_pathname: lag(e.pathname) |> over(:session_window),
+          prev_name: lag(e.name) |> over(:session_window),
+          name: e.name,
+          pathname: e.pathname,
+          timestamp: e.timestamp
+        },
+        where: e.name != "engagement",
+        order_by: [asc: e.timestamp]
+      )
+
+    q_steps =
+      from(e in subquery(q_pairs),
         windows: [step_window: [partition_by: e.user_id, order_by: ^event_ordering]],
         select: %{
           user_id: e.user_id,
@@ -154,7 +176,7 @@ defmodule Plausible.Stats.Exploration do
           name1: e.name,
           pathname1: e.pathname
         },
-        where: e.name != "engagement",
+        where: e.prev_name != e.name or e.prev_pathname != e.pathname,
         order_by: ^event_ordering
       )
 

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -241,5 +241,96 @@ defmodule Plausible.Stats.ExplorationTest do
       assert next_step2.step.pathname == "/login"
       assert next_step2.visitors == 1
     end
+
+    test "treats identical sequence of events as a single step" do
+      site = new_site()
+
+      now = DateTime.utc_now()
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          pathname: "/home",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -270)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/home",
+          timestamp: DateTime.shift(now, minute: -30)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -25)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -24)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/logout",
+          timestamp: DateTime.shift(now, minute: -20)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/home",
+          timestamp: DateTime.shift(now, minute: -30)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -25)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/docs",
+          timestamp: DateTime.shift(now, minute: -20)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/docs",
+          timestamp: DateTime.shift(now, minute: -19)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/logout",
+          timestamp: DateTime.shift(now, minute: -15)
+        )
+      ])
+
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
+        %Exploration.Journey.Step{name: "pageview", pathname: "/login"}
+      ]
+
+      assert {:ok, [next_step1, next_step2, next_step3]} = Exploration.next_steps(query, journey)
+
+      assert next_step1.step.pathname == "/docs"
+      assert next_step1.visitors == 1
+      assert next_step2.step.pathname == "/home"
+      assert next_step2.visitors == 1
+      assert next_step3.step.pathname == "/logout"
+      assert next_step3.visitors == 1
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
+        %Exploration.Journey.Step{name: "pageview", pathname: "/login"},
+        %Exploration.Journey.Step{name: "pageview", pathname: "/docs"}
+      ]
+
+      assert {:ok, [next_step]} = Exploration.next_steps(query, journey)
+
+      assert next_step.step.pathname == "/logout"
+      assert next_step.visitors == 1
+    end
   end
 end

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -275,6 +275,11 @@ defmodule Plausible.Stats.ExplorationTest do
         ),
         build(:pageview,
           user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -23)
+        ),
+        build(:pageview,
+          user_id: 123,
           pathname: "/logout",
           timestamp: DateTime.shift(now, minute: -20)
         ),
@@ -331,6 +336,135 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert next_step.step.pathname == "/logout"
       assert next_step.visitors == 1
+    end
+
+    test "treats identical sequence of events as a single step when searching backwards" do
+      site = new_site()
+
+      now = DateTime.utc_now()
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          pathname: "/home",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -270)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/home",
+          timestamp: DateTime.shift(now, minute: -30)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -25)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -24)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -23)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/logout",
+          timestamp: DateTime.shift(now, minute: -20)
+        )
+      ])
+
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/logout"}
+      ]
+
+      assert {:ok, [next_step]} = Exploration.next_steps(query, journey, "", :backward)
+
+      assert next_step.step.pathname == "/login"
+      assert next_step.visitors == 1
+    end
+
+    test "consecutive events from different users are not merged" do
+      now = DateTime.utc_now()
+
+      site = new_site()
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 124,
+          pathname: "/home",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/home",
+          timestamp: DateTime.shift(now, minute: -30)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -25)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -24)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/login",
+          timestamp: DateTime.shift(now, minute: -23)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/logout",
+          timestamp: DateTime.shift(now, minute: -20)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/logout",
+          timestamp: DateTime.shift(now, minute: -20)
+        )
+      ])
+
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      assert {:ok, [next_step1, next_step2, next_step3]} = Exploration.next_steps(query, [])
+
+      assert next_step1.step.pathname == "/home"
+      assert next_step1.visitors == 2
+      assert next_step2.step.pathname == "/login"
+      assert next_step2.visitors == 2
+      assert next_step3.step.pathname == "/logout"
+      assert next_step3.visitors == 2
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/home"}
+      ]
+
+      assert {:ok, [next_step]} = Exploration.next_steps(query, journey)
+
+      assert next_step.step.pathname == "/login"
+      assert next_step.visitors == 2
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
+        %Exploration.Journey.Step{name: "pageview", pathname: "/login"}
+      ]
+
+      assert {:ok, [next_step]} = Exploration.next_steps(query, journey)
+
+      assert next_step.step.pathname == "/logout"
+      assert next_step.visitors == 2
     end
   end
 end


### PR DESCRIPTION
### Changes

Sequences of events with the same name and pathname within user session are now treated as a single step when exploring user journeys.

### Tests
- [x] Automated tests have been added

