### PR TITLE
Pass segment timestamps in site timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Fixed comparison tooltip in the top pages report missing date labels
 - Fixed top bar not scrolling horizontally on mobile
 - Fixed incline/decline percentages not showing in top stats in comparison mode
+- Fixed issue with timestamps being rendered incorrectly in segment menus and modals for some timezones
 
 ## v3.2.0 - 2026-01-16
 

--- a/assets/js/dashboard/filtering/segments.ts
+++ b/assets/js/dashboard/filtering/segments.ts
@@ -34,9 +34,9 @@ export type SavedSegment = {
   id: number
   name: string
   type: SegmentType
-  /** naive UTC timestamp, example 2025-02-26T10:00:00 */
+  /** naive site-timezone timestamp, example 2025-02-26T10:00:00 */
   inserted_at: string
-  /** naive UTC timestamp, example 2025-02-26T10:00:00 */
+  /** naive site-timezone timestamp, example 2025-02-26T10:00:00 */
   updated_at: string
 } & SegmentOwnership
 

--- a/assets/js/dashboard/segments/segment-authorship.tsx
+++ b/assets/js/dashboard/segments/segment-authorship.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { SavedSegmentPublic, SavedSegment } from '../filtering/segments'
-import { dateForSite, formatDayShort } from '../util/date'
-import { useSiteContext } from '../site-context'
+import { parseNaiveDate, formatDayShort } from '../util/date'
 
 type SegmentAuthorshipProps = {
   className?: string
@@ -14,7 +13,6 @@ export function SegmentAuthorship({
   showOnlyPublicData,
   segment
 }: SegmentAuthorshipProps) {
-  const site = useSiteContext()
   const authorLabel =
     showOnlyPublicData === true
       ? null
@@ -26,12 +24,12 @@ export function SegmentAuthorship({
   return (
     <div className={className}>
       <div>
-        {`Created at ${formatDayShort(dateForSite(inserted_at, site))}`}
+        {`Created at ${formatDayShort(parseNaiveDate(inserted_at))}`}
         {!showUpdatedAt && !!authorLabel && ` by ${authorLabel}`}
       </div>
       {showUpdatedAt && (
         <div>
-          {`Last updated at ${formatDayShort(dateForSite(updated_at, site))}`}
+          {`Last updated at ${formatDayShort(parseNaiveDate(updated_at))}`}
           {!!authorLabel && ` by ${authorLabel}`}
         </div>
       )}

--- a/assets/js/dashboard/util/date.js
+++ b/assets/js/dashboard/util/date.js
@@ -82,10 +82,6 @@ export function parseNaiveDate(dateString) {
   return dayjs(dateString)
 }
 
-export function dateForSite(utcDateString, site) {
-  return dayjs.utc(utcDateString).utcOffset(site.offset / 60)
-}
-
 export function utcNow() {
   return dayjs.utc()
 }

--- a/assets/js/dashboard/util/date.test.ts
+++ b/assets/js/dashboard/util/date.test.ts
@@ -1,5 +1,4 @@
 import {
-  dateForSite,
   formatDayShort,
   formatTime,
   formatMonthYYYY,
@@ -110,16 +109,6 @@ for (const [timezone, suite] of sets) {
     )
   })
 }
-
-describe('formatting UTC dates from database', () => {
-  it('is able to enrich UTC date string with site timezone, formatting the value correctly', () => {
-    expect(
-      formatDayShort(
-        dateForSite('2025-01-01T14:00:00', { offset: 60 * 60 * 11 })
-      )
-    ).toEqual('2 Jan')
-  })
-})
 
 describe('formatting site-timezoned datetimes from database works flawlessly', () => {
   it('is able to enrich UTC date string with site timezone, formatting the value correctly', () => {

--- a/lib/plausible/segments/segment.ex
+++ b/lib/plausible/segments/segment.ex
@@ -154,4 +154,3 @@ defmodule Plausible.Segments.Segment do
     end
   end
 end
-

--- a/lib/plausible/segments/segment.ex
+++ b/lib/plausible/segments/segment.ex
@@ -155,18 +155,3 @@ defmodule Plausible.Segments.Segment do
   end
 end
 
-defimpl Jason.Encoder, for: Plausible.Segments.Segment do
-  def encode(%Plausible.Segments.Segment{} = segment, opts) do
-    %{
-      id: segment.id,
-      name: segment.name,
-      type: segment.type,
-      segment_data: segment.segment_data,
-      owner_id: segment.owner_id,
-      owner_name: if(is_nil(segment.owner_id), do: nil, else: segment.owner.name),
-      inserted_at: segment.inserted_at,
-      updated_at: segment.updated_at
-    }
-    |> Jason.Encode.map(opts)
-  end
-end

--- a/lib/plausible/segments/segments.ex
+++ b/lib/plausible/segments/segments.ex
@@ -433,6 +433,29 @@ defmodule Plausible.Segments do
     |> Repo.aggregate(:count, :id)
   end
 
+  def to_response_map(%Segment{} = segment, %Plausible.Site{} = site) do
+    %{
+      id: segment.id,
+      name: segment.name,
+      type: segment.type,
+      segment_data: segment.segment_data,
+      owner_id: segment.owner_id,
+      owner_name: owner_name(segment),
+      inserted_at: shift_to_site_tz(segment.inserted_at, site.timezone),
+      updated_at: shift_to_site_tz(segment.updated_at, site.timezone)
+    }
+  end
+
+  defp owner_name(%Segment{owner_id: nil}), do: nil
+  defp owner_name(%Segment{owner: %Plausible.Auth.User{name: name}}), do: name
+  defp owner_name(%Segment{}), do: nil
+
+  defp shift_to_site_tz(%NaiveDateTime{} = naive_utc, timezone) do
+    naive_utc
+    |> DateTime.from_naive!("Etc/UTC")
+    |> Plausible.Times.to_naive_datetime!(timezone)
+  end
+
   def roles_with_personal_segments(), do: [:viewer, :editor, :admin, :owner, :super_admin]
   def roles_with_maybe_site_segments(), do: [:editor, :admin, :owner, :super_admin]
 

--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -189,9 +189,7 @@ defmodule Plausible.Stats.Time do
   end
 
   defp to_naive_in_tz!(utc_datetime, timezone) do
-    utc_datetime
-    |> DateTime.shift_zone!(timezone)
-    |> DateTime.to_naive()
+    Plausible.Times.to_naive_datetime!(utc_datetime, timezone)
   end
 
   def present_index(time_labels, query) do

--- a/lib/plausible/times.ex
+++ b/lib/plausible/times.ex
@@ -69,6 +69,13 @@ defmodule Plausible.Times do
     |> DateTime.to_date()
   end
 
+  @spec to_naive_datetime!(DateTime.t(), String.t()) :: NaiveDateTime.t()
+  def to_naive_datetime!(%DateTime{} = dt, tz) do
+    dt
+    |> DateTime.shift_zone!(tz)
+    |> DateTime.to_naive()
+  end
+
   @spec humanize(DateTime.t()) :: String.t()
   def humanize(%DateTime{} = dt) do
     Timex.Format.DateTime.Formatters.Relative.format!(dt, "{relative}")

--- a/lib/plausible_web/controllers/api/internal/segments_controller.ex
+++ b/lib/plausible_web/controllers/api/internal/segments_controller.ex
@@ -33,7 +33,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
         })
 
       {:ok, segment} ->
-        json(conn, segment)
+        json(conn, Segments.to_response_map(segment, site))
     end
   end
 
@@ -67,7 +67,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
         })
 
       {:ok, segment} ->
-        json(conn, segment)
+        json(conn, Segments.to_response_map(segment, site))
     end
   end
 
@@ -94,7 +94,7 @@ defmodule PlausibleWeb.Api.Internal.SegmentsController do
         segment_not_found(conn, params["segment_id"])
 
       {:ok, segment} ->
-        json(conn, segment)
+        json(conn, Segments.to_response_map(segment, site))
     end
   end
 

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -71,6 +71,7 @@ defmodule PlausibleWeb.StatsController do
       conn.params["skip_to_dashboard"] == "true" or consolidated_view?
 
     {:ok, segments} = Plausible.Segments.get_all_for_site(site, site_role)
+    segments = Enum.map(segments, &Plausible.Segments.to_response_map(&1, site))
 
     cond do
       consolidated_view? and not consolidated_view_available? and site_role != :super_admin ->
@@ -484,17 +485,10 @@ defmodule PlausibleWeb.StatsController do
         segments =
           if is_nil(limited_to_segment_id) do
             {:ok, segments} = Plausible.Segments.get_all_for_site(shared_link.site, site_role)
-            segments
+            Enum.map(segments, &Plausible.Segments.to_response_map(&1, shared_link.site))
           else
             shared_link.segment
-            |> Map.take([
-              :id,
-              :name,
-              :type,
-              :inserted_at,
-              :updated_at,
-              :segment_data
-            ])
+            |> Plausible.Segments.to_response_map(shared_link.site)
             |> List.wrap()
           end
 

--- a/test/plausible/segments/segments_test.exs
+++ b/test/plausible/segments/segments_test.exs
@@ -151,4 +151,107 @@ defmodule Plausible.SegmentsTest do
       })
     end
   end
+
+  describe "to_response_map/2" do
+    test "returns owner name for segment with owner association loaded", %{user: user} do
+      site = insert(:site, timezone: "Etc/UTC")
+
+      segment =
+        insert(:segment,
+          name: "Segment with owner",
+          type: :site,
+          site: site,
+          owner: user,
+          inserted_at: ~N[2025-06-01 12:00:00],
+          updated_at: ~N[2025-06-01 13:00:00]
+        )
+
+      assert_matches ^strict_map(%{
+                       id: ^segment.id,
+                       name: ^segment.name,
+                       type: ^segment.type,
+                       segment_data: ^segment.segment_data,
+                       owner_id: ^user.id,
+                       owner_name: ^user.name,
+                       inserted_at: ~N[2025-06-01 12:00:00],
+                       updated_at: ~N[2025-06-01 13:00:00]
+                     }) = Plausible.Segments.to_response_map(segment, site)
+    end
+
+    test "returns nil owner_name when owner association is not loaded", %{user: user} do
+      site = insert(:site, timezone: "Etc/UTC")
+
+      segment =
+        insert(:segment,
+          name: "Segment with owner",
+          site: site,
+          type: :site,
+          owner: user,
+          inserted_at: ~N[2025-06-01 12:00:00],
+          updated_at: ~N[2025-06-01 13:00:00]
+        )
+        |> Map.put(:owner, %Ecto.Association.NotLoaded{})
+
+      assert_matches ^strict_map(%{
+                       id: ^segment.id,
+                       name: ^segment.name,
+                       type: ^segment.type,
+                       segment_data: ^segment.segment_data,
+                       owner_id: ^user.id,
+                       owner_name: nil,
+                       inserted_at: ~N[2025-06-01 12:00:00],
+                       updated_at: ~N[2025-06-01 13:00:00]
+                     }) = Plausible.Segments.to_response_map(segment, site)
+    end
+
+    test "returns nil owner_name when owner_id is nil" do
+      site = insert(:site, timezone: "Etc/UTC")
+
+      segment =
+        insert(:segment,
+          name: "Orphaned segment",
+          site: site,
+          type: :site,
+          owner: nil,
+          inserted_at: ~N[2025-06-01 12:00:00],
+          updated_at: ~N[2025-06-01 13:00:00]
+        )
+
+      assert_matches ^strict_map(%{
+                       id: ^segment.id,
+                       name: ^segment.name,
+                       type: ^segment.type,
+                       segment_data: ^segment.segment_data,
+                       owner_id: nil,
+                       owner_name: nil,
+                       inserted_at: ~N[2025-06-01 12:00:00],
+                       updated_at: ~N[2025-06-01 13:00:00]
+                     }) = Plausible.Segments.to_response_map(segment, site)
+    end
+
+    test "shifts timestamps to site timezone" do
+      site = insert(:site, timezone: "Europe/Tallinn")
+
+      segment =
+        insert(:segment,
+          name: "My Segment",
+          site: site,
+          type: :site,
+          owner: nil,
+          inserted_at: ~N[2025-01-15 15:00:00],
+          updated_at: ~N[2025-01-15 23:00:00]
+        )
+
+      assert_matches ^strict_map(%{
+                       id: ^segment.id,
+                       name: ^segment.name,
+                       type: ^segment.type,
+                       segment_data: ^segment.segment_data,
+                       owner_id: nil,
+                       owner_name: nil,
+                       inserted_at: ~N[2025-01-15 17:00:00],
+                       updated_at: ~N[2025-01-16 01:00:00]
+                     }) = Plausible.Segments.to_response_map(segment, site)
+    end
+  end
 end

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -54,8 +54,6 @@ defmodule PlausibleWeb.StatsControllerTest do
           type: :site,
           name: "EMEA region"
         )
