### PR TITLE
Add highlighted vertical line to graph (with tooltip sticky to the line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Add "Unknown" option to Countries shield, for when the country code is unrecognized
 - Add "Last 24 Hours" to dashboard time range picker and Stats API v2
 - Always compare against the same time range in comparisons with "Today"
+- Added vertical indicator line to graph to make it easier to see what's hovered / selected
 
 ### Removed
 
@@ -24,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - "Top referrers" and "Search terms" breakdowns are rendered side by side with other "Sources" tabs instead of replacing them
 - Improved top bar and top stats UI/styling
 - Moved graph interval picker, export button, imported data toggle and notices out of the graph and into a new options menu in the top bar
+- Changed graph tooltip positioning logic: it now aligns at the top of the chart to the right of the indicator line. Indicator line follows cursor, tooltip follows indicator line.
 
 ### Fixed
 

--- a/assets/js/dashboard/components/graph-tooltip.tsx
+++ b/assets/js/dashboard/components/graph-tooltip.tsx
@@ -23,12 +23,22 @@ export const GraphTooltipWrapper = ({
   transition?: TransitionClasses & TransitionEvents
 }) => {
   const ref = useRef<HTMLDivElement>(null)
-  const xOffsetFromCursor = 12
-  const yOffsetFromCursor = 24
+
+  const xOffset = 12
+
   const [measuredWidth, setMeasuredWidth] = useState(minWidth)
-  // clamp to prevent left/right overflow
-  const rawLeft = x + xOffsetFromCursor
-  const tooltipLeft = Math.max(0, Math.min(rawLeft, maxX - measuredWidth))
+
+  const leftIfAlignedToRight = x + xOffset
+  const leftIfAlignedToLeft = x - xOffset - measuredWidth
+
+  const canFitRight = leftIfAlignedToRight + measuredWidth <= maxX
+  const canFitLeft = leftIfAlignedToLeft >= 0
+  
+  const tooltipLeft = canFitRight
+    ? leftIfAlignedToRight
+    : canFitLeft
+      ? leftIfAlignedToLeft
+      : Math.max(0, Math.min(leftIfAlignedToRight, maxX - measuredWidth))
 
   useLayoutEffect(() => {
     if (!ref.current) {
@@ -46,7 +56,6 @@ export const GraphTooltipWrapper = ({
           minWidth,
           left: tooltipLeft,
           top: y,
-          transform: `translateY(-100%) translateY(-${yOffsetFromCursor}px)`
         }}
       >
         {children}

--- a/assets/js/dashboard/components/graph-tooltip.tsx
+++ b/assets/js/dashboard/components/graph-tooltip.tsx
@@ -28,23 +28,19 @@ export const GraphTooltipWrapper = ({
 
   const [measuredWidth, setMeasuredWidth] = useState(minWidth)
 
-  const leftIfAlignedToRight = x + xOffset
-  const leftIfAlignedToLeft = x - xOffset - measuredWidth
-  const leftIfCentered = Math.max(0, x - measuredWidth / 2)
+  const leftByAlignment = {
+    alignedRight: x + xOffset,
+    alignedLeft: x - xOffset - measuredWidth,
+    alignedRightClamped: Math.max(0, Math.min(x, maxX - measuredWidth))
+  }
 
-  const canFitRight = leftIfAlignedToRight + measuredWidth <= maxX
-  const canFitLeft = leftIfAlignedToLeft >= 0
+  const canFitRight = leftByAlignment.alignedRight + measuredWidth <= maxX
+  const canFitLeft = leftByAlignment.alignedLeft >= 0
   const position = canFitRight
-    ? 'right'
+    ? 'alignedRight'
     : canFitLeft
-      ? 'left'
-      : 'centered-over-top'
-
-  const tooltipLeft = {
-    right: leftIfAlignedToRight,
-    left: leftIfAlignedToLeft,
-    'centered-over-top': leftIfCentered
-  }[position]
+      ? 'alignedLeft'
+      : 'alignedRightClamped'
 
   useLayoutEffect(() => {
     if (!ref.current) {
@@ -60,10 +56,8 @@ export const GraphTooltipWrapper = ({
         className={className}
         style={{
           minWidth,
-          left: tooltipLeft,
-          top: y,
-          transform:
-            position === 'centered-over-top' ? 'translateY(-100%)' : undefined
+          left: leftByAlignment[position],
+          top: y
         }}
       >
         {children}

--- a/assets/js/dashboard/components/graph-tooltip.tsx
+++ b/assets/js/dashboard/components/graph-tooltip.tsx
@@ -30,15 +30,21 @@ export const GraphTooltipWrapper = ({
 
   const leftIfAlignedToRight = x + xOffset
   const leftIfAlignedToLeft = x - xOffset - measuredWidth
+  const leftIfCentered = Math.max(0, x - measuredWidth / 2)
 
   const canFitRight = leftIfAlignedToRight + measuredWidth <= maxX
   const canFitLeft = leftIfAlignedToLeft >= 0
-
-  const tooltipLeft = canFitRight
-    ? leftIfAlignedToRight
+  const position = canFitRight
+    ? 'right'
     : canFitLeft
-      ? leftIfAlignedToLeft
-      : Math.max(0, Math.min(leftIfAlignedToRight, maxX - measuredWidth))
+      ? 'left'
+      : 'centered-over-top'
+
+  const tooltipLeft = {
+    right: leftIfAlignedToRight,
+    left: leftIfAlignedToLeft,
+    'centered-over-top': leftIfCentered
+  }[position]
 
   useLayoutEffect(() => {
     if (!ref.current) {
@@ -55,7 +61,9 @@ export const GraphTooltipWrapper = ({
         style={{
           minWidth,
           left: tooltipLeft,
-          top: y
+          top: y,
+          transform:
+            position === 'centered-over-top' ? 'translateY(-100%)' : undefined
         }}
       >
         {children}

--- a/assets/js/dashboard/components/graph-tooltip.tsx
+++ b/assets/js/dashboard/components/graph-tooltip.tsx
@@ -33,7 +33,7 @@ export const GraphTooltipWrapper = ({
 
   const canFitRight = leftIfAlignedToRight + measuredWidth <= maxX
   const canFitLeft = leftIfAlignedToLeft >= 0
-  
+
   const tooltipLeft = canFitRight
     ? leftIfAlignedToRight
     : canFitLeft
@@ -55,7 +55,7 @@ export const GraphTooltipWrapper = ({
         style={{
           minWidth,
           left: tooltipLeft,
-          top: y,
+          top: y
         }}
       >
         {children}

--- a/assets/js/dashboard/components/graph.tsx
+++ b/assets/js/dashboard/components/graph.tsx
@@ -10,6 +10,8 @@ import classNames from 'classnames'
 
 const IDEAL_Y_TICK_COUNT = 5
 const MAX_X_TICK_COUNT = 8
+const X_TICK_LENGTH_PX = 4
+const HIGHLIGHT_LINE_VERTICAL_SPILL_PX = 4
 
 type GraphYValues = ReadonlyArray<number | null>
 
@@ -74,6 +76,8 @@ export function Graph<T extends GraphYValues>({
     </div>
   )
 }
+
+const highlightIndicatorGroupId = 'highlight-indicator'
 
 function InnerGraph<T extends GraphYValues>({
   className,
@@ -199,7 +203,7 @@ function InnerGraph<T extends GraphYValues>({
             d3
               .axisBottom(x)
               .tickValues(xTickValues)
-              .tickSize(4)
+              .tickSize(X_TICK_LENGTH_PX)
               .tickFormat(getXTickFormat(data))
           )
           .call((g) => g.select('.domain').remove())
@@ -226,6 +230,9 @@ function InnerGraph<T extends GraphYValues>({
       })
     }
 
+    // must be on top of gradients, but under lines and points
+    svg.append('g').attr('id', highlightIndicatorGroupId)
+
     const points: Point<T>[] = []
     for (const [seriesIndex, series] of settings.entries()) {
       if (series.underline) {
@@ -239,7 +246,9 @@ function InnerGraph<T extends GraphYValues>({
           y1Accessor: (d) => y(d.values[seriesIndex]!)
         })
       }
+    }
 
+    for (const [seriesIndex, series] of settings.entries()) {
       if (series.lines) {
         for (const line of series.lines) {
           drawLine({
@@ -275,7 +284,9 @@ function InnerGraph<T extends GraphYValues>({
         })
         points[i] = {
           ...point,
-          dots: [...point.dots, dotForSeries] as { [K in keyof T]: SelectedDot }
+          dots: [...point.dots, dotForSeries] as {
+            [K in keyof T]: SelectedGroup
+          }
         }
       }
     }
@@ -459,15 +470,45 @@ function InnerGraph<T extends GraphYValues>({
   }, [onClick, isInHoverableArea, data])
 
   useEffect(() => {
-    pointsRef.current?.forEach(({ dots }, index) =>
-      dots.forEach((g) =>
-        g.attr(
-          'data-active',
-          highlightedIndex !== null && index === highlightedIndex ? '' : null
+    if (pointsRef.current) {
+      const currentPoints = pointsRef.current
+      currentPoints.forEach(({ dots }, index) =>
+        dots.forEach((g) =>
+          g.attr(
+            'data-active',
+            highlightedIndex !== null && index === highlightedIndex ? '' : null
+          )
         )
       )
-    )
-  }, [highlightedIndex, data])
+
+      if (svgRef.current) {
+        const svg = d3.select(svgRef.current)
+        let line = svg.select<SVGLineElement>(
+          `#${highlightIndicatorGroupId} line`
+        )
+        const shouldShowLine = typeof highlightedIndex === 'number'
+        if (shouldShowLine) {
+          const { x } = currentPoints[highlightedIndex]
+          if (line.empty()) {
+            line = svg.select(`#${highlightIndicatorGroupId}`).append('line')
+          }
+          line
+            .attr('x1', 0)
+            .attr('x2', 0)
+            .attr('y1', marginTop - HIGHLIGHT_LINE_VERTICAL_SPILL_PX)
+            .attr(
+              'y2',
+              height - marginBottom + HIGHLIGHT_LINE_VERTICAL_SPILL_PX
+            )
+            .attr('class', currentlySelectedLineClass)
+            .attr('transform', `translate(${x}, 0)`)
+        }
+        if (!shouldShowLine && !line.empty()) {
+          line.remove()
+        }
+      }
+    }
+  }, [highlightedIndex, data, height, marginBottom, marginTop])
 
   return (
     <svg
@@ -478,6 +519,8 @@ function InnerGraph<T extends GraphYValues>({
   )
 }
 
+const currentlySelectedLineClass =
+  'stroke-1 stroke-gray-300 dark:stroke-gray-700' // maybe add 'transition-transform duration-75'
 const yTickLineClass =
   'stroke-gray-150 dark:stroke-gray-800/75 group-first:stroke-gray-300 dark:group-first:stroke-gray-700'
 const tickTextClass = 'fill-gray-500 dark:fill-gray-400 text-xs select-none'
@@ -777,7 +820,7 @@ function drawDot({
   series: SeriesConfig
   x: number
   y: number | null
-}): SelectedDot {
+}): SelectedGroup {
   const group = svg.append('g').attr('class', 'group')
   if (series.dot && y !== null) {
     group
@@ -834,7 +877,7 @@ type XPos = number
 type Point<T extends GraphYValues> = {
   x: XPos
   values: T
-  dots: { [K in keyof T]: SelectedDot }
+  dots: { [K in keyof T]: SelectedGroup }
 }
 
 export type SeriesConfig = {
@@ -857,4 +900,4 @@ export type PointerHandler<T extends GraphYValues> = (opts: {
 }) => void
 
 type SelectedSVG = d3.Selection<SVGSVGElement, unknown, null, undefined>
-type SelectedDot = d3.Selection<SVGGElement, unknown, null, undefined>
+type SelectedGroup = d3.Selection<SVGGElement, unknown, null, undefined>

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -101,6 +101,16 @@ export const MainGraph = ({
     setTooltip(initialTooltipState)
   }, [data])
 
+  useEffect(() => {
+    const onPointerCancel = (e: PointerEvent) => {
+      if (e.pointerType === 'touch') {
+        setTooltip(initialTooltipState)
+      }
+    }
+    window.addEventListener('pointercancel', onPointerCancel)
+    return () => window.removeEventListener('pointercancel', onPointerCancel)
+  }, [])
+
   const {
     remappedData,
     yMax,
@@ -251,7 +261,16 @@ export const MainGraph = ({
   const onPointerMove = useCallback<PointerHandler<MainGraphYValues>>(
     ({ inHoverableArea, closestPoint, event }) => {
       if (event instanceof PointerEvent && event.pointerType === 'touch') {
-        return setIsTouchDevice(true)
+        setIsTouchDevice(true)
+        if (tooltip.persistent && inHoverableArea && closestPoint) {
+          setTooltip({
+            selectedIndex: closestPoint.index,
+            x: closestPoint.x,
+            y: 0,
+            persistent: true
+          })
+        }
+        return
       }
       setIsTouchDevice(false)
       if (!inHoverableArea || !closestPoint) {
@@ -264,7 +283,7 @@ export const MainGraph = ({
         persistent: false
       })
     },
-    []
+    [tooltip.persistent]
   )
 
   const onGotPointerCapture = useCallback((event: unknown) => {
@@ -280,8 +299,11 @@ export const MainGraph = ({
   }, [])
 
   const onPointerLeave = useCallback(() => {
+    if (tooltip.persistent) {
+      return
+    }
     setTooltip(initialTooltipState)
-  }, [])
+  }, [tooltip.persistent])
 
   const showZoomToPeriod = canZoomToPeriod(
     interval,
@@ -334,7 +356,10 @@ export const MainGraph = ({
 
   return (
     <Graph<MainGraphYValues>
-      className={showZoomToPeriod && selectedDatum ? 'cursor-pointer' : ''}
+      className={classNames(
+        showZoomToPeriod && selectedDatum ? 'cursor-pointer' : '',
+        tooltip.persistent ? 'touch-pan-y' : ''
+      )}
       highlightedIndex={selectedIndex}
       width={width}
       height={height}

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from 'react'
 import { UIMode, useTheme } from '../../theme-context'
@@ -51,6 +52,7 @@ const marginRight = 4
 const marginBottom = 32
 const defaultMarginLeft = 16 // this is adjusted by the Graph component based on y-axis label width
 const hoverBuffer = 4
+const HORIZONTAL_PAN_DELAY_MS = 100
 
 type MainGraphData = MainGraphResponse & {
   period: DashboardPeriod
@@ -93,6 +95,7 @@ export const MainGraph = ({
   const [isTouchDevice, setIsTouchDevice] = useState<null | boolean>(null)
   const [tooltip, setTooltip] = useState<TooltipState>(initialTooltipState)
   const { selectedIndex } = tooltip
+  const panGestureStartTimeRef = useRef<number | null>(null)
   const metric = data.query.metrics[0] as Metric
   const interval = data.interval
   const period = data.period
@@ -104,11 +107,12 @@ export const MainGraph = ({
   useEffect(() => {
     const onPointerCancel = (e: PointerEvent) => {
       if (e.pointerType === 'touch') {
+        panGestureStartTimeRef.current = null
         setTooltip(initialTooltipState)
       }
     }
-    window.addEventListener('pointercancel', onPointerCancel)
-    return () => window.removeEventListener('pointercancel', onPointerCancel)
+    document.addEventListener('pointercancel', onPointerCancel)
+    return () => document.removeEventListener('pointercancel', onPointerCancel)
   }, [])
 
   const {
@@ -263,12 +267,21 @@ export const MainGraph = ({
       if (event instanceof PointerEvent && event.pointerType === 'touch') {
         setIsTouchDevice(true)
         if (tooltip.persistent && inHoverableArea && closestPoint) {
-          setTooltip({
-            selectedIndex: closestPoint.index,
-            x: closestPoint.x,
-            y: 0,
-            persistent: true
-          })
+          const now = Date.now()
+          // move the tooltip only when it is certain it's a y-pan
+          if (panGestureStartTimeRef.current === null) {
+            panGestureStartTimeRef.current = now
+          } else if (
+            now - panGestureStartTimeRef.current >=
+            HORIZONTAL_PAN_DELAY_MS
+          ) {
+            setTooltip({
+              selectedIndex: closestPoint.index,
+              x: closestPoint.x,
+              y: 0,
+              persistent: true
+            })
+          }
         }
         return
       }
@@ -299,6 +312,7 @@ export const MainGraph = ({
   }, [])
 
   const onPointerLeave = useCallback(() => {
+    panGestureStartTimeRef.current = null
     if (tooltip.persistent) {
       return
     }
@@ -454,17 +468,6 @@ const MainGraphTooltip = ({
         'absolute select-none bg-gray-800 dark:bg-gray-950 py-3 px-4 rounded-md shadow shadow-gray-200 dark:shadow-gray-850',
         typeof onClick !== 'function' && 'pointer-events-none'
       )}
-      transition={
-        persistent
-          ? {
-              // enter delay on mobile is needed to prevent the tooltip from entering when the user starts to y-pan
-              // but the y-pan is not yet certain
-              enter: 'transition-opacity duration-0 delay-150',
-              enterFrom: 'opacity-0',
-              enterTo: 'opacity-100'
-            }
-          : {}
-      }
     >
       <aside className="text-sm font-normal text-gray-100 flex flex-col gap-1.5">
         <div className="flex justify-between items-center rounded-sm">

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -70,13 +70,11 @@ type MainGraphYValues = Readonly<
 
 type TooltipState = {
   x: number
-  y: number
   selectedIndex: number | null
   persistent: boolean
 }
 const initialTooltipState: TooltipState = {
   x: 0,
-  y: 0,
   selectedIndex: null,
   persistent: false
 }
@@ -278,7 +276,6 @@ export const MainGraph = ({
             setTooltip({
               selectedIndex: closestPoint.index,
               x: closestPoint.x,
-              y: 0,
               persistent: true
             })
           }
@@ -292,7 +289,6 @@ export const MainGraph = ({
       return setTooltip({
         selectedIndex: closestPoint.index,
         x: closestPoint.x,
-        y: 0,
         persistent: false
       })
     },
@@ -355,7 +351,6 @@ export const MainGraph = ({
           return setTooltip({
             selectedIndex: closestPoint.index,
             x: closestPoint.x,
-            y: 0,
             persistent: true
           })
         }
@@ -404,7 +399,8 @@ export const MainGraph = ({
           interval={interval}
           metric={metric}
           x={tooltip.x}
-          y={tooltip.y}
+          // aligned to top of graph
+          y={0}
           datum={selectedDatum}
           bucketIndex={selectedIndex}
           totalBuckets={remappedData.length}

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -249,7 +249,7 @@ export const MainGraph = ({
   )
 
   const onPointerMove = useCallback<PointerHandler<MainGraphYValues>>(
-    ({ inHoverableArea, closestPoint, xPointer, yPointer, event }) => {
+    ({ inHoverableArea, closestPoint, event }) => {
       if (event instanceof PointerEvent && event.pointerType === 'touch') {
         return setIsTouchDevice(true)
       }
@@ -259,8 +259,8 @@ export const MainGraph = ({
       }
       return setTooltip({
         selectedIndex: closestPoint.index,
-        x: Math.floor(xPointer),
-        y: Math.floor(yPointer),
+        x: closestPoint.x,
+        y: 0,
         persistent: false
       })
     },

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -319,7 +319,7 @@ export const MainGraph = ({
           return setTooltip({
             selectedIndex: closestPoint.index,
             x: closestPoint.x,
-            y: Math.min(...closestPoint.values.filter((y) => y !== null)),
+            y: 0,
             persistent: true
           })
         }


### PR DESCRIPTION
### Changes

- Adds indicator line for selected x-value on graph.
- Makes tooltip anchor to the right* of the indicator line, aligned by top edge to top of graph.
  - (*) when it fits to the right. Otherwise to the left. If it fits neither right or left, it is clamped to the right edge of the graph.
- Touch device tooltip change:
On touch devices, a tap summons the tooltip at tapped x-value (_pre-existing logic_). When the tooltip has been summoned, dragging on the graph horizontally moves the tooltip (**new functionality in this PR**). Panning vertically dismisses the tooltip (_pre-existing logic_). Dragging horizontally without the tooltip being summoned has no effect (_pre-existing logic_). 

There's a pre-existing bug that clicks on menus don't dismiss the tooltip on mobile: this will be addressed separately.

### Tests
- [x] Manually tested on multiple browsers and devices

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] Tested in both dark and light mode