### PR TITLE
Revert "Add implicit wildcard matches to exploration suggestions (#62…

### DIFF
--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -1,14 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react'
 import * as api from '../api'
 import * as url from '../util/url'
-import { Tooltip } from '../util/tooltip'
 import { useDebounce } from '../custom-hooks'
 import { useSiteContext } from '../site-context'
 import { useDashboardStateContext } from '../dashboard-state-context'
-import {
-  numberShortFormatter,
-  numberLongFormatter
-} from '../util/number-formatter'
+import { numberShortFormatter } from '../util/number-formatter'
 
 const PAGE_FILTER_KEYS = ['page', 'entry_page', 'exit_page']
 const EXPLORATION_DIRECTIONS = {
@@ -30,12 +26,7 @@ function stateWithApplicableFilters(dashboardState, steps) {
 }
 
 function toJourney(steps) {
-  return steps.map((s) => ({
-    name: s.name,
-    pathname: s.pathname,
-    includes_subpaths: s.includes_subpaths,
-    subpaths_count: s.subpaths_count
-  }))
+  return steps.map((s) => ({ name: s.name, pathname: s.pathname }))
 }
 
 function fetchNextWithFunnel(
@@ -70,11 +61,7 @@ function fetchInterestingFunnel(site, dashboardState) {
 }
 
 function isSameStep(step, otherStep) {
-  return (
-    step.name === otherStep.name &&
-    step.pathname === otherStep.pathname &&
-    step.includes_subpaths === otherStep.includes_subpaths
-  )
+  return step.name === otherStep.name && step.pathname === otherStep.pathname
 }
 
 function ExplorationColumn({
@@ -161,12 +148,9 @@ function ExplorationColumn({
               isSelected && selectedConversionRate !== null
                 ? selectedConversionRate
                 : Math.round((visitors / stepMaxVisitors) * 100)
-            const label = step.includes_subpaths
-              ? `${step.label}… (${step.subpaths_count} pages)`
-              : step.label
 
             return (
-              <li key={label}>
+              <li key={step.label}>
                 <button
                   className={`group w-full border text-left px-2.5 pt-2 pb-2.5 text-sm rounded-md focus:outline-none ${
                     isSelected
@@ -178,14 +162,12 @@ function ExplorationColumn({
                   <div className="flex items-center justify-between gap-2 mb-1">
                     <span
                       className="truncate font-medium text-gray-800 dark:text-gray-200"
-                      title={label}
+                      title={step.label}
                     >
-                      {label}
+                      {step.label}
                     </span>
                     <span className="shrink-0 text-gray-800 dark:text-gray-200 tabular-nums">
-                      <Tooltip info={numberLongFormatter(visitorsToShow)}>
-                        {numberShortFormatter(visitorsToShow)}
-                      </Tooltip>
+                      {numberShortFormatter(visitorsToShow)}
                     </span>
                   </div>
                   <div

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -8,30 +8,20 @@ defmodule Plausible.Stats.Exploration do
 
     @type t() :: %__MODULE__{}
 
-    @derive {Jason.Encoder, only: [:name, :pathname, :label, :includes_subpaths, :subpaths_count]}
-    defstruct name: nil, pathname: nil, label: nil, includes_subpaths: false, subpaths_count: 0
+    @derive {Jason.Encoder, only: [:name, :pathname, :label]}
+    defstruct [:name, :pathname, :label]
 
     @spec from(map()) :: t()
     def from(step) do
-      new(step.name, step.pathname, step.includes_subpaths, step.subpaths_count)
+      new(step.name, step.pathname)
     end
 
-    @spec new(String.t(), String.t(), boolean(), non_neg_integer()) :: t()
-    def new(name, pathname, includes_subpaths \\ false, subpaths_count \\ 0)
-        when is_boolean(includes_subpaths) and is_integer(subpaths_count) do
-      label =
-        if name != "pageview" do
-          name <> " " <> pathname
-        else
-          pathname
-        end
-
+    @spec new(String.t(), String.t()) :: t()
+    def new(name, pathname) do
       %__MODULE__{
-        label: label,
+        label: if(name == "pageview", do: "Visit", else: name) <> " " <> pathname,
         name: name,
-        pathname: pathname,
-        includes_subpaths: includes_subpaths,
-        subpaths_count: subpaths_count
+        pathname: pathname
       }
     end
   end
@@ -63,27 +53,14 @@ defmodule Plausible.Stats.Exploration do
           conversion_rate_step: String.t()
         }
 
-  @max_steps 20
-  @max_candidates 20
-
   @next_steps_defaults [search_term: "", direction: :forward, max_candidates: 10]
 
-  @spec max_steps() :: pos_integer()
-  def max_steps, do: @max_steps
-
-  @spec next_steps(Query.t(), journey(), keyword()) ::
-          {:ok, [next_step()]} | {:error, :journey_too_long}
-  def next_steps(query, journey, opts \\ [])
-
-  def next_steps(_query, journey, _opts) when length(journey) >= @max_steps do
-    {:error, :journey_too_long}
-  end
-
-  def next_steps(query, journey, opts) do
+  @spec next_steps(Query.t(), journey(), keyword()) :: {:ok, [next_step()]}
+  def next_steps(query, journey, opts \\ []) do
     opts = Keyword.merge(@next_steps_defaults, opts)
     direction = Keyword.fetch!(opts, :direction)
     search_term = Keyword.fetch!(opts, :search_term)
-    max_candidates = min(Keyword.fetch!(opts, :max_candidates), @max_candidates)
+    max_candidates = min(Keyword.fetch!(opts, :max_candidates), 20)
 
     query
     |> Base.base_event_query()
@@ -95,14 +72,10 @@ defmodule Plausible.Stats.Exploration do
   end
 
   @spec journey_funnel(Query.t(), journey(), direction()) ::
-          {:ok, [funnel_step()]} | {:error, :empty_journey | :journey_too_long}
+          {:ok, [funnel_step()]} | {:error, :empty_journey}
   def journey_funnel(query, journey, direction \\ :forward)
 
   def journey_funnel(_query, [], _direction), do: {:error, :empty_journey}
-
-  def journey_funnel(_query, journey, _direction) when length(journey) > @max_steps do
-    {:error, :journey_too_long}
-  end
 
   def journey_funnel(query, journey, direction) when is_direction(direction) do
     query
@@ -137,8 +110,8 @@ defmodule Plausible.Stats.Exploration do
   @spec interesting_funnel(Query.t(), keyword()) ::
           {:ok, [funnel_step()]} | {:error, :not_found}
   def interesting_funnel(query, opts \\ []) do
-    max_steps = min(Keyword.get(opts, :max_steps, 6), @max_steps)
-    max_candidates = min(Keyword.get(opts, :max_candidates, 10), @max_candidates)
+    max_steps = min(Keyword.get(opts, :max_steps, 6), 20)
+    max_candidates = min(Keyword.get(opts, :max_candidates, 10), 20)
 
     case build_interesting_journey(query, max_steps, max_candidates) do
       [] -> {:error, :not_found}
@@ -181,13 +154,6 @@ defmodule Plausible.Stats.Exploration do
   defp normalize_pathname("/"), do: "/"
   defp normalize_pathname(pathname), do: String.trim_trailing(pathname, "/")
 
-  @wildcard_array_join """
-  arrayFold(
-    acc, x -> arrayPushBack(acc, concat(acc[-1], '/', x)), 
-    arraySlice(splitByChar('/', ?) AS split_pathname, 2), 
-    arraySlice(split_pathname, 1, 1))
-  """
-
   defp next_steps_query(query, steps, search_term, direction, max_candidates)
        when is_direction(direction) do
     next_step_idx = length(steps) + 1
@@ -196,147 +162,80 @@ defmodule Plausible.Stats.Exploration do
     next_name = :"name#{next_step_idx}"
     next_pathname = :"pathname#{next_step_idx}"
 
-    q_matches =
+    q_next =
       from(s in subquery(q_steps),
-        where: selected_as(:name) != "",
+        where: selected_as(:next_name) != "",
         select: %{
-          name: selected_as(field(s, ^next_name), :name),
-          pathname: selected_as(field(s, ^next_pathname), :pathname)
-        }
-      )
-
-    q_matches =
-      steps
-      |> Enum.with_index()
-      |> Enum.reduce(q_matches, fn {step, idx}, q ->
-        step_condition = step_condition(step, idx + 1)
-
-        from(s in q, where: ^step_condition)
-      end)
-
-    q_exact_matches =
-      from(m in q_matches,
-        select_merge: %{
-          visitors: scale_sample(fragment("uniq(?)", m.user_id)),
-          includes_subpaths: type(^false, :boolean),
-          subpaths_count: 0
-        },
-        group_by: [selected_as(:name), selected_as(:pathname)]
-      )
-
-    q_per_user_matches =
-      from(m in q_matches,
-        select_merge: %{user_id: m.user_id, _sample_factor: fragment("any(?)", m._sample_factor)},
-        group_by: [selected_as(:name), selected_as(:pathname), m.user_id]
-      )
-
-    q_wildcard_matches =
-      from(em in subquery(q_per_user_matches),
-        join: pname in fragment(@wildcard_array_join, em.pathname),
-        on: true,
-        hints: "ARRAY",
-        where: em.name == "pageview",
-        where: selected_as(:pathname) != "" and selected_as(:pathname) != "/",
-        select: %{
-          name: em.name,
-          pathname: selected_as(fragment("?", pname), :pathname),
-          visitors: selected_as(scale_sample(fragment("uniq(?)", em.user_id)), :visitors),
-          unique_paths: scale_sample(fragment("uniq(?)", em.pathname))
-        },
-        group_by: [em.name, selected_as(:pathname)]
-      )
-
-    q_wildcard_filtered_matches =
-      from(wm in subquery(q_wildcard_matches),
-        left_join: emx in subquery(q_exact_matches),
-        on: emx.name == wm.name and emx.pathname == wm.pathname,
-        where: wm.unique_paths > 1 and (is_nil(emx.name) or wm.visitors != emx.visitors),
-        select: %{
-          name: wm.name,
-          pathname: wm.pathname,
-          visitors: wm.visitors,
-          includes_subpaths: type(^true, :boolean),
-          subpaths_count: wm.unique_paths
-        }
-      )
-
-    q_all_matches =
-      q_exact_matches
-      |> union_all(^q_wildcard_filtered_matches)
-
-    from(m in subquery(q_all_matches),
-      select: %{
-        step: %Journey.Step{
-          label:
-            selected_as(
-              fragment(
-                "if(? != 'pageview', concat(?, ' ', ?), ?)",
-                m.name,
-                m.name,
-                m.pathname,
-                m.pathname
+          step: %Journey.Step{
+            label:
+              selected_as(
+                fragment(
+                  "concat(CASE WHEN ? = ? THEN ? ELSE ? END, ' ', ?)",
+                  selected_as(:next_name),
+                  "pageview",
+                  "Visit",
+                  selected_as(:next_name),
+                  selected_as(:next_pathname)
+                ),
+                :next_label
               ),
-              :label
-            ),
-          name: m.name,
-          pathname: m.pathname,
-          includes_subpaths: m.includes_subpaths,
-          subpaths_count: m.subpaths_count
+            name: selected_as(field(s, ^next_name), :next_name),
+            pathname: selected_as(field(s, ^next_pathname), :next_pathname)
+          },
+          visitors: selected_as(scale_sample(fragment("uniq(?)", s.user_id)), :count)
         },
-        visitors: m.visitors
-      },
-      order_by: [
-        desc: m.visitors,
-        asc: m.pathname,
-        asc: m.name
-      ],
-      limit: ^max_candidates
-    )
-    |> maybe_search(search_term)
+        group_by: [selected_as(:next_name), selected_as(:next_pathname)],
+        order_by: [
+          desc: selected_as(:count),
+          asc: selected_as(:next_pathname),
+          asc: selected_as(:next_name)
+        ],
+        limit: ^max_candidates
+      )
+      |> maybe_search(search_term)
+
+    steps
+    |> Enum.with_index()
+    |> Enum.reduce(q_next, fn {step, idx}, q ->
+      name = :"name#{idx + 1}"
+      pathname = :"pathname#{idx + 1}"
+
+      from(s in q,
+        where: field(s, ^name) == ^step.name and field(s, ^pathname) == ^step.pathname
+      )
+    end)
   end
 
   defp journey_funnel_query(query, steps, direction) do
     q_steps = steps_query(query, length(steps), direction)
 
-    q_funnel = from(s in subquery(q_steps), select: %{})
+    [first_step | steps] = steps
+
+    q_funnel =
+      from(s in subquery(q_steps),
+        where: s.name1 == ^first_step.name and s.pathname1 == ^first_step.pathname,
+        select: %{
+          1 => scale_sample(fragment("uniq(?)", s.user_id))
+        }
+      )
 
     steps
     |> Enum.with_index()
-    |> Enum.reduce(q_funnel, fn
-      {step, 0}, q ->
-        step_condition = step_condition(step, 1)
+    |> Enum.reduce(q_funnel, fn {_step, idx}, q ->
+      current_steps = Enum.take(steps, idx + 1)
 
-        from(e in q,
-          select_merge: %{
-            1 => scale_sample(fragment("uniq(?)", e.user_id))
-          },
-          where: ^step_condition
-        )
+      step_conditions =
+        current_steps
+        |> Enum.with_index()
+        |> Enum.reduce(dynamic(true), fn {step, idx}, acc ->
+          step_condition = step_condition(step, idx + 2)
+          dynamic([q], fragment("? and ?", ^acc, ^step_condition))
+        end)
 
-      {_step, idx}, q ->
-        current_steps = Enum.take(steps, idx + 1)
+      step_count =
+        dynamic([e], scale_sample(fragment("uniqIf(?, ?)", e.user_id, ^step_conditions)))
 
-        step_conditions =
-          current_steps
-          |> Enum.with_index()
-          |> Enum.reduce(dynamic(true), fn {step, idx}, acc ->
-            step_condition = step_condition(step, idx + 1)
-            dynamic([q], fragment("? and ?", ^acc, ^step_condition))
-          end)
-
-        step_count =
-          dynamic(
-            [e],
-            scale_sample(
-              fragment(
-                "uniqIf(?, ?)",
-                e.user_id,
-                ^step_conditions
-              )
-            )
-          )
-
-        from(e in q, select_merge: ^%{(idx + 1) => step_count})
+      from(e in q, select_merge: ^%{(idx + 2) => step_count})
     end)
   end
 
@@ -356,8 +255,7 @@ defmodule Plausible.Stats.Exploration do
           user_id: e.user_id,
           _sample_factor: e._sample_factor,
           name: e.name,
-          pathname:
-            fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname),
+          pathname: e.pathname,
           timestamp: e.timestamp
         },
         where: e.name != "engagement",
@@ -390,9 +288,7 @@ defmodule Plausible.Stats.Exploration do
   defp select_previous(query, :forward) do
     from(e in query,
       select_merge: %{
-        prev_pathname:
-          lag(fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname))
-          |> over(:session_window),
+        prev_pathname: lag(e.pathname) |> over(:session_window),
         prev_name: lag(e.name) |> over(:session_window)
       }
     )
@@ -401,9 +297,7 @@ defmodule Plausible.Stats.Exploration do
   defp select_previous(query, :backward) do
     from(e in query,
       select_merge: %{
-        prev_pathname:
-          lead(fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname))
-          |> over(:session_window),
+        prev_pathname: lead(e.pathname) |> over(:session_window),
         prev_name: lead(e.name) |> over(:session_window)
       }
     )
@@ -427,30 +321,18 @@ defmodule Plausible.Stats.Exploration do
     )
   end
 
-  defp step_condition(step, count) when count <= @max_steps do
-    if step.includes_subpaths do
-      escaped = Regex.escape(step.pathname)
-
-      pattern = "^#{escaped}(/.+)?$"
-
-      dynamic(
-        [s],
-        field(s, ^:"name#{count}") == ^step.name and
-          fragment("match(?, ?)", field(s, ^:"pathname#{count}"), ^pattern)
-      )
-    else
-      dynamic(
-        [s],
-        field(s, ^:"name#{count}") == ^step.name and
-          field(s, ^:"pathname#{count}") == ^step.pathname
-      )
-    end
+  defp step_condition(step, count) do
+    dynamic(
+      [s],
+      field(s, ^:"name#{count}") == ^step.name and
+        field(s, ^:"pathname#{count}") == ^step.pathname
+    )
   end
 
   defp maybe_search(query, search_term) do
     case String.trim(search_term) do
       term when byte_size(term) > 2 ->
-        from(s in query, where: ilike(selected_as(:label), ^"%#{term}%"))
+        from(s in query, where: ilike(selected_as(:next_label), ^"%#{term}%"))
 
       _ ->
         query

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -151,8 +151,8 @@ defmodule PlausibleWeb.Api.StatsController do
              ) do
         json(conn, next_steps)
       else
-        {:error, :journey_too_long} ->
-          bad_request(conn, "The journey is too long")
+        _ ->
+          bad_request(conn, "There was an error with your request")
       end
     end
 
@@ -167,10 +167,13 @@ defmodule PlausibleWeb.Api.StatsController do
         json(conn, funnel)
       else
         {:error, :empty_journey} ->
-          bad_request(conn, "We are unable to show funnels when journey is empty")
-
-        {:error, :journey_too_long} ->
-          bad_request(conn, "The journey is too long")
+          bad_request(
+            conn,
+            "We are unable to show funnels when journey is empty",
+            %{
+              level: :normal
+            }
+          )
       end
     end
 
@@ -224,18 +227,8 @@ defmodule PlausibleWeb.Api.StatsController do
       |> then(&{:ok, &1})
     end
 
-    defp parse_journey_step(%{
-           "name" => name,
-           "pathname" => pathname,
-           "includes_subpaths" => includes_subpaths,
-           "subpaths_count" => subpaths_count
-         }) do
-      Plausible.Stats.Exploration.Journey.Step.new(
-        name,
-        pathname,
-        includes_subpaths,
-        subpaths_count
-      )
+    defp parse_journey_step(%{"name" => name, "pathname" => pathname}) do
+      Plausible.Stats.Exploration.Journey.Step.new(name, pathname)
     end
 
     defp parse_exploration_direction("backward"), do: {:ok, :backward}

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -149,9 +149,9 @@ defmodule Plausible.Stats.ExplorationTest do
 
         assert {:ok, [step1, step2, step3, step4]} = Exploration.journey_funnel(query, journey)
 
-        assert step1.step.label == "/register"
+        assert step1.step.label == "Visit /register"
         assert step2.step.label == "Signup /register"
-        assert step3.step.label == "/activate"
+        assert step3.step.label == "Visit /activate"
         assert step4.step.label == "Create site /sites/new"
       end
 
@@ -194,17 +194,6 @@ defmodule Plausible.Stats.ExplorationTest do
         query = QueryBuilder.build!(site, input_date_range: :all)
 
         assert {:error, :empty_journey} = Exploration.journey_funnel(query, [])
-      end
-
-      test "returns error on too long journey", %{site: site} do
-        query = QueryBuilder.build!(site, input_date_range: :all)
-
-        journey =
-          Enum.map(1..21, fn idx ->
-            %Exploration.Journey.Step{name: "pageview", pathname: "/page#{idx}"}
-          end)
-
-        assert {:error, :journey_too_long} = Exploration.journey_funnel(query, journey)
       end
 
       test "supports backward journey funnel", %{site: site} do
@@ -335,7 +324,7 @@ defmodule Plausible.Stats.ExplorationTest do
         assert {:ok, funnel} = Exploration.interesting_funnel(query)
 
         pathnames = Enum.map(funnel, & &1.step.pathname)
-        assert pathnames == ["/about", "/contact"]
+        assert pathnames == ["/home", "/about/", "/contact"]
       end
 
       test "stops when no more unseen steps are available" do
@@ -441,13 +430,13 @@ defmodule Plausible.Stats.ExplorationTest do
         assert {:ok, [next_step1, next_step2, next_step3]} =
                  Exploration.next_steps(query, journey)
 
-        assert next_step1.step.label == "/docs"
+        assert next_step1.step.label == "Visit /docs"
         assert next_step1.step.pathname == "/docs"
         assert next_step1.visitors == 1
-        assert next_step2.step.label == "/home"
+        assert next_step2.step.label == "Visit /home"
         assert next_step2.step.pathname == "/home"
         assert next_step2.visitors == 1
-        assert next_step3.step.label == "/logout"
+        assert next_step3.step.label == "Visit /logout"
         assert next_step3.step.pathname == "/logout"
         assert next_step3.visitors == 1
       end
@@ -462,17 +451,6 @@ defmodule Plausible.Stats.ExplorationTest do
 
         assert {:ok, [%{step: %{pathname: "/docs"}}]} =
                  Exploration.next_steps(query, journey, max_candidates: 1)
-      end
-
-      test "returns error on too long journey", %{site: site} do
-        query = QueryBuilder.build!(site, input_date_range: :all)
-
-        journey =
-          Enum.map(1..20, fn idx ->
-            %Exploration.Journey.Step{name: "pageview", pathname: "/page#{idx}"}
-          end)
-
-        assert {:error, :journey_too_long} = Exploration.next_steps(query, journey)
       end
 
       test "suggests the first step in the journey", %{site: site} do
@@ -525,42 +503,18 @@ defmodule Plausible.Stats.ExplorationTest do
         assert next_step.visitors == 1
       end
 
-      test "allows to filter according to how label is rendered" do
-        site = new_site()
-
-        now = DateTime.utc_now()
-
-        populate_stats(site, [
-          build(:pageview,
-            user_id: 123,
-            pathname: "/home",
-            timestamp: DateTime.shift(now, minute: -320)
-          ),
-          build(:event,
-            user_id: 123,
-            name: "Signup",
-            pathname: "/register",
-            timestamp: DateTime.shift(now, minute: -300)
-          ),
-          build(:pageview,
-            user_id: 123,
-            pathname: "/sites/new",
-            timestamp: DateTime.shift(now, minute: -270)
-          )
-        ])
-
+      test "allows to filter according to how label is rendered", %{site: site} do
         query = QueryBuilder.build!(site, input_date_range: :all)
 
         journey = [
-          %Exploration.Journey.Step{name: "pageview", pathname: "/home"}
+          %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
+          %Exploration.Journey.Step{name: "pageview", pathname: "/login"}
         ]
 
         assert {:ok, [next_step]} =
-                 Exploration.next_steps(query, journey, search_term: "up /regi")
+                 Exploration.next_steps(query, journey, search_term: "isit /doc")
 
-        assert next_step.step.label == "Signup /register"
-        assert next_step.step.name == "Signup"
-        assert next_step.step.pathname == "/register"
+        assert next_step.step.pathname == "/docs"
         assert next_step.visitors == 1
       end
 
@@ -627,17 +581,11 @@ defmodule Plausible.Stats.ExplorationTest do
 
         query = QueryBuilder.build!(site, input_date_range: :all)
 
-        assert {:ok,
-                [
-                  %{step: %{pathname: "/:dashboard"}}
-                ]} =
-                 Exploration.next_steps(query, journey, search_term: "", direction: :forward)
+        assert {:ok, [%{step: %{pathname: "/:dashboard"}}, %{step: %{pathname: "/:dashboard/"}}]} =
+                 Exploration.next_steps(query, journey, direction: :forward)
 
-        assert {:ok,
-                [
-                  %{step: %{pathname: "/:dashboard"}}
-                ]} =
-                 Exploration.next_steps(query, journey, search_term: "", direction: :backward)
+        assert {:ok, [%{step: %{pathname: "/:dashboard"}}, %{step: %{pathname: "/:dashboard/"}}]} =
+                 Exploration.next_steps(query, journey, direction: :backward)
       end
 
       test "treats identical sequence of events as a single step" do
@@ -865,107 +813,6 @@ defmodule Plausible.Stats.ExplorationTest do
         assert next_step.step.pathname == "/logout"
         assert next_step.visitors == 2
       end
-    end
-
-    test "implicit wildcard path visitors computation is correct and consistent between next_step and journey_funnel" do
-      now = DateTime.utc_now()
-      site = new_site()
-
-      populate_stats(site, [
-        build(:pageview,
-          user_id: 122,
-          pathname: "/aa",
-          timestamp: DateTime.shift(now, minute: -300)
-        ),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/a",
-          timestamp: DateTime.shift(now, minute: -300)
-        ),
-        build(:pageview,
-          user_id: 124,
-          pathname: "/a",
-          timestamp: DateTime.shift(now, minute: -300)
-        ),
-        build(:pageview,
-          user_id: 125,
-          pathname: "/a",
-          timestamp: DateTime.shift(now, minute: -300)
-        ),
-        build(:pageview,
-          user_id: 126,
-          pathname: "/a",
-          timestamp: DateTime.shift(now, minute: -300)
-        ),
-        build(:pageview,
-          user_id: 127,
-          pathname: "/a",
-          timestamp: DateTime.shift(now, minute: -300)
-        ),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/a/b",
-          timestamp: DateTime.shift(now, minute: -270)
-        ),
-        build(:pageview,
-          user_id: 124,
-          pathname: "/a/b",
-          timestamp: DateTime.shift(now, minute: -270)
-        ),
-        build(:pageview,
-          user_id: 126,
-          pathname: "/a/d",
-          timestamp: DateTime.shift(now, minute: -270)
-        ),
-        build(:pageview,
-          user_id: 127,
-          pathname: "/a/d",
-          timestamp: DateTime.shift(now, minute: -270)
-        ),
-        build(:pageview,
-          user_id: 123,
-          pathname: "/a/b/c",
-          timestamp: DateTime.shift(now, minute: -240)
-        ),
-        build(:pageview,
-          user_id: 128,
-          pathname: "/a/b/c",
-          timestamp: DateTime.shift(now, minute: -240)
-        )
-      ])
-
-      query = QueryBuilder.build!(site, input_date_range: :all)
-
-      result = Exploration.next_steps(query, [])
-
-      assert {:ok,
-              [
-                %{step: %{label: "/a", includes_subpaths: true, subpaths_count: 4}, visitors: 6},
-                %{step: %{label: "/a", includes_subpaths: false}, visitors: 5},
-                %{
-                  step: %{label: "/a/b", includes_subpaths: true, subpaths_count: 2},
-                  visitors: 3
-                },
-                %{step: %{label: "/a/b", includes_subpaths: false}, visitors: 2},
-                %{step: %{label: "/a/b/c"}, visitors: 2},
-                %{step: %{label: "/a/d"}, visitors: 2},
-                %{step: %{label: "/aa"}, visitors: 1}
-              ]} = result
-
-      journey = [
-        %Exploration.Journey.Step{
-          name: "pageview",
-          pathname: "/a",
-          includes_subpaths: true,
-          subpaths_count: 4
-        }
-      ]
-
-      assert {:ok, [step1]} = Exploration.journey_funnel(query, journey)
-
-      assert step1.step.label == "/a"
-      assert step1.step.includes_subpaths == true
-      assert step1.visitors == 6
     end
   end
 end

--- a/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/exploration_test.exs
@@ -3,8 +3,6 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
   use Plausible
 
   on_ee do
-    alias Plausible.Stats.Exploration.Journey
-
     setup [:create_user, :log_in, :create_site]
 
     setup %{user: user, site: site} do
@@ -64,11 +62,11 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
     end
 
     describe "exploration_next/2" do
-      test "returns suggestions for the next step", %{conn: conn, site: site} do
+      test "it works", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            Journey.Step.new("pageview", "/home"),
-            Journey.Step.new("pageview", "/login")
+            %{name: "pageview", pathname: "/home"},
+            %{name: "pageview", pathname: "/login"}
           ])
 
         resp =
@@ -80,39 +78,22 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
           |> json_response(200)
 
         assert [next_step1, next_step2, next_step3] = resp
-        assert next_step1["step"]["label"] == "/docs"
+        assert next_step1["step"]["label"] == "Visit /docs"
         assert next_step1["step"]["pathname"] == "/docs"
         assert next_step1["visitors"] == 1
-        assert next_step2["step"]["label"] == "/home"
+        assert next_step2["step"]["label"] == "Visit /home"
         assert next_step2["step"]["pathname"] == "/home"
         assert next_step2["visitors"] == 1
-        assert next_step3["step"]["label"] == "/logout"
+        assert next_step3["step"]["label"] == "Visit /logout"
         assert next_step3["step"]["pathname"] == "/logout"
         assert next_step3["visitors"] == 1
       end
 
-      test "returns error on too long journey", %{conn: conn, site: site} do
-        journey =
-          Jason.encode!(
-            Enum.map(1..20, fn idx -> Journey.Step.new("pageview", "/page#{idx}") end)
-          )
-
-        resp =
-          conn
-          |> post("/api/stats/#{site.domain}/exploration/next/", %{
-            "journey" => journey,
-            "period" => "24h"
-          })
-          |> json_response(400)
-
-        assert resp["error"] == "The journey is too long"
-      end
-
-      test "allows filtering suggestions", %{conn: conn, site: site} do
+      test "it filters", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            Journey.Step.new("pageview", "/home"),
-            Journey.Step.new("pageview", "/login")
+            %{name: "pageview", pathname: "/home"},
+            %{name: "pageview", pathname: "/login"}
           ])
 
         resp =
@@ -129,8 +110,8 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
         assert next_step["visitors"] == 1
       end
 
-      test "supports backward direction", %{conn: conn, site: site} do
-        journey = Jason.encode!([Journey.Step.new("pageview", "/logout")])
+      test "it supports backward direction", %{conn: conn, site: site} do
+        journey = Jason.encode!([%{name: "pageview", pathname: "/logout"}])
 
         resp =
           conn
@@ -150,12 +131,12 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
     end
 
     describe "exploration_funnel/2" do
-      test "returns a funnel", %{conn: conn, site: site} do
+      test "it works", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            Journey.Step.new("pageview", "/home"),
-            Journey.Step.new("pageview", "/login"),
-            Journey.Step.new("pageview", "/logout")
+            %{name: "pageview", pathname: "/home"},
+            %{name: "pageview", pathname: "/login"},
+            %{name: "pageview", pathname: "/logout"}
           ])
 
         resp =
@@ -168,21 +149,21 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
 
         assert [step1, step2, step3] = resp
 
-        assert step1["step"]["label"] == "/home"
+        assert step1["step"]["label"] == "Visit /home"
         assert step1["step"]["pathname"] == "/home"
         assert step1["visitors"] == 2
         assert step1["dropoff"] == 0
         assert step1["dropoff_percentage"] == "0"
         assert step1["conversion_rate"] == "100"
         assert step1["conversion_rate_step"] == "0"
-        assert step2["step"]["label"] == "/login"
+        assert step2["step"]["label"] == "Visit /login"
         assert step2["step"]["pathname"] == "/login"
         assert step2["visitors"] == 2
         assert step2["dropoff"] == 0
         assert step2["dropoff_percentage"] == "0"
         assert step2["conversion_rate"] == "100"
         assert step2["conversion_rate_step"] == "100"
-        assert step3["step"]["label"] == "/logout"
+        assert step3["step"]["label"] == "Visit /logout"
         assert step3["step"]["pathname"] == "/logout"
         assert step3["visitors"] == 1
         assert step3["dropoff"] == 1
@@ -191,41 +172,12 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
         assert step3["conversion_rate_step"] == "50"
       end
 
-      test "returns error on too long journey", %{conn: conn, site: site} do
-        journey =
-          Jason.encode!(
-            Enum.map(1..21, fn idx -> Journey.Step.new("pageview", "/page#{idx}") end)
-          )
-
-        resp =
-          conn
-          |> post("/api/stats/#{site.domain}/exploration/funnel/", %{
-            "journey" => journey,
-            "period" => "24h"
-          })
-          |> json_response(400)
-
-        assert resp["error"] == "The journey is too long"
-      end
-
-      test "returns error on empty journey", %{conn: conn, site: site} do
-        resp =
-          conn
-          |> post("/api/stats/#{site.domain}/exploration/funnel/", %{
-            "journey" => Jason.encode!([]),
-            "period" => "24h"
-          })
-          |> json_response(400)
-
-        assert resp["error"] == "We are unable to show funnels when journey is empty"
-      end
-
-      test "supports backward direction", %{conn: conn, site: site} do
+      test "it supports backward direction", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            Journey.Step.new("pageview", "/logout"),
-            Journey.Step.new("pageview", "/login"),
-            Journey.Step.new("pageview", "/home")
+            %{name: "pageview", pathname: "/logout"},
+            %{name: "pageview", pathname: "/login"},
+            %{name: "pageview", pathname: "/home"}
           ])
 
         resp =
@@ -264,8 +216,8 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "returns next steps without funnel by default", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            Journey.Step.new("pageview", "/home"),
-            Journey.Step.new("pageview", "/login")
+            %{name: "pageview", pathname: "/home"},
+            %{name: "pageview", pathname: "/login"}
           ])
 
         resp =
@@ -277,13 +229,13 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
           |> json_response(200)
 
         assert [next_step1, next_step2, next_step3] = resp["next"]
-        assert next_step1["step"]["label"] == "/docs"
+        assert next_step1["step"]["label"] == "Visit /docs"
         assert next_step1["step"]["pathname"] == "/docs"
         assert next_step1["visitors"] == 1
-        assert next_step2["step"]["label"] == "/home"
+        assert next_step2["step"]["label"] == "Visit /home"
         assert next_step2["step"]["pathname"] == "/home"
         assert next_step2["visitors"] == 1
-        assert next_step3["step"]["label"] == "/logout"
+        assert next_step3["step"]["label"] == "Visit /logout"
         assert next_step3["step"]["pathname"] == "/logout"
         assert next_step3["visitors"] == 1
 
@@ -293,8 +245,8 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "filters next steps by search_term", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            Journey.Step.new("pageview", "/home"),
-            Journey.Step.new("pageview", "/login")
+            %{name: "pageview", pathname: "/home"},
+            %{name: "pageview", pathname: "/login"}
           ])
 
         resp =
@@ -313,7 +265,7 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       end
 
       test "supports backward direction for next steps", %{conn: conn, site: site} do
-        journey = Jason.encode!([Journey.Step.new("pageview", "/logout")])
+        journey = Jason.encode!([%{name: "pageview", pathname: "/logout"}])
 
         resp =
           conn
@@ -335,9 +287,9 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       test "includes funnel when include_funnel is true", %{conn: conn, site: site} do
         journey =
           Jason.encode!([
-            Journey.Step.new("pageview", "/home"),
-            Journey.Step.new("pageview", "/login"),
-            Journey.Step.new("pageview", "/logout")
+            %{name: "pageview", pathname: "/home"},
+            %{name: "pageview", pathname: "/login"},
+            %{name: "pageview", pathname: "/logout"}
           ])
 
         resp =
@@ -351,21 +303,21 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
 
         assert [step1, step2, step3] = resp["funnel"]
 
-        assert step1["step"]["label"] == "/home"
+        assert step1["step"]["label"] == "Visit /home"
         assert step1["step"]["pathname"] == "/home"
         assert step1["visitors"] == 2
         assert step1["dropoff"] == 0
         assert step1["dropoff_percentage"] == "0"
         assert step1["conversion_rate"] == "100"
         assert step1["conversion_rate_step"] == "0"
-        assert step2["step"]["label"] == "/login"
+        assert step2["step"]["label"] == "Visit /login"
         assert step2["step"]["pathname"] == "/login"
         assert step2["visitors"] == 2
         assert step2["dropoff"] == 0
         assert step2["dropoff_percentage"] == "0"
         assert step2["conversion_rate"] == "100"
         assert step2["conversion_rate_step"] == "100"
-        assert step3["step"]["label"] == "/logout"
+        assert step3["step"]["label"] == "Visit /logout"
         assert step3["step"]["pathname"] == "/logout"
         assert step3["visitors"] == 1
         assert step3["dropoff"] == 1
@@ -380,9 +332,9 @@ defmodule PlausibleWeb.Api.StatsController.ExplorationTest do
       } do
         journey =
           Jason.encode!([
-            Journey.Step.new("pageview", "/logout"),
-            Journey.Step.new("pageview", "/login"),
-            Journey.Step.new("pageview", "/home")
+            %{name: "pageview", pathname: "/logout"},
+            %{name: "pageview", pathname: "/login"},
+            %{name: "pageview", pathname: "/home"}
           ])
 
         resp =


### PR DESCRIPTION
…71)"

This reverts commit be2d839f771befe39d2742db12bf41563bab4f02.

### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
