### PR TITLE
Fix bad suggestions due to inconsistent ordering in window queries

### DIFF
--- a/lib/plausible/stats/exploration.ex
+++ b/lib/plausible/stats/exploration.ex
@@ -201,8 +201,8 @@ defmodule Plausible.Stats.Exploration do
   defp steps_query(query, steps, direction) when is_integer(steps) do
     event_ordering =
       case direction do
-        :backward -> [desc: :timestamp]
-        _ -> [asc: :timestamp]
+        :backward -> [desc: :timestamp, desc: :name, desc: :pathname]
+        _ -> [asc: :timestamp, asc: :name, asc: :pathname]
       end
 
     q_pairs =
@@ -210,7 +210,7 @@ defmodule Plausible.Stats.Exploration do
         windows: [
           session_window: [
             partition_by: e.user_id,
-            order_by: [asc: e.timestamp]
+            order_by: ^event_ordering
           ]
         ],
         select: %{
@@ -224,7 +224,7 @@ defmodule Plausible.Stats.Exploration do
           timestamp: e.timestamp
         },
         where: e.name != "engagement",
-        order_by: [asc: e.timestamp]
+        order_by: ^event_ordering
       )
 
     q_steps =

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -329,6 +329,103 @@ defmodule Plausible.Stats.ExplorationTest do
       assert next_step2.visitors == 1
     end
 
+    test "does not suggest current first step" do
+      site = new_site()
+
+      populate_stats(site, [
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:07:01Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:14:25Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 09:14:26Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:14:26Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:16:20Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:46:57Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 09:53:04Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:55:02Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 09:55:03Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:11:23Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 10:11:25Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:11:26Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:15:30Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:21:48Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 10:21:49Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:21:50Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:49:45Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 10:49:47Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:49:47Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard/",
+          timestamp: ~U[2026-03-23 10:50:32Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 11:07:53Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 11:07:55Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:19:21Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 13:19:23Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:19:24Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:30:17Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:32:44Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 13:32:45Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:32:46Z]),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 21:48:23Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 21:48:25Z]
+        ),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 21:48:26Z]),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/:dashboard",
+          timestamp: ~U[2026-03-23 21:48:30Z]
+        )
+      ])
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/sites"}
+      ]
+
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      assert {:ok, [%{step: %{pathname: "/:dashboard"}}]} =
+               Exploration.next_steps(query, journey, "", :forward)
+    end
+
     test "treats identical sequence of events as a single step" do
       site = new_site()
 

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -336,10 +336,10 @@ defmodule Plausible.Stats.ExplorationTest do
 
       ago = fn ms -> DateTime.shift(now, minute: -1 * ms) end
 
-      # The issue manifested from some very specific combinations of events with occurrences
-      # of different path/pathname combinations for the same timestamp appearing in it.
+      # The issue manifested in some very specific combinations of events with occurrences
+      # of different path/pathname combinations, some of them with identical timestamp.
       #
-      # The cause was inconsistent ordering between `q_pairs` and `q_steps` in `steps_query`
+      # The cause was inconsistent ordering between `q_pairs` and `q_steps` in `steps_query`.
       #
       populate_stats(site, [
         build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(100)),

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -329,13 +329,18 @@ defmodule Plausible.Stats.ExplorationTest do
       assert next_step2.visitors == 1
     end
 
-    test "does not suggest current first step" do
+    test "does not suggest the same path/pathname as in previous step (regression test)" do
       site = new_site()
 
       now = DateTime.utc_now()
 
       ago = fn ms -> DateTime.shift(now, minute: -1 * ms) end
 
+      # The issue manifested from some very specific combinations of events with occurrences
+      # of different path/pathname combinations for the same timestamp appearing in it.
+      #
+      # The cause was inconsistent ordering between `q_pairs` and `q_steps` in `steps_query`
+      #
       populate_stats(site, [
         build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(100)),
         build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(100)),
@@ -372,8 +377,11 @@ defmodule Plausible.Stats.ExplorationTest do
 
       query = QueryBuilder.build!(site, input_date_range: :all)
 
-      assert {:ok, [%{step: %{pathname: "/:dashboard"}}]} =
+      assert {:ok, [%{step: %{pathname: "/:dashboard"}}, %{step: %{pathname: "/:dashboard/"}}]} =
                Exploration.next_steps(query, journey, "", :forward)
+
+      assert {:ok, [%{step: %{pathname: "/:dashboard"}}, %{step: %{pathname: "/:dashboard/"}}]} =
+               Exploration.next_steps(query, journey, "", :backward)
     end
 
     test "treats identical sequence of events as a single step" do

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -332,88 +332,38 @@ defmodule Plausible.Stats.ExplorationTest do
     test "does not suggest current first step" do
       site = new_site()
 
+      now = DateTime.utc_now()
+
+      ago = fn ms -> DateTime.shift(now, minute: -1 * ms) end
+
       populate_stats(site, [
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:07:01Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:14:25Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 09:14:26Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:14:26Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:16:20Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:46:57Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 09:53:04Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 09:55:02Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 09:55:03Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:11:23Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 10:11:25Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:11:26Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:15:30Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:21:48Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 10:21:49Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:21:50Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:49:45Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 10:49:47Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 10:49:47Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard/",
-          timestamp: ~U[2026-03-23 10:50:32Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 11:07:53Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 11:07:55Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:19:21Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 13:19:23Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:19:24Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:30:17Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:32:44Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 13:32:45Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 13:32:46Z]),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 21:48:23Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 21:48:25Z]
-        ),
-        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ~U[2026-03-23 21:48:26Z]),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/:dashboard",
-          timestamp: ~U[2026-03-23 21:48:30Z]
-        )
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(100)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(100)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(99)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(98)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(97)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(96)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(95)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(94)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(93)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(92)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(91)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(90)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(89)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(88)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(87)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(87)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard/", timestamp: ago.(86)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(85)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(84)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(83)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(82)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(81)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(80)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(79)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(78)),
+        build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(77)),
+        build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(76))
       ])
 
       journey = [


### PR DESCRIPTION
### Changes

Addresses a bug where exact same path and pathname combination is suggested in a following step.

It was caused by inconsistent ordering in cases where events occurred within the same timestamp second. 

Before the fix:

<img width="1132" height="452" alt="image" src="https://github.com/user-attachments/assets/dbc75e1e-05a3-4b5d-b89b-a680c03d8bea" />


After the fix:

<img width="1133" height="452" alt="image" src="https://github.com/user-attachments/assets/27b3cbf9-b482-4e0e-bdac-df59aa142cd4" />


### Tests
- [x] Automated tests have been added
