### PR TITLE
Add implicit wildcard matches to exploration suggestions

### DIFF
--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -70,7 +70,11 @@ function fetchInterestingFunnel(site, dashboardState) {
 }
 
 function isSameStep(step, otherStep) {
-  return step.name === otherStep.name && step.pathname === otherStep.pathname
+  return (
+    step.name === otherStep.name &&
+    step.pathname === otherStep.pathname &&
+    step.includes_subpaths === otherStep.includes_subpaths
+  )
 }
 
 function ExplorationColumn({

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -26,7 +26,12 @@ function stateWithApplicableFilters(dashboardState, steps) {
 }
 
 function toJourney(steps) {
-  return steps.map((s) => ({ name: s.name, pathname: s.pathname }))
+  return steps.map((s) => ({
+    name: s.name,
+    pathname: s.pathname,
+    include_subpaths: s.include_subpaths,
+    subpaths_count: s.subpaths_count
+  }))
 }
 
 function fetchNextWithFunnel(

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -5,7 +5,10 @@ import { Tooltip } from '../util/tooltip'
 import { useDebounce } from '../custom-hooks'
 import { useSiteContext } from '../site-context'
 import { useDashboardStateContext } from '../dashboard-state-context'
-import { numberShortFormatter } from '../util/number-formatter'
+import {
+  numberShortFormatter,
+  numberLongFormatter
+} from '../util/number-formatter'
 
 const PAGE_FILTER_KEYS = ['page', 'entry_page', 'exit_page']
 const EXPLORATION_DIRECTIONS = {
@@ -176,7 +179,7 @@ function ExplorationColumn({
                       {label}
                     </span>
                     <span className="shrink-0 text-gray-800 dark:text-gray-200 tabular-nums">
-                      <Tooltip info={visitorsToShow}>
+                      <Tooltip info={numberLongFormatter(visitorsToShow)}>
                         {numberShortFormatter(visitorsToShow)}
                       </Tooltip>
                     </span>

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import * as api from '../api'
 import * as url from '../util/url'
+import { Tooltip } from '../util/tooltip'
 import { useDebounce } from '../custom-hooks'
 import { useSiteContext } from '../site-context'
 import { useDashboardStateContext } from '../dashboard-state-context'
@@ -172,7 +173,9 @@ function ExplorationColumn({
                       {step.label}
                     </span>
                     <span className="shrink-0 text-gray-800 dark:text-gray-200 tabular-nums">
-                      {numberShortFormatter(visitorsToShow)}
+                      <Tooltip info={visitorsToShow}>
+                        {numberShortFormatter(visitorsToShow)}
+                      </Tooltip>
                     </span>
                   </div>
                   <div

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -30,7 +30,7 @@ function toJourney(steps) {
   return steps.map((s) => ({
     name: s.name,
     pathname: s.pathname,
-    include_subpaths: s.include_subpaths,
+    includes_subpaths: s.includes_subpaths,
     subpaths_count: s.subpaths_count
   }))
 }
@@ -154,9 +154,12 @@ function ExplorationColumn({
               isSelected && selectedConversionRate !== null
                 ? selectedConversionRate
                 : Math.round((visitors / stepMaxVisitors) * 100)
+            const label = step.includes_subpaths
+              ? `${step.label}… (${step.subpaths_count} pages)`
+              : step.label
 
             return (
-              <li key={step.label}>
+              <li key={label}>
                 <button
                   className={`group w-full border text-left px-2.5 pt-2 pb-2.5 text-sm rounded-md focus:outline-none ${
                     isSelected
@@ -168,9 +171,9 @@ function ExplorationColumn({
                   <div className="flex items-center justify-between gap-2 mb-1">
                     <span
                       className="truncate font-medium text-gray-800 dark:text-gray-200"
-                      title={step.label}
+                      title={label}
                     >
-                      {step.label}
+                      {label}
                     </span>
                     <span className="shrink-0 text-gray-800 dark:text-gray-200 tabular-nums">
                       <Tooltip info={visitorsToShow}>

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -411,7 +411,7 @@ defmodule Plausible.Stats.Exploration do
         |> String.trim_trailing("...")
         |> Regex.escape()
 
-      pattern = "^#{escaped}($|/.*)$"
+      pattern = "^#{escaped}(/.*)?$"
 
       dynamic(
         [s],

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -8,20 +8,34 @@ defmodule Plausible.Stats.Exploration do
 
     @type t() :: %__MODULE__{}
 
-    @derive {Jason.Encoder, only: [:name, :pathname, :label]}
-    defstruct [:name, :pathname, :label]
+    @derive {Jason.Encoder, only: [:name, :pathname, :label, :include_subpaths, :subpaths_count]}
+    defstruct name: nil, pathname: nil, label: nil, include_subpaths: false, subpaths_count: 0
 
     @spec from(map()) :: t()
     def from(step) do
-      new(step.name, step.pathname)
+      new(step.name, step.pathname, step.include_subpaths, step.subpaths_count)
     end
 
-    @spec new(String.t(), String.t()) :: t()
-    def new(name, pathname) do
+    @spec new(String.t(), String.t(), boolean(), non_neg_integer()) :: t()
+    def new(name, pathname, include_subpaths \\ false, subpaths_count \\ 0) do
+      label =
+        cond do
+          name != "pageview" ->
+            name <> " " <> pathname
+
+          include_subpaths ->
+            pathname <> " (" <> to_string(subpaths_count) <> " pages)"
+
+          true ->
+            pathname
+        end
+
       %__MODULE__{
-        label: if(name == "pageview", do: "", else: name <> " ") <> pathname,
+        label: label,
         name: name,
-        pathname: pathname
+        pathname: pathname,
+        include_subpaths: include_subpaths,
+        subpaths_count: subpaths_count
       }
     end
   end
@@ -32,7 +46,6 @@ defmodule Plausible.Stats.Exploration do
 
   alias Plausible.ClickhouseRepo
   alias Plausible.Stats.Base
-  alias Plausible.Stats.Filters
   alias Plausible.Stats.Query
 
   @type journey() :: [Journey.Step.t()]
@@ -176,7 +189,9 @@ defmodule Plausible.Stats.Exploration do
         select: %{
           name: selected_as(field(s, ^next_name), :name),
           pathname: selected_as(field(s, ^next_pathname), :pathname),
-          visitors: scale_sample(fragment("uniq(?)", s.user_id))
+          visitors: scale_sample(fragment("uniq(?)", s.user_id)),
+          include_subpaths: type(^false, :boolean),
+          subpaths_count: 0
         },
         group_by: [selected_as(:name), selected_as(:pathname)]
       )
@@ -195,13 +210,13 @@ defmodule Plausible.Stats.Exploration do
         join: pname in fragment(@wildcard_array_join, em.pathname),
         on: true,
         hints: "ARRAY",
-        where: selected_as(:pathname) != "*" and selected_as(:pathname) != "/*",
         where: em.name == "pageview",
+        where: selected_as(:pathname) != "" and selected_as(:pathname) != "/",
         select: %{
           name: em.name,
-          pathname: selected_as(fragment("concat(?, '*')", pname), :pathname),
-          pathname_plain: selected_as(fragment("?", pname), :pathname_plain),
-          visitors: selected_as(fragment("sum(?)", em.visitors), :visitors)
+          pathname: selected_as(fragment("?", pname), :pathname),
+          visitors: selected_as(fragment("sum(?)", em.visitors), :visitors),
+          unique_paths: fragment("uniq(?)", em.pathname)
         },
         group_by: [em.name, fragment("?", pname)]
       )
@@ -209,12 +224,14 @@ defmodule Plausible.Stats.Exploration do
     q_wildcard_filtered_matches =
       from(wm in subquery(q_wildcard_matches),
         left_join: emx in subquery(q_exact_matches),
-        on: emx.name == wm.name and emx.pathname == wm.pathname_plain,
-        where: is_nil(emx.name) or wm.visitors != emx.visitors,
+        on: emx.name == wm.name and emx.pathname == wm.pathname,
+        where: wm.unique_paths > 1 and (is_nil(emx.name) or wm.visitors != emx.visitors),
         select: %{
           name: wm.name,
           pathname: wm.pathname,
-          visitors: wm.visitors
+          visitors: wm.visitors,
+          include_subpaths: type(^true, :boolean),
+          subpaths_count: wm.unique_paths
         }
       )
 
@@ -228,17 +245,21 @@ defmodule Plausible.Stats.Exploration do
           label:
             selected_as(
               fragment(
-                "if(? != ?, concat(?, ' ', ?), ?)",
+                "multiIf(? != 'pageview', concat(?, ' ', ?), ? = true, concat(?, ' (' , ?, ' pages)'), ?)",
                 m.name,
-                "pageview",
                 m.name,
                 m.pathname,
+                m.include_subpaths,
+                m.pathname,
+                m.subpaths_count,
                 m.pathname
               ),
               :label
             ),
           name: m.name,
-          pathname: m.pathname
+          pathname: m.pathname,
+          include_subpaths: m.include_subpaths,
+          subpaths_count: m.subpaths_count
         },
         visitors: m.visitors
       },
@@ -255,12 +276,7 @@ defmodule Plausible.Stats.Exploration do
   defp journey_funnel_query(query, steps, direction) do
     q_steps = steps_query(query, length(steps), direction)
 
-    q_funnel =
-      from(s in subquery(q_steps),
-        select: %{
-          1 => scale_sample(fragment("uniq(?)", s.user_id))
-        }
-      )
+    q_funnel = from(s in subquery(q_steps), select: %{})
 
     steps
     |> Enum.with_index()
@@ -389,8 +405,8 @@ defmodule Plausible.Stats.Exploration do
   end
 
   defp step_condition(step, count) do
-    if String.contains?(step.pathname, "*") do
-      pattern = Filters.Utils.page_regex(step.pathname)
+    if step.include_subpaths do
+      pattern = "^#{Regex.escape(step.pathname)}($|/.*)$"
 
       dynamic(
         [s],

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -217,7 +217,7 @@ defmodule Plausible.Stats.Exploration do
     q_exact_matches =
       from(m in q_matches,
         select_merge: %{
-          visitors: scale_sample(fragment("uniqExact(?)", m.user_id)),
+          visitors: scale_sample(fragment("uniq(?)", m.user_id)),
           includes_subpaths: type(^false, :boolean),
           subpaths_count: 0
         },
@@ -240,8 +240,8 @@ defmodule Plausible.Stats.Exploration do
         select: %{
           name: em.name,
           pathname: selected_as(fragment("?", pname), :pathname),
-          visitors: selected_as(scale_sample(fragment("uniqExact(?)", em.user_id)), :visitors),
-          unique_paths: scale_sample(fragment("uniqExact(?)", em.pathname))
+          visitors: selected_as(scale_sample(fragment("uniq(?)", em.user_id)), :visitors),
+          unique_paths: scale_sample(fragment("uniq(?)", em.pathname))
         },
         group_by: [em.name, selected_as(:pathname)]
       )
@@ -308,7 +308,7 @@ defmodule Plausible.Stats.Exploration do
 
         from(e in q,
           select_merge: %{
-            1 => scale_sample(fragment("uniqExact(?)", e.user_id))
+            1 => scale_sample(fragment("uniq(?)", e.user_id))
           },
           where: ^step_condition
         )
@@ -329,7 +329,7 @@ defmodule Plausible.Stats.Exploration do
             [e],
             scale_sample(
               fragment(
-                "uniqExactIf(?, ?)",
+                "uniqIf(?, ?)",
                 e.user_id,
                 ^step_conditions
               )

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -411,7 +411,7 @@ defmodule Plausible.Stats.Exploration do
         |> String.trim_trailing("...")
         |> Regex.escape()
 
-      pattern = "^#{escaped}(/.*)?$"
+      pattern = "^#{escaped}(/.+)?$"
 
       dynamic(
         [s],

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -195,7 +195,7 @@ defmodule Plausible.Stats.Exploration do
         join: pname in fragment(@wildcard_array_join, em.pathname),
         on: true,
         hints: "ARRAY",
-        where: selected_as(:pathname) != "/*",
+        where: selected_as(:pathname) != "*",
         select: %{
           name: em.name,
           pathname: selected_as(fragment("concat(?, '*')", pname), :pathname),

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -374,9 +374,7 @@ defmodule Plausible.Stats.Exploration do
 
   defp step_condition(step, count) do
     if String.contains?(step.pathname, "*") do
-      escaped = Filters.Utils.page_regex(step.pathname)
-
-      pattern = "^#{escaped}$"
+      pattern = Filters.Utils.page_regex(step.pathname)
 
       dynamic(
         [s],

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -70,17 +70,30 @@ defmodule Plausible.Stats.Exploration do
 
   @wildcard_suffix "…"
 
+  @max_steps 20
+  @max_candidates 20
+
   @next_steps_defaults [search_term: "", direction: :forward, max_candidates: 10]
 
   @spec wildcard_suffix() :: String.t()
   def wildcard_suffix, do: @wildcard_suffix
 
-  @spec next_steps(Query.t(), journey(), keyword()) :: {:ok, [next_step()]}
-  def next_steps(query, journey, opts \\ []) do
+  @spec max_steps() :: pos_integer()
+  def max_steps, do: @max_steps
+
+  @spec next_steps(Query.t(), journey(), keyword()) ::
+          {:ok, [next_step()]} | {:error, :journey_too_long}
+  def next_steps(query, journey, opts \\ [])
+
+  def next_steps(_query, journey, _opts) when length(journey) >= @max_steps do
+    {:error, :journey_too_long}
+  end
+
+  def next_steps(query, journey, opts) do
     opts = Keyword.merge(@next_steps_defaults, opts)
     direction = Keyword.fetch!(opts, :direction)
     search_term = Keyword.fetch!(opts, :search_term)
-    max_candidates = min(Keyword.fetch!(opts, :max_candidates), 20)
+    max_candidates = min(Keyword.fetch!(opts, :max_candidates), @max_candidates)
 
     query
     |> Base.base_event_query()
@@ -92,10 +105,14 @@ defmodule Plausible.Stats.Exploration do
   end
 
   @spec journey_funnel(Query.t(), journey(), direction()) ::
-          {:ok, [funnel_step()]} | {:error, :empty_journey}
+          {:ok, [funnel_step()]} | {:error, :empty_journey | :journey_too_long}
   def journey_funnel(query, journey, direction \\ :forward)
 
   def journey_funnel(_query, [], _direction), do: {:error, :empty_journey}
+
+  def journey_funnel(_query, journey, _direction) when length(journey) > @max_steps do
+    {:error, :journey_too_long}
+  end
 
   def journey_funnel(query, journey, direction) when is_direction(direction) do
     query
@@ -130,8 +147,8 @@ defmodule Plausible.Stats.Exploration do
   @spec interesting_funnel(Query.t(), keyword()) ::
           {:ok, [funnel_step()]} | {:error, :not_found}
   def interesting_funnel(query, opts \\ []) do
-    max_steps = min(Keyword.get(opts, :max_steps, 6), 20)
-    max_candidates = min(Keyword.get(opts, :max_candidates, 10), 20)
+    max_steps = min(Keyword.get(opts, :max_steps, 6), @max_steps)
+    max_candidates = min(Keyword.get(opts, :max_candidates, 10), @max_candidates)
 
     case build_interesting_journey(query, max_steps, max_candidates) do
       [] -> {:error, :not_found}
@@ -413,7 +430,7 @@ defmodule Plausible.Stats.Exploration do
     )
   end
 
-  defp step_condition(step, count) do
+  defp step_condition(step, count) when count <= @max_steps do
     if step.include_subpaths do
       escaped =
         step.pathname

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -201,7 +201,8 @@ defmodule Plausible.Stats.Exploration do
         where: selected_as(:name) != "",
         select: %{
           name: selected_as(field(s, ^next_name), :name),
-          pathname: selected_as(field(s, ^next_pathname), :pathname)
+          pathname: selected_as(field(s, ^next_pathname), :pathname),
+          _sample_factor: s._sample_factor
         }
       )
 
@@ -240,8 +241,8 @@ defmodule Plausible.Stats.Exploration do
         select: %{
           name: em.name,
           pathname: selected_as(fragment("?", pname), :pathname),
-          visitors: selected_as(fragment("uniqExact(?)", em.user_id), :visitors),
-          unique_paths: fragment("uniqExact(?)", em.pathname)
+          visitors: selected_as(scale_sample(fragment("uniqExact(?)", em.user_id)), :visitors),
+          unique_paths: scale_sample(fragment("uniqExact(?)", em.pathname))
         },
         group_by: [em.name, selected_as(:pathname)]
       )

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -218,7 +218,7 @@ defmodule Plausible.Stats.Exploration do
           visitors: selected_as(fragment("sum(?)", em.visitors), :visitors),
           unique_paths: fragment("uniq(?)", em.pathname)
         },
-        group_by: [em.name, fragment("?", pname)]
+        group_by: [em.name, selected_as(:pathname)]
       )
 
     q_wildcard_filtered_matches =

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -196,6 +196,7 @@ defmodule Plausible.Stats.Exploration do
         on: true,
         hints: "ARRAY",
         where: selected_as(:pathname) != "*" and selected_as(:pathname) != "/*",
+        where: em.name == "pageview",
         select: %{
           name: em.name,
           pathname: selected_as(fragment("concat(?, '*')", pname), :pathname),

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -206,30 +206,42 @@ defmodule Plausible.Stats.Exploration do
     next_name = :"name#{next_step_idx}"
     next_pathname = :"pathname#{next_step_idx}"
 
-    q_exact_matches =
+    q_matches =
       from(s in subquery(q_steps),
         where: selected_as(:name) != "",
         select: %{
           name: selected_as(field(s, ^next_name), :name),
-          pathname: selected_as(field(s, ^next_pathname), :pathname),
-          visitors: scale_sample(fragment("uniqExact(?)", s.user_id)),
+          pathname: selected_as(field(s, ^next_pathname), :pathname)
+        }
+      )
+
+    q_matches =
+      steps
+      |> Enum.with_index()
+      |> Enum.reduce(q_matches, fn {step, idx}, q ->
+        step_condition = step_condition(step, idx + 1)
+
+        from(s in q, where: ^step_condition)
+      end)
+
+    q_exact_matches =
+      from(m in q_matches,
+        select_merge: %{
+          visitors: scale_sample(fragment("uniqExact(?)", m.user_id)),
           include_subpaths: type(^false, :boolean),
           subpaths_count: 0
         },
         group_by: [selected_as(:name), selected_as(:pathname)]
       )
 
-    q_exact_matches =
-      steps
-      |> Enum.with_index()
-      |> Enum.reduce(q_exact_matches, fn {step, idx}, q ->
-        step_condition = step_condition(step, idx + 1)
-
-        from(s in q, where: ^step_condition)
-      end)
+    q_per_user_matches =
+      from(m in q_matches,
+        select_merge: %{user_id: m.user_id},
+        group_by: [selected_as(:name), selected_as(:pathname), m.user_id]
+      )
 
     q_wildcard_matches =
-      from(em in subquery(q_exact_matches),
+      from(em in subquery(q_per_user_matches),
         join: pname in fragment(@wildcard_array_join, em.pathname),
         on: true,
         hints: "ARRAY",
@@ -238,7 +250,7 @@ defmodule Plausible.Stats.Exploration do
         select: %{
           name: em.name,
           pathname: selected_as(fragment("?", pname), :pathname),
-          visitors: selected_as(fragment("sum(?)", em.visitors), :visitors),
+          visitors: selected_as(fragment("uniqExact(?)", em.user_id), :visitors),
           unique_paths: fragment("uniqExact(?)", em.pathname)
         },
         group_by: [em.name, selected_as(:pathname)]
@@ -309,7 +321,7 @@ defmodule Plausible.Stats.Exploration do
 
         from(e in q,
           select_merge: %{
-            1 => scale_sample(fragment("uniqExact(?, ?, ?)", e.user_id, e.name1, e.pathname1))
+            1 => scale_sample(fragment("uniqExact(?)", e.user_id))
           },
           where: ^step_condition
         )
@@ -330,10 +342,8 @@ defmodule Plausible.Stats.Exploration do
             [e],
             scale_sample(
               fragment(
-                "uniqExactIf(?, ?, ?, ?)",
+                "uniqExactIf(?, ?)",
                 e.user_id,
-                field(e, ^:"name#{idx + 1}"),
-                field(e, ^:"pathname#{idx + 1}"),
                 ^step_conditions
               )
             )

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -19,7 +19,7 @@ defmodule Plausible.Stats.Exploration do
     @spec new(String.t(), String.t()) :: t()
     def new(name, pathname) do
       %__MODULE__{
-        label: if(name == "pageview", do: "Visit", else: name) <> " " <> pathname,
+        label: if(name == "pageview", do: "", else: name <> " ") <> pathname,
         name: name,
         pathname: pathname
       }
@@ -32,6 +32,7 @@ defmodule Plausible.Stats.Exploration do
 
   alias Plausible.ClickhouseRepo
   alias Plausible.Stats.Base
+  alias Plausible.Stats.Filters
   alias Plausible.Stats.Query
 
   @type journey() :: [Journey.Step.t()]
@@ -154,6 +155,13 @@ defmodule Plausible.Stats.Exploration do
   defp normalize_pathname("/"), do: "/"
   defp normalize_pathname(pathname), do: String.trim_trailing(pathname, "/")
 
+  @wildcard_array_join """
+  arrayFold(
+    acc, x -> arrayPushBack(acc, concat(acc[-1], '/', x)), 
+    arraySlice(splitByChar('/', ?) AS split_pathname, 3), 
+    arraySlice(split_pathname, 2, 1))
+  """
+
   defp next_steps_query(query, steps, search_term, direction, max_candidates)
        when is_direction(direction) do
     next_step_idx = length(steps) + 1
@@ -162,58 +170,92 @@ defmodule Plausible.Stats.Exploration do
     next_name = :"name#{next_step_idx}"
     next_pathname = :"pathname#{next_step_idx}"
 
-    q_next =
+    q_exact_matches =
       from(s in subquery(q_steps),
-        where: selected_as(:next_name) != "",
+        where: selected_as(:name) != "",
         select: %{
-          step: %Journey.Step{
-            label:
-              selected_as(
-                fragment(
-                  "concat(CASE WHEN ? = ? THEN ? ELSE ? END, ' ', ?)",
-                  selected_as(:next_name),
-                  "pageview",
-                  "Visit",
-                  selected_as(:next_name),
-                  selected_as(:next_pathname)
-                ),
-                :next_label
-              ),
-            name: selected_as(field(s, ^next_name), :next_name),
-            pathname: selected_as(field(s, ^next_pathname), :next_pathname)
-          },
-          visitors: selected_as(scale_sample(fragment("uniq(?)", s.user_id)), :count)
+          name: selected_as(field(s, ^next_name), :name),
+          pathname: selected_as(field(s, ^next_pathname), :pathname),
+          visitors: scale_sample(fragment("uniq(?)", s.user_id))
         },
-        group_by: [selected_as(:next_name), selected_as(:next_pathname)],
-        order_by: [
-          desc: selected_as(:count),
-          asc: selected_as(:next_pathname),
-          asc: selected_as(:next_name)
-        ],
-        limit: ^max_candidates
+        group_by: [selected_as(:name), selected_as(:pathname)]
       )
-      |> maybe_search(search_term)
 
-    steps
-    |> Enum.with_index()
-    |> Enum.reduce(q_next, fn {step, idx}, q ->
-      name = :"name#{idx + 1}"
-      pathname = :"pathname#{idx + 1}"
+    q_exact_matches =
+      steps
+      |> Enum.with_index()
+      |> Enum.reduce(q_exact_matches, fn {step, idx}, q ->
+        step_condition = step_condition(step, idx + 1)
 
-      from(s in q,
-        where: field(s, ^name) == ^step.name and field(s, ^pathname) == ^step.pathname
+        from(s in q, where: ^step_condition)
+      end)
+
+    q_wildcard_matches =
+      from(em in subquery(q_exact_matches),
+        join: pname in fragment(@wildcard_array_join, em.pathname),
+        on: true,
+        hints: "ARRAY",
+        where: selected_as(:pathname) != "/*",
+        select: %{
+          name: em.name,
+          pathname: selected_as(fragment("concat('/', ?, '*')", pname), :pathname),
+          pathname_plain: selected_as(fragment("concat('/', ?)", pname), :pathname_plain),
+          visitors: selected_as(sum(em.visitors), :visitors)
+        },
+        group_by: [em.name, fragment("?", pname)]
       )
-    end)
+
+    q_wildcard_filtered_matches =
+      from(wm in subquery(q_wildcard_matches),
+        left_join: emx in subquery(q_exact_matches),
+        on: emx.name == wm.name and emx.pathname == wm.pathname_plain,
+        where: is_nil(emx.name) or wm.visitors != emx.visitors,
+        select: %{
+          name: wm.name,
+          pathname: wm.pathname,
+          visitors: wm.visitors
+        }
+      )
+
+    q_all_matches =
+      q_exact_matches
+      |> union_all(^q_wildcard_filtered_matches)
+
+    from(m in subquery(q_all_matches),
+      select: %{
+        step: %Journey.Step{
+          label:
+            selected_as(
+              fragment(
+                "if(? != ?, concat(?, ' ', ?), ?)",
+                m.name,
+                "pageview",
+                m.name,
+                m.pathname,
+                m.pathname
+              ),
+              :label
+            ),
+          name: m.name,
+          pathname: m.pathname
+        },
+        visitors: m.visitors
+      },
+      order_by: [
+        desc: m.visitors,
+        asc: m.pathname,
+        asc: m.name
+      ],
+      limit: ^max_candidates
+    )
+    |> maybe_search(search_term)
   end
 
   defp journey_funnel_query(query, steps, direction) do
     q_steps = steps_query(query, length(steps), direction)
 
-    [first_step | steps] = steps
-
     q_funnel =
       from(s in subquery(q_steps),
-        where: s.name1 == ^first_step.name and s.pathname1 == ^first_step.pathname,
         select: %{
           1 => scale_sample(fragment("uniq(?)", s.user_id))
         }
@@ -221,21 +263,30 @@ defmodule Plausible.Stats.Exploration do
 
     steps
     |> Enum.with_index()
-    |> Enum.reduce(q_funnel, fn {_step, idx}, q ->
-      current_steps = Enum.take(steps, idx + 1)
+    |> Enum.reduce(q_funnel, fn
+      {step, 0}, q ->
+        step_condition = step_condition(step, 1)
 
-      step_conditions =
-        current_steps
-        |> Enum.with_index()
-        |> Enum.reduce(dynamic(true), fn {step, idx}, acc ->
-          step_condition = step_condition(step, idx + 2)
-          dynamic([q], fragment("? and ?", ^acc, ^step_condition))
-        end)
+        from(e in q,
+          select_merge: %{1 => scale_sample(fragment("uniq(?)", e.user_id))},
+          where: ^step_condition
+        )
 
-      step_count =
-        dynamic([e], scale_sample(fragment("uniqIf(?, ?)", e.user_id, ^step_conditions)))
+      {_step, idx}, q ->
+        current_steps = Enum.take(steps, idx + 1)
 
-      from(e in q, select_merge: ^%{(idx + 2) => step_count})
+        step_conditions =
+          current_steps
+          |> Enum.with_index()
+          |> Enum.reduce(dynamic(true), fn {step, idx}, acc ->
+            step_condition = step_condition(step, idx + 1)
+            dynamic([q], fragment("? and ?", ^acc, ^step_condition))
+          end)
+
+        step_count =
+          dynamic([e], scale_sample(fragment("uniqIf(?, ?)", e.user_id, ^step_conditions)))
+
+        from(e in q, select_merge: ^%{(idx + 1) => step_count})
     end)
   end
 
@@ -322,17 +373,29 @@ defmodule Plausible.Stats.Exploration do
   end
 
   defp step_condition(step, count) do
-    dynamic(
-      [s],
-      field(s, ^:"name#{count}") == ^step.name and
-        field(s, ^:"pathname#{count}") == ^step.pathname
-    )
+    if String.contains?(step.pathname, "*") do
+      escaped = Filters.Utils.page_regex(step.pathname)
+
+      pattern = "^#{escaped}$"
+
+      dynamic(
+        [s],
+        field(s, ^:"name#{count}") == ^step.name and
+          fragment("match(?, ?)", field(s, ^:"pathname#{count}"), ^pattern)
+      )
+    else
+      dynamic(
+        [s],
+        field(s, ^:"name#{count}") == ^step.name and
+          field(s, ^:"pathname#{count}") == ^step.pathname
+      )
+    end
   end
 
   defp maybe_search(query, search_term) do
     case String.trim(search_term) do
       term when byte_size(term) > 2 ->
-        from(s in query, where: ilike(selected_as(:next_label), ^"%#{term}%"))
+        from(s in query, where: ilike(selected_as(:label), ^"%#{term}%"))
 
       _ ->
         query

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -189,7 +189,7 @@ defmodule Plausible.Stats.Exploration do
         select: %{
           name: selected_as(field(s, ^next_name), :name),
           pathname: selected_as(field(s, ^next_pathname), :pathname),
-          visitors: scale_sample(fragment("uniq(?)", s.user_id)),
+          visitors: scale_sample(fragment("uniqExact(?)", s.user_id)),
           include_subpaths: type(^false, :boolean),
           subpaths_count: 0
         },
@@ -216,7 +216,7 @@ defmodule Plausible.Stats.Exploration do
           name: em.name,
           pathname: selected_as(fragment("?", pname), :pathname),
           visitors: selected_as(fragment("sum(?)", em.visitors), :visitors),
-          unique_paths: fragment("uniq(?)", em.pathname)
+          unique_paths: fragment("uniqExact(?)", em.pathname)
         },
         group_by: [em.name, selected_as(:pathname)]
       )
@@ -286,7 +286,7 @@ defmodule Plausible.Stats.Exploration do
 
         from(e in q,
           select_merge: %{
-            1 => scale_sample(fragment("uniq(?, ?, ?)", e.user_id, e.name1, e.pathname1))
+            1 => scale_sample(fragment("uniqExact(?, ?, ?)", e.user_id, e.name1, e.pathname1))
           },
           where: ^step_condition
         )
@@ -307,7 +307,7 @@ defmodule Plausible.Stats.Exploration do
             [e],
             scale_sample(
               fragment(
-                "uniqIf(?, ?, ?, ?)",
+                "uniqExactIf(?, ?, ?, ?)",
                 e.user_id,
                 field(e, ^:"name#{idx + 1}"),
                 field(e, ^:"pathname#{idx + 1}"),

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -17,7 +17,8 @@ defmodule Plausible.Stats.Exploration do
     end
 
     @spec new(String.t(), String.t(), boolean(), non_neg_integer()) :: t()
-    def new(name, pathname, include_subpaths \\ false, subpaths_count \\ 0) do
+    def new(name, pathname, include_subpaths \\ false, subpaths_count \\ 0)
+        when is_boolean(include_subpaths) and is_integer(subpaths_count) do
       label =
         cond do
           name != "pageview" ->

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -228,7 +228,7 @@ defmodule Plausible.Stats.Exploration do
         where: wm.unique_paths > 1 and (is_nil(emx.name) or wm.visitors != emx.visitors),
         select: %{
           name: wm.name,
-          pathname: wm.pathname,
+          pathname: fragment("concat(?, '...')", wm.pathname),
           visitors: wm.visitors,
           include_subpaths: type(^true, :boolean),
           subpaths_count: wm.unique_paths
@@ -406,7 +406,12 @@ defmodule Plausible.Stats.Exploration do
 
   defp step_condition(step, count) do
     if step.include_subpaths do
-      pattern = "^#{Regex.escape(step.pathname)}($|/.*)$"
+      escaped =
+        step.pathname
+        |> String.trim_trailing("...")
+        |> Regex.escape()
+
+      pattern = "^#{escaped}($|/.*)$"
 
       dynamic(
         [s],

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -201,8 +201,7 @@ defmodule Plausible.Stats.Exploration do
         where: selected_as(:name) != "",
         select: %{
           name: selected_as(field(s, ^next_name), :name),
-          pathname: selected_as(field(s, ^next_pathname), :pathname),
-          _sample_factor: s._sample_factor
+          pathname: selected_as(field(s, ^next_pathname), :pathname)
         }
       )
 
@@ -227,7 +226,7 @@ defmodule Plausible.Stats.Exploration do
 
     q_per_user_matches =
       from(m in q_matches,
-        select_merge: %{user_id: m.user_id},
+        select_merge: %{user_id: m.user_id, _sample_factor: fragment("any(?)", m._sample_factor)},
         group_by: [selected_as(:name), selected_as(:pathname), m.user_id]
       )
 

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -268,7 +268,7 @@ defmodule Plausible.Stats.Exploration do
         step_condition = step_condition(step, 1)
 
         from(e in q,
-          select_merge: %{1 => scale_sample(fragment("uniq(?)", e.user_id))},
+          select_merge: %{1 => scale_sample(fragment("uniq(?, ?)", e.user_id, e.pathname1))},
           where: ^step_condition
         )
 
@@ -284,7 +284,17 @@ defmodule Plausible.Stats.Exploration do
           end)
 
         step_count =
-          dynamic([e], scale_sample(fragment("uniqIf(?, ?)", e.user_id, ^step_conditions)))
+          dynamic(
+            [e],
+            scale_sample(
+              fragment(
+                "uniqIf(?, ?, ?)",
+                e.user_id,
+                field(e, ^:"pathname#{idx + 1}"),
+                ^step_conditions
+              )
+            )
+          )
 
         from(e in q, select_merge: ^%{(idx + 1) => step_count})
     end)

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -158,8 +158,8 @@ defmodule Plausible.Stats.Exploration do
   @wildcard_array_join """
   arrayFold(
     acc, x -> arrayPushBack(acc, concat(acc[-1], '/', x)), 
-    arraySlice(splitByChar('/', ?) AS split_pathname, 3), 
-    arraySlice(split_pathname, 2, 1))
+    arraySlice(splitByChar('/', ?) AS split_pathname, 2), 
+    arraySlice(split_pathname, 1, 1))
   """
 
   defp next_steps_query(query, steps, search_term, direction, max_candidates)
@@ -198,9 +198,9 @@ defmodule Plausible.Stats.Exploration do
         where: selected_as(:pathname) != "/*",
         select: %{
           name: em.name,
-          pathname: selected_as(fragment("concat('/', ?, '*')", pname), :pathname),
-          pathname_plain: selected_as(fragment("concat('/', ?)", pname), :pathname_plain),
-          visitors: selected_as(sum(em.visitors), :visitors)
+          pathname: selected_as(fragment("concat(?, '*')", pname), :pathname),
+          pathname_plain: selected_as(fragment("?", pname), :pathname_plain),
+          visitors: selected_as(fragment("sum(?)", em.visitors), :visitors)
         },
         group_by: [em.name, fragment("?", pname)]
       )

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -306,7 +306,8 @@ defmodule Plausible.Stats.Exploration do
           user_id: e.user_id,
           _sample_factor: e._sample_factor,
           name: e.name,
-          pathname: e.pathname,
+          pathname:
+            fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname),
           timestamp: e.timestamp
         },
         where: e.name != "engagement",
@@ -339,7 +340,9 @@ defmodule Plausible.Stats.Exploration do
   defp select_previous(query, :forward) do
     from(e in query,
       select_merge: %{
-        prev_pathname: lag(e.pathname) |> over(:session_window),
+        prev_pathname:
+          lag(fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname))
+          |> over(:session_window),
         prev_name: lag(e.name) |> over(:session_window)
       }
     )
@@ -348,7 +351,9 @@ defmodule Plausible.Stats.Exploration do
   defp select_previous(query, :backward) do
     from(e in query,
       select_merge: %{
-        prev_pathname: lead(e.pathname) |> over(:session_window),
+        prev_pathname:
+          lead(fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname))
+          |> over(:session_window),
         prev_name: lead(e.name) |> over(:session_window)
       }
     )

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -8,34 +8,29 @@ defmodule Plausible.Stats.Exploration do
 
     @type t() :: %__MODULE__{}
 
-    @derive {Jason.Encoder, only: [:name, :pathname, :label, :include_subpaths, :subpaths_count]}
-    defstruct name: nil, pathname: nil, label: nil, include_subpaths: false, subpaths_count: 0
+    @derive {Jason.Encoder, only: [:name, :pathname, :label, :includes_subpaths, :subpaths_count]}
+    defstruct name: nil, pathname: nil, label: nil, includes_subpaths: false, subpaths_count: 0
 
     @spec from(map()) :: t()
     def from(step) do
-      new(step.name, step.pathname, step.include_subpaths, step.subpaths_count)
+      new(step.name, step.pathname, step.includes_subpaths, step.subpaths_count)
     end
 
     @spec new(String.t(), String.t(), boolean(), non_neg_integer()) :: t()
-    def new(name, pathname, include_subpaths \\ false, subpaths_count \\ 0)
-        when is_boolean(include_subpaths) and is_integer(subpaths_count) do
+    def new(name, pathname, includes_subpaths \\ false, subpaths_count \\ 0)
+        when is_boolean(includes_subpaths) and is_integer(subpaths_count) do
       label =
-        cond do
-          name != "pageview" ->
-            name <> " " <> pathname
-
-          include_subpaths ->
-            pathname <> " (" <> to_string(subpaths_count) <> " pages)"
-
-          true ->
-            pathname
+        if name != "pageview" do
+          name <> " " <> pathname
+        else
+          pathname
         end
 
       %__MODULE__{
         label: label,
         name: name,
         pathname: pathname,
-        include_subpaths: include_subpaths,
+        includes_subpaths: includes_subpaths,
         subpaths_count: subpaths_count
       }
     end
@@ -68,15 +63,10 @@ defmodule Plausible.Stats.Exploration do
           conversion_rate_step: String.t()
         }
 
-  @wildcard_suffix "…"
-
   @max_steps 20
   @max_candidates 20
 
   @next_steps_defaults [search_term: "", direction: :forward, max_candidates: 10]
-
-  @spec wildcard_suffix() :: String.t()
-  def wildcard_suffix, do: @wildcard_suffix
 
   @spec max_steps() :: pos_integer()
   def max_steps, do: @max_steps
@@ -228,7 +218,7 @@ defmodule Plausible.Stats.Exploration do
       from(m in q_matches,
         select_merge: %{
           visitors: scale_sample(fragment("uniqExact(?)", m.user_id)),
-          include_subpaths: type(^false, :boolean),
+          includes_subpaths: type(^false, :boolean),
           subpaths_count: 0
         },
         group_by: [selected_as(:name), selected_as(:pathname)]
@@ -263,9 +253,9 @@ defmodule Plausible.Stats.Exploration do
         where: wm.unique_paths > 1 and (is_nil(emx.name) or wm.visitors != emx.visitors),
         select: %{
           name: wm.name,
-          pathname: fragment("concat(?, ?)", wm.pathname, @wildcard_suffix),
+          pathname: wm.pathname,
           visitors: wm.visitors,
-          include_subpaths: type(^true, :boolean),
+          includes_subpaths: type(^true, :boolean),
           subpaths_count: wm.unique_paths
         }
       )
@@ -280,20 +270,17 @@ defmodule Plausible.Stats.Exploration do
           label:
             selected_as(
               fragment(
-                "multiIf(? != 'pageview', concat(?, ' ', ?), ? = true, concat(?, ' (' , ?, ' pages)'), ?)",
+                "if(? != 'pageview', concat(?, ' ', ?), ?)",
                 m.name,
                 m.name,
                 m.pathname,
-                m.include_subpaths,
-                m.pathname,
-                m.subpaths_count,
                 m.pathname
               ),
               :label
             ),
           name: m.name,
           pathname: m.pathname,
-          include_subpaths: m.include_subpaths,
+          includes_subpaths: m.includes_subpaths,
           subpaths_count: m.subpaths_count
         },
         visitors: m.visitors
@@ -441,11 +428,8 @@ defmodule Plausible.Stats.Exploration do
   end
 
   defp step_condition(step, count) when count <= @max_steps do
-    if step.include_subpaths do
-      escaped =
-        step.pathname
-        |> String.trim_trailing(@wildcard_suffix)
-        |> Regex.escape()
+    if step.includes_subpaths do
+      escaped = Regex.escape(step.pathname)
 
       pattern = "^#{escaped}(/.+)?$"
 

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -67,7 +67,12 @@ defmodule Plausible.Stats.Exploration do
           conversion_rate_step: String.t()
         }
 
+  @wildcard_suffix "…"
+
   @next_steps_defaults [search_term: "", direction: :forward, max_candidates: 10]
+
+  @spec wildcard_suffix() :: String.t()
+  def wildcard_suffix, do: @wildcard_suffix
 
   @spec next_steps(Query.t(), journey(), keyword()) :: {:ok, [next_step()]}
   def next_steps(query, journey, opts \\ []) do
@@ -228,7 +233,7 @@ defmodule Plausible.Stats.Exploration do
         where: wm.unique_paths > 1 and (is_nil(emx.name) or wm.visitors != emx.visitors),
         select: %{
           name: wm.name,
-          pathname: fragment("concat(?, '...')", wm.pathname),
+          pathname: fragment("concat(?, ?)", wm.pathname, @wildcard_suffix),
           visitors: wm.visitors,
           include_subpaths: type(^true, :boolean),
           subpaths_count: wm.unique_paths
@@ -411,7 +416,7 @@ defmodule Plausible.Stats.Exploration do
     if step.include_subpaths do
       escaped =
         step.pathname
-        |> String.trim_trailing("...")
+        |> String.trim_trailing(@wildcard_suffix)
         |> Regex.escape()
 
       pattern = "^#{escaped}(/.+)?$"

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -285,7 +285,9 @@ defmodule Plausible.Stats.Exploration do
         step_condition = step_condition(step, 1)
 
         from(e in q,
-          select_merge: %{1 => scale_sample(fragment("uniq(?, ?)", e.user_id, e.pathname1))},
+          select_merge: %{
+            1 => scale_sample(fragment("uniq(?, ?, ?)", e.user_id, e.name1, e.pathname1))
+          },
           where: ^step_condition
         )
 
@@ -305,8 +307,9 @@ defmodule Plausible.Stats.Exploration do
             [e],
             scale_sample(
               fragment(
-                "uniqIf(?, ?, ?)",
+                "uniqIf(?, ?, ?, ?)",
                 e.user_id,
+                field(e, ^:"name#{idx + 1}"),
                 field(e, ^:"pathname#{idx + 1}"),
                 ^step_conditions
               )

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -195,7 +195,7 @@ defmodule Plausible.Stats.Exploration do
         join: pname in fragment(@wildcard_array_join, em.pathname),
         on: true,
         hints: "ARRAY",
-        where: selected_as(:pathname) != "*",
+        where: selected_as(:pathname) != "*" and selected_as(:pathname) != "/*",
         select: %{
           name: em.name,
           pathname: selected_as(fragment("concat(?, '*')", pname), :pathname),

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -227,13 +227,13 @@ defmodule PlausibleWeb.Api.StatsController do
     defp parse_journey_step(%{
            "name" => name,
            "pathname" => pathname,
-           "include_subpaths" => include_subpaths,
+           "includes_subpaths" => includes_subpaths,
            "subpaths_count" => subpaths_count
          }) do
       Plausible.Stats.Exploration.Journey.Step.new(
         name,
         pathname,
-        include_subpaths,
+        includes_subpaths,
         subpaths_count
       )
     end

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -153,9 +153,6 @@ defmodule PlausibleWeb.Api.StatsController do
       else
         {:error, :journey_too_long} ->
           bad_request(conn, "The journey is too long")
-
-        _ ->
-          bad_request(conn, "There was an error with your request")
       end
     end
 

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -227,8 +227,18 @@ defmodule PlausibleWeb.Api.StatsController do
       |> then(&{:ok, &1})
     end
 
-    defp parse_journey_step(%{"name" => name, "pathname" => pathname}) do
-      Plausible.Stats.Exploration.Journey.Step.new(name, pathname)
+    defp parse_journey_step(%{
+           "name" => name,
+           "pathname" => pathname,
+           "include_subpaths" => include_subpaths,
+           "subpaths_count" => subpaths_count
+         }) do
+      Plausible.Stats.Exploration.Journey.Step.new(
+        name,
+        pathname,
+        include_subpaths,
+        subpaths_count
+      )
     end
 
     defp parse_exploration_direction("backward"), do: {:ok, :backward}

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -151,6 +151,9 @@ defmodule PlausibleWeb.Api.StatsController do
              ) do
         json(conn, next_steps)
       else
+        {:error, :journey_too_long} ->
+          bad_request(conn, "The journey is too long")
+
         _ ->
           bad_request(conn, "There was an error with your request")
       end
@@ -167,13 +170,10 @@ defmodule PlausibleWeb.Api.StatsController do
         json(conn, funnel)
       else
         {:error, :empty_journey} ->
-          bad_request(
-            conn,
-            "We are unable to show funnels when journey is empty",
-            %{
-              level: :normal
-            }
-          )
+          bad_request(conn, "We are unable to show funnels when journey is empty")
+
+        {:error, :journey_too_long} ->
+          bad_request(conn, "The journey is too long")
       end
     end
 

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -928,21 +928,28 @@ defmodule Plausible.Stats.ExplorationTest do
           user_id: 123,
           pathname: "/a/b/c",
           timestamp: DateTime.shift(now, minute: -240)
+        ),
+        build(:pageview,
+          user_id: 128,
+          pathname: "/a/b/c",
+          timestamp: DateTime.shift(now, minute: -240)
         )
       ])
 
       query = QueryBuilder.build!(site, input_date_range: :all)
 
+      result = Exploration.next_steps(query, [])
+
       assert {:ok,
               [
-                %{step: %{label: "/a" <> @wildcard_suffix <> " (4 pages)"}, visitors: 10},
+                %{step: %{label: "/a" <> @wildcard_suffix <> " (4 pages)"}, visitors: 6},
                 %{step: %{label: "/a"}, visitors: 5},
                 %{step: %{label: "/a/b" <> @wildcard_suffix <> " (2 pages)"}, visitors: 3},
                 %{step: %{label: "/a/b"}, visitors: 2},
+                %{step: %{label: "/a/b/c"}, visitors: 2},
                 %{step: %{label: "/a/d"}, visitors: 2},
-                %{step: %{label: "/a/b/c"}, visitors: 1},
                 %{step: %{label: "/aa"}, visitors: 1}
-              ]} = Exploration.next_steps(query, [])
+              ]} = result
 
       journey = [
         %Exploration.Journey.Step{
@@ -956,7 +963,7 @@ defmodule Plausible.Stats.ExplorationTest do
       assert {:ok, [step1]} = Exploration.journey_funnel(query, journey)
 
       assert step1.step.label == "/a#{@wildcard_suffix} (4 pages)"
-      assert step1.visitors == 10
+      assert step1.visitors == 6
     end
   end
 end

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -911,9 +911,9 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert {:ok,
               [
-                %{step: %{label: "/a (4 pages)"}, visitors: 10},
+                %{step: %{label: "/a... (4 pages)"}, visitors: 10},
                 %{step: %{label: "/a"}, visitors: 5},
-                %{step: %{label: "/a/b (2 pages)"}, visitors: 3},
+                %{step: %{label: "/a/b... (2 pages)"}, visitors: 3},
                 %{step: %{label: "/a/b"}, visitors: 2},
                 %{step: %{label: "/a/d"}, visitors: 2},
                 %{step: %{label: "/a/b/c"}, visitors: 1},
@@ -923,7 +923,7 @@ defmodule Plausible.Stats.ExplorationTest do
       journey = [
         %Exploration.Journey.Step{
           name: "pageview",
-          pathname: "/a",
+          pathname: "/a...",
           include_subpaths: true,
           subpaths_count: 4
         }
@@ -931,7 +931,7 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert {:ok, [step1]} = Exploration.journey_funnel(query, journey)
 
-      assert step1.step.label == "/a (4 pages)"
+      assert step1.step.label == "/a... (4 pages)"
       assert step1.visitors == 10
     end
   end

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -848,5 +848,75 @@ defmodule Plausible.Stats.ExplorationTest do
         assert next_step.visitors == 2
       end
     end
+
+    test "implicit wildcard path visitors computation is correct" do
+      now = DateTime.utc_now()
+      site = new_site()
+
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          pathname: "/a",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/a",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 125,
+          pathname: "/a",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 126,
+          pathname: "/a",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 127,
+          pathname: "/a",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/a/b",
+          timestamp: DateTime.shift(now, minute: -270)
+        ),
+        build(:pageview,
+          user_id: 124,
+          pathname: "/a/b",
+          timestamp: DateTime.shift(now, minute: -270)
+        ),
+        build(:pageview,
+          user_id: 126,
+          pathname: "/a/d",
+          timestamp: DateTime.shift(now, minute: -270)
+        ),
+        build(:pageview,
+          user_id: 127,
+          pathname: "/a/d",
+          timestamp: DateTime.shift(now, minute: -270)
+        ),
+        build(:pageview,
+          user_id: 123,
+          pathname: "/a/b/c",
+          timestamp: DateTime.shift(now, minute: -240)
+        )
+      ])
+
+      query = QueryBuilder.build!(site, input_date_range: :all)
+
+      assert {:ok,
+              [
+                %{step: %{label: "/a*"}, visitors: 10},
+                %{step: %{label: "/a"}, visitors: 5},
+                %{step: %{label: "/a/b*"}, visitors: 3},
+                %{step: %{label: "/a/b"}, visitors: 2},
+                %{step: %{label: "/a/d"}, visitors: 2},
+                %{step: %{label: "/a/b/c"}, visitors: 1}
+              ]} = Exploration.next_steps(query, [])
+    end
   end
 end

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -6,6 +6,8 @@ defmodule Plausible.Stats.ExplorationTest do
     alias Plausible.Stats.Exploration
     alias Plausible.Stats.QueryBuilder
 
+    @wildcard_suffix Exploration.wildcard_suffix()
+
     setup do
       site = new_site()
 
@@ -911,9 +913,9 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert {:ok,
               [
-                %{step: %{label: "/a... (4 pages)"}, visitors: 10},
+                %{step: %{label: "/a" <> @wildcard_suffix <> " (4 pages)"}, visitors: 10},
                 %{step: %{label: "/a"}, visitors: 5},
-                %{step: %{label: "/a/b... (2 pages)"}, visitors: 3},
+                %{step: %{label: "/a/b" <> @wildcard_suffix <> " (2 pages)"}, visitors: 3},
                 %{step: %{label: "/a/b"}, visitors: 2},
                 %{step: %{label: "/a/d"}, visitors: 2},
                 %{step: %{label: "/a/b/c"}, visitors: 1},
@@ -923,7 +925,7 @@ defmodule Plausible.Stats.ExplorationTest do
       journey = [
         %Exploration.Journey.Step{
           name: "pageview",
-          pathname: "/a...",
+          pathname: "/a" <> @wildcard_suffix,
           include_subpaths: true,
           subpaths_count: 4
         }
@@ -931,7 +933,7 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert {:ok, [step1]} = Exploration.journey_funnel(query, journey)
 
-      assert step1.step.label == "/a... (4 pages)"
+      assert step1.step.label == "/a#{@wildcard_suffix} (4 pages)"
       assert step1.visitors == 10
     end
   end

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -149,9 +149,9 @@ defmodule Plausible.Stats.ExplorationTest do
 
         assert {:ok, [step1, step2, step3, step4]} = Exploration.journey_funnel(query, journey)
 
-        assert step1.step.label == "Visit /register"
+        assert step1.step.label == "/register"
         assert step2.step.label == "Signup /register"
-        assert step3.step.label == "Visit /activate"
+        assert step3.step.label == "/activate"
         assert step4.step.label == "Create site /sites/new"
       end
 
@@ -324,7 +324,7 @@ defmodule Plausible.Stats.ExplorationTest do
         assert {:ok, funnel} = Exploration.interesting_funnel(query)
 
         pathnames = Enum.map(funnel, & &1.step.pathname)
-        assert pathnames == ["/home", "/about/", "/contact"]
+        assert pathnames == ["/about*", "/contact"]
       end
 
       test "stops when no more unseen steps are available" do
@@ -430,13 +430,13 @@ defmodule Plausible.Stats.ExplorationTest do
         assert {:ok, [next_step1, next_step2, next_step3]} =
                  Exploration.next_steps(query, journey)
 
-        assert next_step1.step.label == "Visit /docs"
+        assert next_step1.step.label == "/docs"
         assert next_step1.step.pathname == "/docs"
         assert next_step1.visitors == 1
-        assert next_step2.step.label == "Visit /home"
+        assert next_step2.step.label == "/home"
         assert next_step2.step.pathname == "/home"
         assert next_step2.visitors == 1
-        assert next_step3.step.label == "Visit /logout"
+        assert next_step3.step.label == "/logout"
         assert next_step3.step.pathname == "/logout"
         assert next_step3.visitors == 1
       end
@@ -503,18 +503,42 @@ defmodule Plausible.Stats.ExplorationTest do
         assert next_step.visitors == 1
       end
 
-      test "allows to filter according to how label is rendered", %{site: site} do
+      test "allows to filter according to how label is rendered" do
+        site = new_site()
+
+        now = DateTime.utc_now()
+
+        populate_stats(site, [
+          build(:pageview,
+            user_id: 123,
+            pathname: "/home",
+            timestamp: DateTime.shift(now, minute: -320)
+          ),
+          build(:event,
+            user_id: 123,
+            name: "Signup",
+            pathname: "/register",
+            timestamp: DateTime.shift(now, minute: -300)
+          ),
+          build(:pageview,
+            user_id: 123,
+            pathname: "/sites/new",
+            timestamp: DateTime.shift(now, minute: -270)
+          )
+        ])
+
         query = QueryBuilder.build!(site, input_date_range: :all)
 
         journey = [
-          %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
-          %Exploration.Journey.Step{name: "pageview", pathname: "/login"}
+          %Exploration.Journey.Step{name: "pageview", pathname: "/home"}
         ]
 
         assert {:ok, [next_step]} =
-                 Exploration.next_steps(query, journey, search_term: "isit /doc")
+                 Exploration.next_steps(query, journey, search_term: "up /regi")
 
-        assert next_step.step.pathname == "/docs"
+        assert next_step.step.label == "Signup /register"
+        assert next_step.step.name == "Signup"
+        assert next_step.step.pathname == "/register"
         assert next_step.visitors == 1
       end
 
@@ -581,11 +605,21 @@ defmodule Plausible.Stats.ExplorationTest do
 
         query = QueryBuilder.build!(site, input_date_range: :all)
 
-        assert {:ok, [%{step: %{pathname: "/:dashboard"}}, %{step: %{pathname: "/:dashboard/"}}]} =
-                 Exploration.next_steps(query, journey, direction: :forward)
+        assert {:ok,
+                [
+                  %{step: %{pathname: "/:dashboard*"}},
+                  %{step: %{pathname: "/:dashboard"}},
+                  %{step: %{pathname: "/:dashboard/"}}
+                ]} =
+                 Exploration.next_steps(query, journey, search_term: "", direction: :forward)
 
-        assert {:ok, [%{step: %{pathname: "/:dashboard"}}, %{step: %{pathname: "/:dashboard/"}}]} =
-                 Exploration.next_steps(query, journey, direction: :backward)
+        assert {:ok,
+                [
+                  %{step: %{pathname: "/:dashboard*"}},
+                  %{step: %{pathname: "/:dashboard"}},
+                  %{step: %{pathname: "/:dashboard/"}}
+                ]} =
+                 Exploration.next_steps(query, journey, search_term: "", direction: :backward)
       end
 
       test "treats identical sequence of events as a single step" do

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -198,6 +198,17 @@ defmodule Plausible.Stats.ExplorationTest do
         assert {:error, :empty_journey} = Exploration.journey_funnel(query, [])
       end
 
+      test "returns error on too long journey", %{site: site} do
+        query = QueryBuilder.build!(site, input_date_range: :all)
+
+        journey =
+          Enum.map(1..21, fn idx ->
+            %Exploration.Journey.Step{name: "pageview", pathname: "/page#{idx}"}
+          end)
+
+        assert {:error, :journey_too_long} = Exploration.journey_funnel(query, journey)
+      end
+
       test "supports backward journey funnel", %{site: site} do
         query = QueryBuilder.build!(site, input_date_range: :all)
 
@@ -453,6 +464,17 @@ defmodule Plausible.Stats.ExplorationTest do
 
         assert {:ok, [%{step: %{pathname: "/docs"}}]} =
                  Exploration.next_steps(query, journey, max_candidates: 1)
+      end
+
+      test "returns error on too long journey", %{site: site} do
+        query = QueryBuilder.build!(site, input_date_range: :all)
+
+        journey =
+          Enum.map(1..20, fn idx ->
+            %Exploration.Journey.Step{name: "pageview", pathname: "/page#{idx}"}
+          end)
+
+        assert {:error, :journey_too_long} = Exploration.next_steps(query, journey)
       end
 
       test "suggests the first step in the journey", %{site: site} do

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -6,8 +6,6 @@ defmodule Plausible.Stats.ExplorationTest do
     alias Plausible.Stats.Exploration
     alias Plausible.Stats.QueryBuilder
 
-    @wildcard_suffix Exploration.wildcard_suffix()
-
     setup do
       site = new_site()
 
@@ -942,10 +940,13 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert {:ok,
               [
-                %{step: %{label: "/a" <> @wildcard_suffix <> " (4 pages)"}, visitors: 6},
-                %{step: %{label: "/a"}, visitors: 5},
-                %{step: %{label: "/a/b" <> @wildcard_suffix <> " (2 pages)"}, visitors: 3},
-                %{step: %{label: "/a/b"}, visitors: 2},
+                %{step: %{label: "/a", includes_subpaths: true, subpaths_count: 4}, visitors: 6},
+                %{step: %{label: "/a", includes_subpaths: false}, visitors: 5},
+                %{
+                  step: %{label: "/a/b", includes_subpaths: true, subpaths_count: 2},
+                  visitors: 3
+                },
+                %{step: %{label: "/a/b", includes_subpaths: false}, visitors: 2},
                 %{step: %{label: "/a/b/c"}, visitors: 2},
                 %{step: %{label: "/a/d"}, visitors: 2},
                 %{step: %{label: "/aa"}, visitors: 1}
@@ -954,15 +955,16 @@ defmodule Plausible.Stats.ExplorationTest do
       journey = [
         %Exploration.Journey.Step{
           name: "pageview",
-          pathname: "/a" <> @wildcard_suffix,
-          include_subpaths: true,
+          pathname: "/a",
+          includes_subpaths: true,
           subpaths_count: 4
         }
       ]
 
       assert {:ok, [step1]} = Exploration.journey_funnel(query, journey)
 
-      assert step1.step.label == "/a#{@wildcard_suffix} (4 pages)"
+      assert step1.step.label == "/a"
+      assert step1.step.includes_subpaths == true
       assert step1.visitors == 6
     end
   end

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -324,7 +324,7 @@ defmodule Plausible.Stats.ExplorationTest do
         assert {:ok, funnel} = Exploration.interesting_funnel(query)
 
         pathnames = Enum.map(funnel, & &1.step.pathname)
-        assert pathnames == ["/about*", "/contact"]
+        assert pathnames == ["/about", "/contact"]
       end
 
       test "stops when no more unseen steps are available" do
@@ -607,17 +607,13 @@ defmodule Plausible.Stats.ExplorationTest do
 
         assert {:ok,
                 [
-                  %{step: %{pathname: "/:dashboard*"}},
-                  %{step: %{pathname: "/:dashboard"}},
-                  %{step: %{pathname: "/:dashboard/"}}
+                  %{step: %{pathname: "/:dashboard"}}
                 ]} =
                  Exploration.next_steps(query, journey, search_term: "", direction: :forward)
 
         assert {:ok,
                 [
-                  %{step: %{pathname: "/:dashboard*"}},
-                  %{step: %{pathname: "/:dashboard"}},
-                  %{step: %{pathname: "/:dashboard/"}}
+                  %{step: %{pathname: "/:dashboard"}}
                 ]} =
                  Exploration.next_steps(query, journey, search_term: "", direction: :backward)
       end
@@ -917,6 +913,15 @@ defmodule Plausible.Stats.ExplorationTest do
                 %{step: %{label: "/a/d"}, visitors: 2},
                 %{step: %{label: "/a/b/c"}, visitors: 1}
               ]} = Exploration.next_steps(query, [])
+
+      journey = [
+        %Exploration.Journey.Step{name: "pageview", pathname: "/a*"}
+      ]
+
+      assert {:ok, [step1]} = Exploration.journey_funnel(query, journey)
+
+      assert step1.step.pathname == "/a*"
+      assert step1.visitors == 10
     end
   end
 end

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -845,11 +845,16 @@ defmodule Plausible.Stats.ExplorationTest do
       end
     end
 
-    test "implicit wildcard path visitors computation is correct" do
+    test "implicit wildcard path visitors computation is correct and consistent between next_step and journey_funnel" do
       now = DateTime.utc_now()
       site = new_site()
 
       populate_stats(site, [
+        build(:pageview,
+          user_id: 122,
+          pathname: "/aa",
+          timestamp: DateTime.shift(now, minute: -300)
+        ),
         build(:pageview,
           user_id: 123,
           pathname: "/a",
@@ -906,21 +911,27 @@ defmodule Plausible.Stats.ExplorationTest do
 
       assert {:ok,
               [
-                %{step: %{label: "/a*"}, visitors: 10},
+                %{step: %{label: "/a (4 pages)"}, visitors: 10},
                 %{step: %{label: "/a"}, visitors: 5},
-                %{step: %{label: "/a/b*"}, visitors: 3},
+                %{step: %{label: "/a/b (2 pages)"}, visitors: 3},
                 %{step: %{label: "/a/b"}, visitors: 2},
                 %{step: %{label: "/a/d"}, visitors: 2},
-                %{step: %{label: "/a/b/c"}, visitors: 1}
+                %{step: %{label: "/a/b/c"}, visitors: 1},
+                %{step: %{label: "/aa"}, visitors: 1}
               ]} = Exploration.next_steps(query, [])
 
       journey = [
-        %Exploration.Journey.Step{name: "pageview", pathname: "/a*"}
+        %Exploration.Journey.Step{
+          name: "pageview",
+          pathname: "/a",
+          include_subpaths: true,
+          subpaths_count: 4
+        }
       ]
 
       assert {:ok, [step1]} = Exploration.journey_funnel(query, journey)
 
-      assert step1.step.pathname == "/a*"
+      assert step1.step.label == "/a (4 pages)"
       assert step1.visitors == 10
     end
   end

--- a/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
@@ -3,6 +3,8 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
   use Plausible
 
   on_ee do
+    alias Plausible.Stats.Exploration.Journey
+
     setup [:create_user, :log_in, :create_site]
 
     setup %{user: user, site: site} do
@@ -65,8 +67,8 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "it works", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            %{name: "pageview", pathname: "/home"},
-            %{name: "pageview", pathname: "/login"}
+            Journey.Step.new("pageview", "/home"),
+            Journey.Step.new("pageview", "/login")
           ])
 
         resp =
@@ -92,8 +94,8 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "it filters", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            %{name: "pageview", pathname: "/home"},
-            %{name: "pageview", pathname: "/login"}
+            Journey.Step.new("pageview", "/home"),
+            Journey.Step.new("pageview", "/login")
           ])
 
         resp =
@@ -111,7 +113,7 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       end
 
       test "it supports backward direction", %{conn: conn, site: site} do
-        journey = Jason.encode!([%{name: "pageview", pathname: "/logout"}])
+        journey = Jason.encode!([Journey.Step.new("pageview", "/logout")])
 
         resp =
           conn
@@ -134,9 +136,9 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "it works", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            %{name: "pageview", pathname: "/home"},
-            %{name: "pageview", pathname: "/login"},
-            %{name: "pageview", pathname: "/logout"}
+            Journey.Step.new("pageview", "/home"),
+            Journey.Step.new("pageview", "/login"),
+            Journey.Step.new("pageview", "/logout")
           ])
 
         resp =
@@ -175,9 +177,9 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "it supports backward direction", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            %{name: "pageview", pathname: "/logout"},
-            %{name: "pageview", pathname: "/login"},
-            %{name: "pageview", pathname: "/home"}
+            Journey.Step.new("pageview", "/logout"),
+            Journey.Step.new("pageview", "/login"),
+            Journey.Step.new("pageview", "/home")
           ])
 
         resp =
@@ -216,8 +218,8 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "returns next steps without funnel by default", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            %{name: "pageview", pathname: "/home"},
-            %{name: "pageview", pathname: "/login"}
+            Journey.Step.new("pageview", "/home"),
+            Journey.Step.new("pageview", "/login")
           ])
 
         resp =
@@ -245,8 +247,8 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "filters next steps by search_term", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            %{name: "pageview", pathname: "/home"},
-            %{name: "pageview", pathname: "/login"}
+            Journey.Step.new("pageview", "/home"),
+            Journey.Step.new("pageview", "/login")
           ])
 
         resp =
@@ -265,7 +267,7 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       end
 
       test "supports backward direction for next steps", %{conn: conn, site: site} do
-        journey = Jason.encode!([%{name: "pageview", pathname: "/logout"}])
+        journey = Jason.encode!([Journey.Step.new("pageview", "/logout")])
 
         resp =
           conn
@@ -287,9 +289,9 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "includes funnel when include_funnel is true", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            %{name: "pageview", pathname: "/home"},
-            %{name: "pageview", pathname: "/login"},
-            %{name: "pageview", pathname: "/logout"}
+            Journey.Step.new("pageview", "/home"),
+            Journey.Step.new("pageview", "/login"),
+            Journey.Step.new("pageview", "/logout")
           ])
 
         resp =
@@ -332,9 +334,9 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       } do
         journey =
           Jason.encode!([
-            %{name: "pageview", pathname: "/logout"},
-            %{name: "pageview", pathname: "/login"},
-            %{name: "pageview", pathname: "/home"}
+            Journey.Step.new("pageview", "/logout"),
+            Journey.Step.new("pageview", "/login"),
+            Journey.Step.new("pageview", "/home")
           ])
 
         resp =

--- a/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
@@ -78,13 +78,13 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
           |> json_response(200)
 
         assert [next_step1, next_step2, next_step3] = resp
-        assert next_step1["step"]["label"] == "Visit /docs"
+        assert next_step1["step"]["label"] == "/docs"
         assert next_step1["step"]["pathname"] == "/docs"
         assert next_step1["visitors"] == 1
-        assert next_step2["step"]["label"] == "Visit /home"
+        assert next_step2["step"]["label"] == "/home"
         assert next_step2["step"]["pathname"] == "/home"
         assert next_step2["visitors"] == 1
-        assert next_step3["step"]["label"] == "Visit /logout"
+        assert next_step3["step"]["label"] == "/logout"
         assert next_step3["step"]["pathname"] == "/logout"
         assert next_step3["visitors"] == 1
       end
@@ -149,21 +149,21 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
 
         assert [step1, step2, step3] = resp
 
-        assert step1["step"]["label"] == "Visit /home"
+        assert step1["step"]["label"] == "/home"
         assert step1["step"]["pathname"] == "/home"
         assert step1["visitors"] == 2
         assert step1["dropoff"] == 0
         assert step1["dropoff_percentage"] == "0"
         assert step1["conversion_rate"] == "100"
         assert step1["conversion_rate_step"] == "0"
-        assert step2["step"]["label"] == "Visit /login"
+        assert step2["step"]["label"] == "/login"
         assert step2["step"]["pathname"] == "/login"
         assert step2["visitors"] == 2
         assert step2["dropoff"] == 0
         assert step2["dropoff_percentage"] == "0"
         assert step2["conversion_rate"] == "100"
         assert step2["conversion_rate_step"] == "100"
-        assert step3["step"]["label"] == "Visit /logout"
+        assert step3["step"]["label"] == "/logout"
         assert step3["step"]["pathname"] == "/logout"
         assert step3["visitors"] == 1
         assert step3["dropoff"] == 1
@@ -229,13 +229,13 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
           |> json_response(200)
 
         assert [next_step1, next_step2, next_step3] = resp["next"]
-        assert next_step1["step"]["label"] == "Visit /docs"
+        assert next_step1["step"]["label"] == "/docs"
         assert next_step1["step"]["pathname"] == "/docs"
         assert next_step1["visitors"] == 1
-        assert next_step2["step"]["label"] == "Visit /home"
+        assert next_step2["step"]["label"] == "/home"
         assert next_step2["step"]["pathname"] == "/home"
         assert next_step2["visitors"] == 1
-        assert next_step3["step"]["label"] == "Visit /logout"
+        assert next_step3["step"]["label"] == "/logout"
         assert next_step3["step"]["pathname"] == "/logout"
         assert next_step3["visitors"] == 1
 
@@ -303,21 +303,21 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
 
         assert [step1, step2, step3] = resp["funnel"]
 
-        assert step1["step"]["label"] == "Visit /home"
+        assert step1["step"]["label"] == "/home"
         assert step1["step"]["pathname"] == "/home"
         assert step1["visitors"] == 2
         assert step1["dropoff"] == 0
         assert step1["dropoff_percentage"] == "0"
         assert step1["conversion_rate"] == "100"
         assert step1["conversion_rate_step"] == "0"
-        assert step2["step"]["label"] == "Visit /login"
+        assert step2["step"]["label"] == "/login"
         assert step2["step"]["pathname"] == "/login"
         assert step2["visitors"] == 2
         assert step2["dropoff"] == 0
         assert step2["dropoff_percentage"] == "0"
         assert step2["conversion_rate"] == "100"
         assert step2["conversion_rate_step"] == "100"
-        assert step3["step"]["label"] == "Visit /logout"
+        assert step3["step"]["label"] == "/logout"
         assert step3["step"]["pathname"] == "/logout"
         assert step3["visitors"] == 1
         assert step3["dropoff"] == 1

--- a/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
@@ -64,7 +64,7 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
     end
 
     describe "exploration_next/2" do
-      test "it works", %{conn: conn, site: site} do
+      test "returns suggestions for the next step", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
             Journey.Step.new("pageview", "/home"),
@@ -91,7 +91,24 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
         assert next_step3["visitors"] == 1
       end
 
-      test "it filters", %{conn: conn, site: site} do
+      test "returns error on too long journey", %{conn: conn, site: site} do
+        journey =
+          Jason.encode!(
+            Enum.map(1..20, fn idx -> Journey.Step.new("pageview", "/page#{idx}") end)
+          )
+
+        resp =
+          conn
+          |> post("/api/stats/#{site.domain}/exploration/next/", %{
+            "journey" => journey,
+            "period" => "24h"
+          })
+          |> json_response(400)
+
+        assert resp["error"] == "The journey is too long"
+      end
+
+      test "allows filtering suggestions", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
             Journey.Step.new("pageview", "/home"),
@@ -112,7 +129,7 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
         assert next_step["visitors"] == 1
       end
 
-      test "it supports backward direction", %{conn: conn, site: site} do
+      test "supports backward direction", %{conn: conn, site: site} do
         journey = Jason.encode!([Journey.Step.new("pageview", "/logout")])
 
         resp =
@@ -133,7 +150,7 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
     end
 
     describe "exploration_funnel/2" do
-      test "it works", %{conn: conn, site: site} do
+      test "returns a funnel", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
             Journey.Step.new("pageview", "/home"),
@@ -174,7 +191,36 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
         assert step3["conversion_rate_step"] == "50"
       end
 
-      test "it supports backward direction", %{conn: conn, site: site} do
+      test "returns error on too long journey", %{conn: conn, site: site} do
+        journey =
+          Jason.encode!(
+            Enum.map(1..21, fn idx -> Journey.Step.new("pageview", "/page#{idx}") end)
+          )
+
+        resp =
+          conn
+          |> post("/api/stats/#{site.domain}/exploration/funnel/", %{
+            "journey" => journey,
+            "period" => "24h"
+          })
+          |> json_response(400)
+
+        assert resp["error"] == "The journey is too long"
+      end
+
+      test "returns error on empty journey", %{conn: conn, site: site} do
+        resp =
+          conn
+          |> post("/api/stats/#{site.domain}/exploration/funnel/", %{
+            "journey" => Jason.encode!([]),
+            "period" => "24h"
+          })
+          |> json_response(400)
+
+        assert resp["error"] == "We are unable to show funnels when journey is empty"
+      end
+
+      test "supports backward direction", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
             Journey.Step.new("pageview", "/logout"),


### PR DESCRIPTION
### Changes

This PR adds experimental implementation of implicit wildcard pathnames support to exploration funnel.

The wildcard suggestions are automatically generated from underlying suggested transitions. The paths are generated segment by segment. The patterns which have visitors counts exactly equal to their non-wildcard counterparts are eliminated to only show the actual wildcards that group more than one path.

~There's still a very small discrepancy between visitors counts for wildcard patterns between next step suggestions and funnel computation. I'm still not sure where it's coming from (the way the visitors are computed is very differernt, though the outcome _should be_ the same). We can look deeper into this, provided this feature will be needed at all.~

~The idea is for this "prototype" to be merged for actual early testing, so that we get feedback whether it's worth having at all.~

In the mean time, on the basis of this change, we will work on adding support for pageview and custom goals in funnel exploration.

Other changes made within the scope of this PR:

- pathnames are normalised, so that the trailing slashes are removed from them. With this, pathnames like "/:dashboard" and "/:dashboard/" are treated as the same path
- we no longer prepend pageview steps with "Visit " - it's label is a plain path
- implicit wilcards are customised to be different from pageview goal patterns - the way they are computed differs from a pageview goal like "/path*" in that is does not count things like "/path-to-some-other-page".

### Tests
- [x] Automated tests have been added