-        |> Map.put(:owner_name, nil)
-        |> Map.put(:owner_id, nil)
 
       foo_personal_segment =
         insert(:segment,
@@ -64,15 +62,19 @@ defmodule PlausibleWeb.StatsControllerTest do
           type: :personal,
           name: "FOO"
         )
-        |> Map.put(:owner_name, nil)
-        |> Map.put(:owner_id, nil)
 
       conn = get(conn, "/#{site.domain}")
       resp = html_response(conn, 200)
       assert element_exists?(resp, @react_container)
 
       assert text_of_attr(resp, @react_container, "data-segments") ==
-               Jason.encode!([foo_personal_segment, emea_site_segment])
+               Jason.encode!([
+                 Plausible.Segments.to_response_map(
+                   %{foo_personal_segment | owner_id: nil},
+                   site
+                 ),
+                 Plausible.Segments.to_response_map(%{emea_site_segment | owner_id: nil}, site)
+               ])
     end
 
     test "plausible.io live demo - shows site stats, header and footer", %{conn: conn} do
@@ -318,7 +320,6 @@ defmodule PlausibleWeb.StatsControllerTest do
           type: :site,
           name: "EMEA region"
         )
-        |> Map.put(:owner_name, user.name)
 
       foo_personal_segment =
         insert(:segment,
@@ -327,14 +328,16 @@ defmodule PlausibleWeb.StatsControllerTest do
           type: :personal,
           name: "FOO"
         )
