### PR TITLE
Fix performance regression after introducing wildcard pathnames

### DIFF
--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -251,12 +251,11 @@ defmodule Plausible.Stats.Exploration do
       )
 
     # Fan out each q_combined row into up to two output rows (exact + wildcard)
-    # using ARRAY JOIN over a small boolean array — no UNION ALL, no branching,
-    # no second scan of events_v2.
+    # using ARRAY JOIN over a small boolean array.
     #
     # For each row we build [false, true] and filter it down to just [false]
     # when the wildcard row should be suppressed (non-pageview, only one distinct
-    # subpath, or same visitor count as exact). ARRAY JOIN then emits one or two
+    # subpath, or same visitor count as exact). ARRAY JOIN then emits one or more
     # rows per group. The joined boolean `is_wildcard` selects which values to
     # use for visitors / includes_subpaths / subpaths_count.
     q_all_matches =

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -252,37 +252,41 @@ defmodule Plausible.Stats.Exploration do
         group_by: [em.name, selected_as(:pathname)]
       )
 
-    # The aggregated result q_combined is tiny (one row per distinct prefix
-    # path). The UNION ALL below operates on this small in-memory table, not on
-    # raw events — so both branches are cheap regardless of inlining.
-    q_exact_matches =
-      from(m in subquery(q_combined),
-        select: %{
-          name: m.name,
-          pathname: m.pathname,
-          visitors: m.exact_visitors,
-          includes_subpaths: type(^false, :boolean),
-          subpaths_count: 0
-        }
-      )
-
-    q_wildcard_matches =
-      from(m in subquery(q_combined),
-        where:
-          m.name == "pageview" and m.subpaths_count > 1 and
-            m.wildcard_visitors != m.exact_visitors,
-        select: %{
-          name: m.name,
-          pathname: m.pathname,
-          visitors: m.wildcard_visitors,
-          includes_subpaths: type(^true, :boolean),
-          subpaths_count: m.subpaths_count
-        }
-      )
-
+    # Fan out each q_combined row into up to two output rows (exact + wildcard)
+    # using ARRAY JOIN over a small boolean array — no UNION ALL, no branching,
+    # no second scan of events_v2.
+    #
+    # For each row we build [false, true] and filter it down to just [false]
+    # when the wildcard row should be suppressed (non-pageview, only one distinct
+    # subpath, or same visitor count as exact). ARRAY JOIN then emits one or two
+    # rows per group. The joined boolean `is_wildcard` selects which values to
+    # use for visitors / includes_subpaths / subpaths_count.
     q_all_matches =
-      q_exact_matches
-      |> union_all(^q_wildcard_matches)
+      from(m in subquery(q_combined),
+        join:
+          is_wildcard in fragment(
+            """
+            arrayFilter(
+              x -> x = false OR (? = 'pageview' AND ? > 1 AND ? != ?),
+              [false, true]
+            )
+            """,
+            m.name,
+            m.subpaths_count,
+            m.wildcard_visitors,
+            m.exact_visitors
+          ),
+        on: true,
+        hints: "ARRAY",
+        select: %{
+          name: m.name,
+          pathname: m.pathname,
+          visitors:
+            fragment("if(?, ?, ?)", is_wildcard, m.wildcard_visitors, m.exact_visitors),
+          includes_subpaths: fragment("CAST(?, 'Bool')", is_wildcard),
+          subpaths_count: fragment("if(?, ?, 0)", is_wildcard, m.subpaths_count)
+        }
+      )
 
     from(m in subquery(q_all_matches),
       select: %{

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -242,9 +242,7 @@ defmodule Plausible.Stats.Exploration do
           name: em.name,
           pathname: selected_as(fragment("?", pname), :pathname),
           exact_visitors:
-            scale_sample(
-              fragment("uniqIf(?, ? = ?)", em.user_id, em.pathname, pname)
-            ),
+            scale_sample(fragment("uniqIf(?, ? = ?)", em.user_id, em.pathname, pname)),
           wildcard_visitors:
             selected_as(scale_sample(fragment("uniq(?)", em.user_id)), :wildcard_visitors),
           subpaths_count: scale_sample(fragment("uniq(?)", em.pathname))
@@ -281,8 +279,7 @@ defmodule Plausible.Stats.Exploration do
         select: %{
           name: m.name,
           pathname: m.pathname,
-          visitors:
-            fragment("if(?, ?, ?)", is_wildcard, m.wildcard_visitors, m.exact_visitors),
+          visitors: fragment("if(?, ?, ?)", is_wildcard, m.wildcard_visitors, m.exact_visitors),
           includes_subpaths: fragment("CAST(?, 'Bool')", is_wildcard),
           subpaths_count: fragment("if(?, ?, 0)", is_wildcard, m.subpaths_count)
         }
@@ -384,8 +381,7 @@ defmodule Plausible.Stats.Exploration do
             fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname),
           timestamp: e.timestamp
         },
