### PR TITLE
Build exploration funnel step labels on the backend and make them searchable

### DIFF
--- a/assets/js/dashboard/stats/exploration.js
+++ b/assets/js/dashboard/stats/exploration.js
@@ -166,7 +166,6 @@ function ExplorationColumn({
               )
             : results.slice(0, 10)
           ).map(({ step, visitors }) => {
-            const label = `${step.name} ${step.pathname}`
             const isSelected =
               !!selected &&
               step.name === selected.name &&
@@ -181,7 +180,7 @@ function ExplorationColumn({
                 : Math.round((visitors / stepMaxVisitors) * 100)
 
             return (
-              <li key={label}>
+              <li key={step.label}>
                 <button
                   className={`group w-full border text-left px-2.5 pt-2 pb-2.5 text-sm rounded-md focus:outline-none ${
                     isSelected
@@ -193,9 +192,9 @@ function ExplorationColumn({
                   <div className="flex items-center justify-between gap-2 mb-1">
                     <span
                       className="truncate font-medium text-gray-800 dark:text-gray-200"
-                      title={label}
+                      title={step.label}
                     >
-                      {label}
+                      {step.label}
                     </span>
                     <span className="shrink-0 text-gray-800 dark:text-gray-200 tabular-nums">
                       {numberShortFormatter(visitorsToShow)}

--- a/lib/plausible/stats/exploration.ex
+++ b/lib/plausible/stats/exploration.ex
@@ -8,8 +8,22 @@ defmodule Plausible.Stats.Exploration do
 
     @type t() :: %__MODULE__{}
 
-    @derive {Jason.Encoder, only: [:name, :pathname]}
-    defstruct [:name, :pathname]
+    @derive {Jason.Encoder, only: [:name, :pathname, :label]}
+    defstruct [:name, :pathname, :label]
+
+    @spec from(map()) :: t()
+    def from(step) do
+      new(step.name, step.pathname)
+    end
+
+    @spec new(String.t(), String.t()) :: t()
+    def new(name, pathname) do
+      %__MODULE__{
+        label: if(name == "pageview", do: "Visit", else: name) <> " " <> pathname,
+        name: name,
+        pathname: pathname
+      }
+    end
   end
 
   import Ecto.Query
@@ -80,6 +94,18 @@ defmodule Plausible.Stats.Exploration do
         where: selected_as(:next_name) != "",
         select: %{
           step: %Journey.Step{
+            label:
+              selected_as(
+                fragment(
+                  "concat(CASE WHEN ? = ? THEN ? ELSE ? END, ' ', ?)",
+                  selected_as(:next_name),
+                  "pageview",
+                  "Visit",
+                  selected_as(:next_name),
+                  selected_as(:next_pathname)
+                ),
+                :next_label
+              ),
             name: selected_as(field(s, ^next_name), :next_name),
             pathname: selected_as(field(s, ^next_pathname), :next_pathname)
           }
@@ -239,11 +265,7 @@ defmodule Plausible.Stats.Exploration do
   defp maybe_search(query, search_term) do
     case String.trim(search_term) do
       term when byte_size(term) > 2 ->
-        from(s in query,
-          where:
-            ilike(selected_as(:next_name), ^"%#{term}%") or
-              ilike(selected_as(:next_pathname), ^"%#{term}%")
-        )
+        from(s in query, where: ilike(selected_as(:next_label), ^"%#{term}%"))
 
       _ ->
         query
@@ -255,6 +277,7 @@ defmodule Plausible.Stats.Exploration do
     |> Enum.with_index()
     |> Enum.reduce(%{funnel: [], visitors_at_previous: nil, total_visitors: nil}, fn {step, idx},
                                                                                      acc ->
+      step = Journey.Step.from(step)
       current_visitors = Map.get(result, idx + 1, 0)
       total_visitors = acc.total_visitors || current_visitors
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -378,10 +378,7 @@ defmodule PlausibleWeb.Api.StatsController do
   end
 
   defp parse_journey_step(%{"name" => name, "pathname" => pathname}) do
-    %Exploration.Journey.Step{
-      name: name,
-      pathname: pathname
-    }
+    Exploration.Journey.Step.new(name, pathname)
   end
 
   defp parse_exploration_direction("backward"), do: {:ok, :backward}

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -101,6 +101,58 @@ defmodule Plausible.Stats.ExplorationTest do
       assert step3.conversion_rate_step == "50"
     end
 
+    test "returns labels" do
+      site = new_site()
+
+      now = DateTime.utc_now()
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          pathname: "/home",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/register",
+          timestamp: DateTime.shift(now, minute: -290)
+        ),
+        build(:event,
+          user_id: 123,
+          name: "Signup",
+          pathname: "/register",
+          timestamp: DateTime.shift(now, minute: -280)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/activate",
+          timestamp: DateTime.shift(now, minute: -270)
+        ),
+        build(:event,
+          user_id: 123,
+          name: "Create site",
+          pathname: "/sites/new",
+          timestamp: DateTime.shift(now, minute: -260)
+        )
+      ])
+
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/register"},
+        %Exploration.Journey.Step{name: "Signup", pathname: "/register"},
+        %Exploration.Journey.Step{name: "pageview", pathname: "/activate"},
+        %Exploration.Journey.Step{name: "Create site", pathname: "/sites/new"}
+      ]
+
+      assert {:ok, [step1, step2, step3, step4]} = Exploration.journey_funnel(query, journey)
+
+      assert step1.step.label == "Visit /register"
+      assert step2.step.label == "Signup /register"
+      assert step3.step.label == "Visit /activate"
+      assert step4.step.label == "Create site /sites/new"
+    end
+
     test "respects filters in the query", %{site: site} do
       query =
         QueryBuilder.build!(site,
@@ -186,10 +238,13 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert {:ok, [next_step1, next_step2, next_step3]} = Exploration.next_steps(query, journey)
 
+      assert next_step1.step.label == "Visit /docs"
       assert next_step1.step.pathname == "/docs"
       assert next_step1.visitors == 1
+      assert next_step2.step.label == "Visit /home"
       assert next_step2.step.pathname == "/home"
       assert next_step2.visitors == 1
+      assert next_step3.step.label == "Visit /logout"
       assert next_step3.step.pathname == "/logout"
       assert next_step3.visitors == 1
     end
@@ -239,6 +294,20 @@ defmodule Plausible.Stats.ExplorationTest do
       ]
 
       assert {:ok, [next_step]} = Exploration.next_steps(query, journey, "doc")
+
+      assert next_step.step.pathname == "/docs"
+      assert next_step.visitors == 1
+    end
+
+    test "allows to filter according to how label is rendered", %{site: site} do
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
+        %Exploration.Journey.Step{name: "pageview", pathname: "/login"}
+      ]
+
+      assert {:ok, [next_step]} = Exploration.next_steps(query, journey, "isit /doc")
 
       assert next_step.step.pathname == "/docs"
       assert next_step.visitors == 1

--- a/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
@@ -78,10 +78,13 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
           |> json_response(200)
 
         assert [next_step1, next_step2, next_step3] = resp
+        assert next_step1["step"]["label"] == "Visit /docs"
         assert next_step1["step"]["pathname"] == "/docs"
         assert next_step1["visitors"] == 1
+        assert next_step2["step"]["label"] == "Visit /home"
         assert next_step2["step"]["pathname"] == "/home"
         assert next_step2["visitors"] == 1
+        assert next_step3["step"]["label"] == "Visit /logout"
         assert next_step3["step"]["pathname"] == "/logout"
         assert next_step3["visitors"] == 1
       end
@@ -146,18 +149,21 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
 
         assert [step1, step2, step3] = resp
 
+        assert step1["step"]["label"] == "Visit /home"
         assert step1["step"]["pathname"] == "/home"
         assert step1["visitors"] == 2
         assert step1["dropoff"] == 0
         assert step1["dropoff_percentage"] == "0"
         assert step1["conversion_rate"] == "100"
         assert step1["conversion_rate_step"] == "0"
+        assert step2["step"]["label"] == "Visit /login"
         assert step2["step"]["pathname"] == "/login"
         assert step2["visitors"] == 2
         assert step2["dropoff"] == 0
         assert step2["dropoff_percentage"] == "0"
         assert step2["conversion_rate"] == "100"
         assert step2["conversion_rate_step"] == "100"
+        assert step3["step"]["label"] == "Visit /logout"
         assert step3["step"]["pathname"] == "/logout"
         assert step3["visitors"] == 1
         assert step3["dropoff"] == 1


### PR DESCRIPTION
### Changes

Journey step labels are now constructed entirely on the backend. It's now also possible to filter by them via step search as they appear.

### Tests
- [x] Automated tests have been added

