### PR TITLE
Stop ordering by name and pathname in steps_query window definitions

### DIFF
--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -425,7 +425,8 @@ defmodule Plausible.Stats.Exploration do
             fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname),
           timestamp: e.timestamp
         },
-        where: e.name != "engagement"
+        where: e.name != "engagement",
+        order_by: [asc: e.timestamp]
       )
       |> select_previous(direction)
 

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -408,14 +408,12 @@ defmodule Plausible.Stats.Exploration do
   end
 
   defp steps_query(query, steps, direction) when is_integer(steps) do
-    event_ordering = [asc: :timestamp, asc: :name, asc: :pathname]
-
     q_pairs =
       from(e in query,
         windows: [
           session_window: [
             partition_by: e.user_id,
-            order_by: ^event_ordering
+            order_by: [asc: e.timestamp]
           ]
         ],
         select: %{
@@ -433,7 +431,7 @@ defmodule Plausible.Stats.Exploration do
 
     q_steps =
       from(e in subquery(q_pairs),
-        windows: [step_window: [partition_by: e.user_id, order_by: ^event_ordering]],
+        windows: [step_window: [partition_by: e.user_id]],
         select: %{
           user_id: e.user_id,
           _sample_factor: e._sample_factor,

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -420,6 +420,7 @@ defmodule Plausible.Stats.Exploration do
           site_id: e.site_id,
           user_id: e.user_id,
           _sample_factor: e._sample_factor,
+          row_number: row_number() |> over(:session_window),
           name: e.name,
           pathname:
             fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname),
@@ -432,7 +433,9 @@ defmodule Plausible.Stats.Exploration do
 
     q_steps =
       from(e in subquery(q_pairs),
-        windows: [step_window: [partition_by: e.user_id]],
+        windows: [
+          step_window: [partition_by: e.user_id, order_by: [asc: e.timestamp, asc: e.row_number]]
+        ],
         select: %{
           user_id: e.user_id,
           _sample_factor: e._sample_factor,

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -269,10 +269,15 @@ defmodule Plausible.Stats.Exploration do
           ),
         on: true,
         hints: "ARRAY",
+        where: selected_as(:visitors) > 0,
         select: %{
           name: m.name,
           pathname: m.pathname,
-          visitors: fragment("if(?, ?, ?)", is_wildcard, m.wildcard_visitors, m.exact_visitors),
+          visitors:
+            selected_as(
+              fragment("if(?, ?, ?)", is_wildcard, m.wildcard_visitors, m.exact_visitors),
+              :visitors
+            ),
           includes_subpaths: fragment("CAST(?, 'Bool')", is_wildcard),
           subpaths_count: fragment("if(?, ?, 0)", is_wildcard, m.subpaths_count)
         }

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -426,8 +426,7 @@ defmodule Plausible.Stats.Exploration do
             fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname),
           timestamp: e.timestamp
         },
-        where: e.name != "engagement",
-        order_by: [asc: e.timestamp]
+        where: e.name != "engagement"
       )
       |> select_previous(direction)
 


### PR DESCRIPTION
### Changes

Another go at optimising performance of the suggestion query. This time we avoid ordering by name and pathname in the innermost, window queries. Stable ordering is ensured by enumerating by row_number() in the inner window and using it for sortin in the outer window, in addition to the timestamp. Very rarely, there's an artifact of a suggestion identical to the previous step appearing but it has 0 visitors - it's most likely due to union -> "smart join" optimisation done earlier.