### PR TITLE
Stop normalizing pathnames based on trailing slash

### DIFF
--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -427,8 +427,7 @@ defmodule Plausible.Stats.Exploration do
           _sample_factor: e._sample_factor,
           row_number: row_number() |> over(:session_window),
           name: e.name,
-          pathname:
-            fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname),
+          pathname: e.pathname,
           timestamp: e.timestamp
         },
         where: e.name != "engagement"
@@ -461,9 +460,7 @@ defmodule Plausible.Stats.Exploration do
   defp select_previous(query, :forward) do
     from(e in query,
       select_merge: %{
-        prev_pathname:
-          lag(fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname))
-          |> over(:session_window),
+        prev_pathname: lag(e.pathname) |> over(:session_window),
         prev_name: lag(e.name) |> over(:session_window)
       }
     )
@@ -473,7 +470,7 @@ defmodule Plausible.Stats.Exploration do
     from(e in query,
       select_merge: %{
         prev_pathname:
-          lead(fragment("if(? = '/', ?, trimRight(?, '/'))", e.pathname, e.pathname, e.pathname))
+          lead(e.pathname)
           |> over(:session_window),
         prev_name: lead(e.name) |> over(:session_window)
       }

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -275,69 +275,6 @@ defmodule Plausible.Stats.ExplorationTest do
         assert {:error, :not_found} = Exploration.interesting_funnel(query)
       end
 
-      test "treats trailing slash as the same page" do
-        site = new_site()
-        now = DateTime.utc_now()
-
-        populate_stats(site, [
-          # user 123
-          build(:pageview,
-            user_id: 123,
-            pathname: "/home",
-            timestamp: DateTime.shift(now, minute: -30)
-          ),
-          build(:pageview,
-            user_id: 123,
-            pathname: "/about/",
-            timestamp: DateTime.shift(now, minute: -25)
-          ),
-          build(:pageview,
-            user_id: 123,
-            pathname: "/contact",
-            timestamp: DateTime.shift(now, minute: -20)
-          ),
-          # user 124
-          build(:pageview,
-            user_id: 124,
-            pathname: "/home",
-            timestamp: DateTime.shift(now, minute: -30)
-          ),
-          build(:pageview,
-            user_id: 124,
-            pathname: "/about",
-            timestamp: DateTime.shift(now, minute: -25)
-          ),
-          build(:pageview,
-            user_id: 124,
-            pathname: "/pricing",
-            timestamp: DateTime.shift(now, minute: -20)
-          ),
-          # user 125
-          build(:pageview,
-            user_id: 125,
-            pathname: "/home",
-            timestamp: DateTime.shift(now, minute: -30)
-          ),
-          build(:pageview,
-            user_id: 125,
-            pathname: "/about/",
-            timestamp: DateTime.shift(now, minute: -25)
-          ),
-          build(:pageview,
-            user_id: 125,
-            pathname: "/contact",
-            timestamp: DateTime.shift(now, minute: -20)
-          )
-        ])
-
-        query = QueryBuilder.build!(site, input_date_range: :all)
-
-        assert {:ok, funnel} = Exploration.interesting_funnel(query)
-
-        pathnames = Enum.map(funnel, & &1.step.pathname)
-        assert pathnames == ["/about", "/contact"]
-      end
-
       test "stops when no more unseen steps are available" do
         site = new_site()
         now = DateTime.utc_now()
@@ -643,7 +580,7 @@ defmodule Plausible.Stats.ExplorationTest do
           build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(88)),
           build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(87)),
           build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(87)),
-          build(:pageview, user_id: 123, pathname: "/:dashboard/", timestamp: ago.(86)),
+          build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(86)),
           build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(85)),
           build(:pageview, user_id: 123, pathname: "/:dashboard", timestamp: ago.(84)),
           build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(83)),


### PR DESCRIPTION
### Changes

Per @metmarkosaric - we don't normalize path names anywhere else, so normalizing them here would be inconsistent.