### PR TITLE
Remove redundant handler causing double-fetch in realtime

### DIFF
--- a/assets/js/dashboard/stats/graph/visitor-graph.tsx
+++ b/assets/js/dashboard/stats/graph/visitor-graph.tsx
@@ -12,7 +12,6 @@ import { PlausibleSite, useSiteContext } from '../../site-context'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Metric } from '../../../types/query-api'
 import { DashboardPeriod } from '../../dashboard-time-periods'
-import { DashboardState } from '../../dashboard-state'
 import { nowForSite } from '../../util/date'
 import { getStaleTime } from '../../hooks/api-client'
 import { MainGraph, MainGraphContainer, useMainGraphWidth } from './main-graph'
@@ -172,17 +171,6 @@ export default function VisitorGraph({
   useEffect(() => {
     const onTick = () => {
       setIsRealtimeSilentUpdate({ topStats: true, mainGraph: true })
-      queryClient.invalidateQueries({
-        predicate: ({ queryKey }) => {
-          const realtimeTopStatsOrMainGraphQuery =
-            ['top-stats', 'main-graph'].includes(queryKey[0] as string) &&
-            typeof queryKey[1] === 'object' &&
-            (queryKey[1] as { dashboardState?: DashboardState })?.dashboardState
-              ?.period === DashboardPeriod.realtime
-
-          return realtimeTopStatsOrMainGraphQuery
-        }
-      })
       refetchTopStats()
       refetchMainGraph()
     }

--- a/assets/js/dashboard/stats/graph/visitor-graph.tsx
+++ b/assets/js/dashboard/stats/graph/visitor-graph.tsx
@@ -12,6 +12,7 @@ import { PlausibleSite, useSiteContext } from '../../site-context'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Metric } from '../../../types/query-api'
 import { DashboardPeriod } from '../../dashboard-time-periods'
+import { DashboardState } from '../../dashboard-state'
 import { nowForSite } from '../../util/date'
 import { getStaleTime } from '../../hooks/api-client'
 import { MainGraph, MainGraphContainer, useMainGraphWidth } from './main-graph'
@@ -171,6 +172,17 @@ export default function VisitorGraph({
   useEffect(() => {
     const onTick = () => {
       setIsRealtimeSilentUpdate({ topStats: true, mainGraph: true })
+      queryClient.invalidateQueries({
+        predicate: ({ queryKey }) => {
+          const realtimeTopStatsOrMainGraphQuery =
+            ['top-stats', 'main-graph'].includes(queryKey[0] as string) &&
+            typeof queryKey[1] === 'object' &&
+            (queryKey[1] as { dashboardState?: DashboardState })?.dashboardState
+              ?.period === DashboardPeriod.realtime
+
+          return realtimeTopStatsOrMainGraphQuery
+        }
+      })
       refetchTopStats()
       refetchMainGraph()
     }

--- a/assets/js/dashboard/stats/graph/visitor-graph.tsx
+++ b/assets/js/dashboard/stats/graph/visitor-graph.tsx
@@ -165,10 +165,6 @@ export default function VisitorGraph({
     }
   }, [topStatsQuery.data, updateImportedDataInView])
 
-  // fetch realtime stats
-  const refetchTopStats = topStatsQuery.refetch
-  const refetchMainGraph = mainGraphQuery.refetch
-
   useEffect(() => {
     const onTick = () => {
       setIsRealtimeSilentUpdate({ topStats: true, mainGraph: true })
@@ -181,11 +177,8 @@ export default function VisitorGraph({
               ?.period === DashboardPeriod.realtime
 
           return realtimeTopStatsOrMainGraphQuery
-        },
-        refetchType: 'none'
+        }
       })
-      refetchTopStats()
-      refetchMainGraph()
     }
 
     if (isRealtime) {
@@ -195,7 +188,7 @@ export default function VisitorGraph({
     return () => {
       document.removeEventListener('tick', onTick)
     }
-  }, [queryClient, isRealtime, refetchTopStats, refetchMainGraph])
+  }, [queryClient, isRealtime])
 
   const importedSwitchVisible = !['no_imported_data', 'out_of_range'].includes(
     topStatsQuery.data?.meta.imports_skip_reason as string

--- a/assets/js/dashboard/stats/graph/visitor-graph.tsx
+++ b/assets/js/dashboard/stats/graph/visitor-graph.tsx
@@ -181,7 +181,8 @@ export default function VisitorGraph({
               ?.period === DashboardPeriod.realtime
 
           return realtimeTopStatsOrMainGraphQuery
-        }
+        },
+        refetchType: 'none'
       })
       refetchTopStats()
       refetchMainGraph()


### PR DESCRIPTION
### Changes

Calling refetch manually in the onTick handler ignores the cached value anyway so there's no need to explicitly invalidate the cached realtime responses. Currently that's just triggering another background refetch.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