-        where: e.name != "engagement",
-        order_by: ^event_ordering
+        where: e.name != "engagement"
       )
       |> select_previous(direction)
 
@@ -398,8 +394,7 @@ defmodule Plausible.Stats.Exploration do
           name1: e.name,
           pathname1: e.pathname
         },
-        where: e.prev_name != e.name or e.prev_pathname != e.pathname,
-        order_by: ^event_ordering
+        where: e.prev_name != e.name or e.prev_pathname != e.pathname
       )
 
     if steps > 1 do

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -214,20 +214,28 @@ defmodule Plausible.Stats.Exploration do
         from(s in q, where: ^step_condition)
       end)
 
-    q_exact_matches =
-      from(m in q_matches,
-        select_merge: %{
-          visitors: scale_sample(fragment("uniq(?)", m.user_id)),
-          includes_subpaths: type(^false, :boolean),
-          subpaths_count: 0
-        },
-        group_by: [selected_as(:name), selected_as(:pathname)]
-      )
-
+    # Scan events_v2 once, producing one row per (name, pathname, user_id).
+    # Both the exact-match aggregation and the wildcard/subpath aggregation are
+    # derived from this single result, avoiding a second scan of events_v2.
     q_per_user_matches =
       from(m in q_matches,
         select_merge: %{user_id: m.user_id, _sample_factor: fragment("any(?)", m._sample_factor)},
         group_by: [selected_as(:name), selected_as(:pathname), m.user_id]
+      )
+
+    # Derive exact-match visitor counts by re-aggregating q_per_user_matches.
+    # Since it already has one row per (name, pathname, user_id), count() is
+    # equivalent to uniq(user_id) on the raw events — no second scan needed.
+    q_exact_matches =
+      from(m in subquery(q_per_user_matches),
+        select: %{
+          name: m.name,
+          pathname: m.pathname,
+          visitors: scale_sample(fragment("count()")),
+          includes_subpaths: type(^false, :boolean),
+          subpaths_count: 0
+        },
+        group_by: [m.name, m.pathname]
       )
 
     q_wildcard_matches =
@@ -248,12 +256,8 @@ defmodule Plausible.Stats.Exploration do
       )
 
     # Union exact matches and wildcard matches together, then filter in the outer
-    # query. This avoids re-scanning events_v2 a third time: previously the
-    # LEFT JOIN in q_wildcard_filtered_matches caused q_exact_matches (and
-    # therefore the base event scan) to be evaluated again. Now we look up the
-    # exact-match visitor count from the same UNION ALL result via a window
-    # function partitioned by (name, pathname), keeping the total scan count at
-    # two.
+    # query. Both branches derive from q_per_user_matches which itself comes from
+    # a single scan of events_v2 — keeping total scan count at one.
     q_all_unfiltered =
       q_exact_matches
       |> union_all(^q_wildcard_matches)

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -182,10 +182,10 @@ defmodule Plausible.Stats.Exploration do
   defp normalize_pathname(pathname), do: String.trim_trailing(pathname, "/")
 
   @wildcard_array_join """
-  arrayFold(
+  if(? = 'pageview', arrayFold(
     acc, x -> arrayPushBack(acc, concat(acc[-1], '/', x)), 
     arraySlice(splitByChar('/', ?) AS split_pathname, 2), 
-    arraySlice(split_pathname, 1, 1))
+    arraySlice(split_pathname, 1, 1)), [?])
   """
 
   defp next_steps_query(query, steps, search_term, direction, max_candidates)
@@ -234,7 +234,7 @@ defmodule Plausible.Stats.Exploration do
 
     q_combined =
       from(em in subquery(q_per_user_matches),
-        join: pname in fragment(@wildcard_array_join, em.pathname),
+        join: pname in fragment(@wildcard_array_join, em.name, em.pathname, em.pathname),
         on: true,
         hints: "ARRAY",
         where: selected_as(:pathname) != "" and selected_as(:pathname) != "/",

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -241,28 +241,64 @@ defmodule Plausible.Stats.Exploration do
           name: em.name,
           pathname: selected_as(fragment("?", pname), :pathname),
           visitors: selected_as(scale_sample(fragment("uniq(?)", em.user_id)), :visitors),
-          unique_paths: scale_sample(fragment("uniq(?)", em.pathname))
+          includes_subpaths: type(^true, :boolean),
+          subpaths_count: scale_sample(fragment("uniq(?)", em.pathname))
         },
         group_by: [em.name, selected_as(:pathname)]
       )
 
