### PR TITLE
Show provisional visitors instantly after switching candidate

### DIFF
--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -889,13 +889,13 @@ export function FunnelExploration() {
               loading={isActive ? activeColumnLoading : false}
               selected={steps[i] || null}
               selectedVisitors={
-                funnel[i]?.visitors ??
                 provisionalFunnelEntries[i]?.visitors ??
+                funnel[i]?.visitors ??
                 null
               }
               selectedConversionRate={
-                funnel[i]?.conversion_rate ??
                 provisionalFunnelEntries[i]?.conversion_rate ??
+                funnel[i]?.conversion_rate ??
                 null
               }
               maxVisitors={funnel[0]?.visitors ?? null}


### PR DESCRIPTION
### Changes

When a new candidate is selected in an already occupied column, `funnel[i]` still holds the old funnel data (the new funnel hasn't loaded yet). So `funnel[i].visitors` is truthy and shadows the newly set `provisionalFunnelEntries[i].visitors`, causing the old visitor count to flash until the API response arrives.

This PR fixes it by making `provisionalFunnelEntries` take precedence over the stale funnel data.