### PR TITLE
Record trace metadata when executing funnel and exploration queries

### DIFF
--- a/extra/lib/plausible/stats/funnel.ex
+++ b/extra/lib/plausible/stats/funnel.ex
@@ -36,6 +36,8 @@ defmodule Plausible.Stats.Funnel do
       |> Query.set(preloaded_goals: %{all: [], matching_toplevel_filters: goals})
       |> Base.base_event_query()
       |> funnel_query(funnel)
+      # We pass the query struct to record query metadata for
+      # the CH debug console.
       |> ClickhouseRepo.all(query: query)
 
     # Funnel definition steps are 1-indexed, if there's index 0 in the resulting query,

--- a/extra/lib/plausible/stats/funnel.ex
+++ b/extra/lib/plausible/stats/funnel.ex
@@ -35,7 +35,8 @@ defmodule Plausible.Stats.Funnel do
       query
       |> Query.set(preloaded_goals: %{all: [], matching_toplevel_filters: goals})
       |> Base.base_event_query()
-      |> query_funnel(funnel)
+      |> funnel_query(funnel)
+      |> ClickhouseRepo.all(query: query)
 
     # Funnel definition steps are 1-indexed, if there's index 0 in the resulting query,
     # it signifies the number of visitors that haven't entered the funnel.
@@ -62,7 +63,7 @@ defmodule Plausible.Stats.Funnel do
      }}
   end
 
-  defp query_funnel(query, funnel_definition) do
+  defp funnel_query(query, funnel_definition) do
     q_events =
       from(e in query,
         select: %{user_id: e.user_id, _sample_factor: fragment("any(_sample_factor)")},
@@ -72,13 +73,10 @@ defmodule Plausible.Stats.Funnel do
       )
       |> select_funnel(funnel_definition)
 
-    query =
-      from(f in subquery(q_events),
-        select: {f.step, total()},
-        group_by: f.step
-      )
-
-    ClickhouseRepo.all(query)
+    from(f in subquery(q_events),
+      select: {f.step, total()},
+      group_by: f.step
+    )
   end
 
   defp select_funnel(db_query, funnel_definition) do

--- a/lib/plausible/stats/exploration.ex
+++ b/lib/plausible/stats/exploration.ex
@@ -60,7 +60,7 @@ defmodule Plausible.Stats.Exploration do
     query
     |> Base.base_event_query()
     |> next_steps_query(journey, search_term, direction)
-    |> ClickhouseRepo.all()
+    |> ClickhouseRepo.all(query: query)
     |> then(&{:ok, &1})
   end
 
@@ -74,7 +74,7 @@ defmodule Plausible.Stats.Exploration do
     query
     |> Base.base_event_query()
     |> journey_funnel_query(journey, direction)
-    |> ClickhouseRepo.all()
+    |> ClickhouseRepo.all(query: query)
     |> to_funnel(journey)
     |> then(&{:ok, &1})
   end

--- a/lib/plausible/stats/exploration.ex
+++ b/lib/plausible/stats/exploration.ex
@@ -60,6 +60,8 @@ defmodule Plausible.Stats.Exploration do
     query
     |> Base.base_event_query()
     |> next_steps_query(journey, search_term, direction)
+    # We pass the query struct to record query metadata for
+    # the CH debug console.
     |> ClickhouseRepo.all(query: query)
     |> then(&{:ok, &1})
   end
@@ -74,6 +76,8 @@ defmodule Plausible.Stats.Exploration do
     query
     |> Base.base_event_query()
     |> journey_funnel_query(journey, direction)
+    # We pass the query struct to record query metadata for
+    # the CH debug console.
     |> ClickhouseRepo.all(query: query)
     |> to_funnel(journey)
     |> then(&{:ok, &1})


### PR DESCRIPTION
### Changes

This change enables viewing the funnel and exploration queries via /debug/clickhouse endpoint