-        |> Map.put(:owner_name, user.name)
 
       conn = get(conn, "/#{site.domain}")
       resp = html_response(conn, 200)
       assert element_exists?(resp, @react_container)
 
       assert text_of_attr(resp, @react_container, "data-segments") ==
-               Jason.encode!([foo_personal_segment, emea_site_segment])
+               Jason.encode!([
+                 Plausible.Segments.to_response_map(foo_personal_segment, site),
+                 Plausible.Segments.to_response_map(emea_site_segment, site)
+               ])
     end
   end
 
@@ -1381,9 +1384,9 @@ defmodule PlausibleWeb.StatsControllerTest do
 
       assert text_of_attr(resp, @react_container, "data-segments") ==
                emea_site_segment
-               |> Map.take([:id, :name, :type, :inserted_at, :updated_at, :segment_data])
+               |> Plausible.Segments.to_response_map(site)
                |> List.wrap()
-               |> JSON.encode!()
+               |> Jason.encode!()
 
       refute resp =~ apac_site_segment.name
 
@@ -1519,8 +1522,6 @@ defmodule PlausibleWeb.StatsControllerTest do
           type: :site,
           name: "EMEA region"
         )
-        |> Map.put(:owner_name, nil)
-        |> Map.put(:owner_id, nil)
 
       foo_personal_segment =
         insert(:segment,
@@ -1529,14 +1530,18 @@ defmodule PlausibleWeb.StatsControllerTest do
           type: :personal,
           name: "FOO"
         )