-    q_wildcard_filtered_matches =
-      from(wm in subquery(q_wildcard_matches),
-        left_join: emx in subquery(q_exact_matches),
-        on: emx.name == wm.name and emx.pathname == wm.pathname,
-        where: wm.unique_paths > 1 and (is_nil(emx.name) or wm.visitors != emx.visitors),
+    # Union exact matches and wildcard matches together, then filter in the outer
+    # query. This avoids re-scanning events_v2 a third time: previously the
+    # LEFT JOIN in q_wildcard_filtered_matches caused q_exact_matches (and
+    # therefore the base event scan) to be evaluated again. Now we look up the
+    # exact-match visitor count from the same UNION ALL result via a window
+    # function partitioned by (name, pathname), keeping the total scan count at
+    # two.
+    q_all_unfiltered =
+      q_exact_matches
+      |> union_all(^q_wildcard_matches)
+
+    # Annotate every row with the exact-match visitor count for that
+    # (name, pathname) pair using a window function. ClickHouse does not allow
+    # window functions directly in WHERE, so we wrap in a subquery first and
+    # filter in the outer query.
+    q_with_exact_visitors =
+      from(m in subquery(q_all_unfiltered),
         select: %{
-          name: wm.name,
-          pathname: wm.pathname,
-          visitors: wm.visitors,
-          includes_subpaths: type(^true, :boolean),
-          subpaths_count: wm.unique_paths
+          name: m.name,
+          pathname: m.pathname,
+          visitors: m.visitors,
+          includes_subpaths: m.includes_subpaths,
+          subpaths_count: m.subpaths_count,
+          exact_visitors:
+            fragment(
+              "anyIf(?, NOT ?) OVER (PARTITION BY ?, ?)",
+              m.visitors,
+              m.includes_subpaths,
+              m.name,
+              m.pathname
+            )
         }
       )
 
+    # For each (name, pathname) pair, compute the exact-match visitor count
+    # (includes_subpaths = false) across all rows sharing that pair.
+    # Wildcard rows are kept only when their visitor count differs from the
+    # exact count (meaning the prefix genuinely adds paths beyond the exact
+    # match) and they cover more than one distinct path.
     q_all_matches =
-      q_exact_matches
-      |> union_all(^q_wildcard_filtered_matches)
+      from(m in subquery(q_with_exact_visitors),
+        select: %{
+          name: m.name,
+          pathname: m.pathname,
+          visitors: m.visitors,
+          includes_subpaths: m.includes_subpaths,
+          subpaths_count: m.subpaths_count
+        },
+        where:
+          not m.includes_subpaths or
+            (m.subpaths_count > 1 and m.visitors != m.exact_visitors)
+      )
 
     from(m in subquery(q_all_matches),
       select: %{

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -214,95 +214,75 @@ defmodule Plausible.Stats.Exploration do
         from(s in q, where: ^step_condition)
       end)
 
-    # Scan events_v2 once, producing one row per (name, pathname, user_id).
-    # Both the exact-match aggregation and the wildcard/subpath aggregation are
-    # derived from this single result, avoiding a second scan of events_v2.
+    # Expand each (name, pathname, user_id) row into all prefix paths via
+    # ARRAY JOIN, then aggregate once to get both exact and wildcard visitor
+    # counts in a single scan of events_v2.
+    #
+    # The arrayFold expansion includes the original pathname as the last
+    # element, so uniqIf(user_id, original_pathname = prefix_pathname) gives the
+    # exact-match count for free, alongside the wildcard uniq(user_id) and the
+    # uniq(original_pathname) subpath count — all in one GROUP BY.
+    #
+    # Non-pageview events are included in the expansion but produce only a
+    # single prefix (their exact pathname), so they naturally get
+    # subpaths_count = 1 and are only emitted as exact rows.
     q_per_user_matches =
       from(m in q_matches,
         select_merge: %{user_id: m.user_id, _sample_factor: fragment("any(?)", m._sample_factor)},
         group_by: [selected_as(:name), selected_as(:pathname), m.user_id]
       )
 
-    # Derive exact-match visitor counts by re-aggregating q_per_user_matches.
-    # Since it already has one row per (name, pathname, user_id), count() is
-    # equivalent to uniq(user_id) on the raw events — no second scan needed.
-    q_exact_matches =
-      from(m in subquery(q_per_user_matches),
-        select: %{
-          name: m.name,
-          pathname: m.pathname,
-          visitors: scale_sample(fragment("count()")),
-          includes_subpaths: type(^false, :boolean),
-          subpaths_count: 0
-        },
-        group_by: [m.name, m.pathname]
-      )
-
-    q_wildcard_matches =
+    q_combined =
       from(em in subquery(q_per_user_matches),
         join: pname in fragment(@wildcard_array_join, em.pathname),
         on: true,
         hints: "ARRAY",
-        where: em.name == "pageview",
         where: selected_as(:pathname) != "" and selected_as(:pathname) != "/",
         select: %{
           name: em.name,
           pathname: selected_as(fragment("?", pname), :pathname),
-          visitors: selected_as(scale_sample(fragment("uniq(?)", em.user_id)), :visitors),
-          includes_subpaths: type(^true, :boolean),
+          exact_visitors:
+            scale_sample(
+              fragment("uniqIf(?, ? = ?)", em.user_id, em.pathname, pname)
+            ),
+          wildcard_visitors:
+            selected_as(scale_sample(fragment("uniq(?)", em.user_id)), :wildcard_visitors),
           subpaths_count: scale_sample(fragment("uniq(?)", em.pathname))
         },
         group_by: [em.name, selected_as(:pathname)]
       )
 
-    # Union exact matches and wildcard matches together, then filter in the outer
-    # query. Both branches derive from q_per_user_matches which itself comes from
-    # a single scan of events_v2 — keeping total scan count at one.
-    q_all_unfiltered =
-      q_exact_matches
-      |> union_all(^q_wildcard_matches)
-
-    # Annotate every row with the exact-match visitor count for that
-    # (name, pathname) pair using a window function. ClickHouse does not allow
-    # window functions directly in WHERE, so we wrap in a subquery first and
-    # filter in the outer query.
-    q_with_exact_visitors =
-      from(m in subquery(q_all_unfiltered),
+    # The aggregated result q_combined is tiny (one row per distinct prefix
+    # path). The UNION ALL below operates on this small in-memory table, not on
+    # raw events — so both branches are cheap regardless of inlining.
+    q_exact_matches =
+      from(m in subquery(q_combined),
         select: %{
           name: m.name,
           pathname: m.pathname,
-          visitors: m.visitors,
-          includes_subpaths: m.includes_subpaths,
-          subpaths_count: m.subpaths_count,
-          exact_visitors:
-            fragment(
-              "anyIf(?, NOT ?) OVER (PARTITION BY ?, ?)",
-              m.visitors,
-              m.includes_subpaths,
-              m.name,
-              m.pathname
-            )
+          visitors: m.exact_visitors,
+          includes_subpaths: type(^false, :boolean),
+          subpaths_count: 0
         }
       )
 
-    # For each (name, pathname) pair, compute the exact-match visitor count
-    # (includes_subpaths = false) across all rows sharing that pair.
-    # Wildcard rows are kept only when their visitor count differs from the
-    # exact count (meaning the prefix genuinely adds paths beyond the exact
-    # match) and they cover more than one distinct path.
-    q_all_matches =
-      from(m in subquery(q_with_exact_visitors),
+    q_wildcard_matches =
+      from(m in subquery(q_combined),
+        where:
+          m.name == "pageview" and m.subpaths_count > 1 and
+            m.wildcard_visitors != m.exact_visitors,
         select: %{
           name: m.name,
           pathname: m.pathname,
-          visitors: m.visitors,
-          includes_subpaths: m.includes_subpaths,
+          visitors: m.wildcard_visitors,
+          includes_subpaths: type(^true, :boolean),
           subpaths_count: m.subpaths_count
-        },
-        where:
-          not m.includes_subpaths or
-            (m.subpaths_count > 1 and m.visitors != m.exact_visitors)
+        }
       )
+
+    q_all_matches =
+      q_exact_matches
+      |> union_all(^q_wildcard_matches)
 
     from(m in subquery(q_all_matches),
       select: %{


### PR DESCRIPTION
### Changes

This PR modifies the next step query so that exact and wildcard entries are fetched without a union, potentially avoiding excessive table scans. Additionally, explicit ORDER BY was removed from the inner steps_query, only leaving ordering within the windows.


