### PR TITLE
Exclude pathname from custom events

### DIFF
--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -9,7 +9,7 @@ defmodule Plausible.Stats.Exploration do
     @type t() :: %__MODULE__{}
 
     @derive {Jason.Encoder, only: [:name, :pathname, :label, :includes_subpaths, :subpaths_count]}
-    defstruct name: nil, pathname: nil, label: nil, includes_subpaths: false, subpaths_count: 0
+    defstruct name: nil, pathname: "", label: nil, includes_subpaths: false, subpaths_count: 0
 
     @spec from(map()) :: t()
     def from(step) do
@@ -21,7 +21,7 @@ defmodule Plausible.Stats.Exploration do
         when is_boolean(includes_subpaths) and is_integer(subpaths_count) do
       label =
         if name != "pageview" do
-          name <> " " <> pathname
+          name
         else
           pathname
         end
@@ -289,10 +289,9 @@ defmodule Plausible.Stats.Exploration do
           label:
             selected_as(
               fragment(
-                "if(? != 'pageview', concat(?, ' ', ?), ?)",
+                "if(? != 'pageview', ?, ?)",
                 m.name,
                 m.name,
-                m.pathname,
                 m.pathname
               ),
               :label
@@ -338,7 +337,7 @@ defmodule Plausible.Stats.Exploration do
       join: pname in fragment(@wildcard_array_join, em.name, em.pathname, em.pathname),
       on: true,
       hints: "ARRAY",
-      where: selected_as(:pathname) != "",
+      where: em.name != "pageview" or selected_as(:pathname) != "",
       select: %{
         name: em.name,
         pathname: selected_as(fragment("?", pname), :pathname),
@@ -354,7 +353,7 @@ defmodule Plausible.Stats.Exploration do
 
   defp combined_query(q_matches, false = _include_wildcard?) do
     from(em in subquery(q_matches),
-      where: selected_as(:pathname) != "",
+      where: em.name != "pageview" or selected_as(:pathname) != "",
       select: %{
         name: em.name,
         pathname: selected_as(em.pathname, :pathname),
@@ -427,7 +426,7 @@ defmodule Plausible.Stats.Exploration do
           _sample_factor: e._sample_factor,
           row_number: row_number() |> over(:session_window),
           name: e.name,
-          pathname: e.pathname,
+          pathname: fragment("if(? = 'pageview', ?, '')", e.name, e.pathname),
           timestamp: e.timestamp
         },
         where: e.name != "engagement"
@@ -460,7 +459,8 @@ defmodule Plausible.Stats.Exploration do
   defp select_previous(query, :forward) do
     from(e in query,
       select_merge: %{
-        prev_pathname: lag(e.pathname) |> over(:session_window),
+        prev_pathname:
+          lag(fragment("if(? = 'pageview', ?, '')", e.name, e.pathname)) |> over(:session_window),
         prev_name: lag(e.name) |> over(:session_window)
       }
     )
@@ -470,8 +470,7 @@ defmodule Plausible.Stats.Exploration do
     from(e in query,
       select_merge: %{
         prev_pathname:
-          lead(e.pathname)
-          |> over(:session_window),
+          lead(fragment("if(? = 'pageview', ?, '')", e.name, e.pathname)) |> over(:session_window),
         prev_name: lead(e.name) |> over(:session_window)
       }
     )

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -142,17 +142,17 @@ defmodule Plausible.Stats.ExplorationTest do
 
         journey = [
           %Exploration.Journey.Step{name: "pageview", pathname: "/register"},
-          %Exploration.Journey.Step{name: "Signup", pathname: "/register"},
+          %Exploration.Journey.Step{name: "Signup"},
           %Exploration.Journey.Step{name: "pageview", pathname: "/activate"},
-          %Exploration.Journey.Step{name: "Create site", pathname: "/sites/new"}
+          %Exploration.Journey.Step{name: "Create site"}
         ]
 
         assert {:ok, [step1, step2, step3, step4]} = Exploration.journey_funnel(query, journey)
 
         assert step1.step.label == "/register"
-        assert step2.step.label == "Signup /register"
+        assert step2.step.label == "Signup"
         assert step3.step.label == "/activate"
-        assert step4.step.label == "Create site /sites/new"
+        assert step4.step.label == "Create site"
       end
 
       test "respects filters in the query", %{site: site} do
@@ -493,7 +493,7 @@ defmodule Plausible.Stats.ExplorationTest do
         assert next_step1.step.label == "/"
         assert next_step1.visitors == 2
 
-        assert next_step2.step.label == "Signup /register"
+        assert next_step2.step.label == "Signup"
         assert next_step2.visitors == 1
       end
 
@@ -528,11 +528,11 @@ defmodule Plausible.Stats.ExplorationTest do
         ]
 
         assert {:ok, [next_step]} =
-                 Exploration.next_steps(query, journey, search_term: "up /regi")
+                 Exploration.next_steps(query, journey, search_term: "up")
 
-        assert next_step.step.label == "Signup /register"
+        assert next_step.step.label == "Signup"
         assert next_step.step.name == "Signup"
-        assert next_step.step.pathname == "/register"
+        assert next_step.step.pathname == ""
         assert next_step.visitors == 1
       end
 


### PR DESCRIPTION
Instead of `Purchase /product` we'll present the step as `Purchase` only.