-        |> Map.put(:owner_name, nil)
-        |> Map.put(:owner_id, nil)
 
       conn = get(conn, "/share/#{site.domain}/?auth=#{link.slug}")
       resp = html_response(conn, 200)
 
       assert text_of_attr(resp, @react_container, "data-segments") ==
-               Jason.encode!([foo_personal_segment, emea_site_segment])
+               Jason.encode!([
+                 Plausible.Segments.to_response_map(
+                   %{foo_personal_segment | owner_id: nil},
+                   site
+                 ),
+                 Plausible.Segments.to_response_map(%{emea_site_segment | owner_id: nil}, site)
+               ])
     end
   end
 


### PR DESCRIPTION
### Changes

The frontend doesn't have enough information to render the UTC timestamps sent to it correctly. 

Site timezone offset isn't enough, because the offset is dynamic. It depends on the time. 

For example, for a site with the timezone Tallinn/Estonia, the UTC datetime `2026-01-01T00:00:00` must be rendered as `2026-01-01 02:00:00` whereas `2026-04-01T00:00:00` must be rendered as `2026-04-01 03:00:00`. 

This problem manifests with segment related timestamps: if the user on the Tallinn/Estonia site creates a segment in January and looks at it in April, the shown timestamp will be off by one hour, because we use the offset right now.

This PR fixes it by converting the dates on the backend. 
The alternative would be to provide the timezone locale to the FE and use that. The issue with that is the tz database falling out of sync between the BE and the FE. Also, we already convert some dates on the backend (in queries with the time dimension). 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
