### PR TITLE
Clean up main graph route

### DIFF
--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -18,10 +18,6 @@ defmodule PlausibleWeb.StatsController do
     Api.StatsController --) Browser: {"top_stats": [...]}
     Note left of Browser: TopStats.render()
 
-    Browser -) Api.StatsController: GET /api/stats/mydomain.com/main-graph
-    Api.StatsController --) Browser: [{"plot": [...], "labels": [...]}, ...]
-    Note left of Browser: VisitorGraph.render()
-
     Browser -) Api.StatsController: GET /api/stats/mydomain.com/sources
     Api.StatsController --) Browser: [{"name": "Google", "visitors": 292150}, ...]
     Note left of Browser: Sources.render()

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -296,7 +296,6 @@ defmodule PlausibleWeb.Router do
       scope private: %{allow_consolidated_views: true} do
         post "/:domain/query", StatsController, :query
         get "/:domain/current-visitors", StatsController, :current_visitors
-        get "/:domain/main-graph", StatsController, :main_graph
         get "/:domain/sources", StatsController, :sources
         get "/:domain/channels", StatsController, :channels
         get "/:domain/utm_mediums", StatsController, :utm_mediums

--- a/test/plausible_web/controllers/api/stats_controller/authorization_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/authorization_test.exs
@@ -12,7 +12,9 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
   describe "API authorization - as anonymous user" do
     test "returns 404 for a site that doesn't exist", %{conn: conn} do
       conn = init_session(conn)
-      conn = get(conn, "/api/stats/fake-site.com/main-graph")
+
+      conn =
+        post(conn, "/api/stats/fake-site.com/query", %{})
 
       assert json_response(conn, 404) == %{
                "error" => "Site does not exist or user does not have sufficient access."
@@ -22,7 +24,9 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
     test "returns 404 for private site", %{conn: conn} do
       conn = init_session(conn)
       site = insert(:site, public: false)
-      conn = get(conn, "/api/stats/#{site.domain}/main-graph")
+
+      conn =
+        post(conn, "/api/stats/#{site.domain}/query", %{})
 
       assert json_response(conn, 404) == %{
                "error" => "Site does not exist or user does not have sufficient access."
@@ -34,10 +38,7 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
       site = insert(:site, public: true)
 
       conn =
-        post(conn, "/api/stats/#{site.domain}/query", %{
-          "date_range" => "day",
-          "metrics" => ["visitors"]
-        })
+        query_visitors(conn, site, [])
 
       assert %{"results" => _} = json_response(conn, 200)
     end
@@ -183,7 +184,9 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
 
     test "returns 404 for a site that doesn't exist", %{conn: conn} do
       conn = init_session(conn)
-      conn = get(conn, "/api/stats/fake-site.com/main-graph/")
+
+      conn =
+        post(conn, "/api/stats/fake-site.com/query", %{})
 
       assert json_response(conn, 404) == %{
                "error" => "Site does not exist or user does not have sufficient access."
@@ -192,7 +195,9 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
 
     test "returns 404 when user does not have access to site", %{conn: conn} do
       site = new_site()
-      conn = get(conn, "/api/stats/#{site.domain}/main-graph")
+
+      conn =
+        post(conn, "/api/stats/#{site.domain}/query", %{})
 
       assert json_response(conn, 404) == %{
                "error" => "Site does not exist or user does not have sufficient access."
@@ -203,10 +208,7 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
       site = new_site(public: true)
 
       conn =
-        post(conn, "/api/stats/#{site.domain}/query", %{
-          "date_range" => "day",
-          "metrics" => ["visitors"]
-        })
+        query_visitors(conn, site, [])
 
       assert %{"results" => _} = json_response(conn, 200)
     end
@@ -214,11 +216,7 @@ defmodule PlausibleWeb.Api.StatsController.AuthorizationTest do
     test "returns stats for a private site that the user owns", %{conn: conn, user: user} do
       site = new_site(public: false, owner: user)
 
-      conn =
-        post(conn, "/api/stats/#{site.domain}/query", %{
-          "date_range" => "day",
-          "metrics" => ["visitors"]
-        })
+      conn = query_visitors(conn, site, [])
 
       assert %{"results" => _} = json_response(conn, 200)
     end


### PR DESCRIPTION
### Changes

- Cleans up main-graph route. 
- Fixes authorization tests to use the same utility.

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
