### PR TITLE
Improve columnar display depending on journey state

### DIFF
--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -790,7 +790,15 @@ export function FunnelExploration() {
 
   const initialLoading =
     !inViewport || (steps.length === 0 && activeColumnLoading)
-  const numColumns = Math.max(steps.length + 1, initialLoading ? 1 : 3)
+  const journeyEnded =
+    !activeColumnLoading &&
+    activeColumnResults.length === 0 &&
+    steps.length >= 1
+  const numColumns = initialLoading
+    ? 1
+    : journeyEnded || (activeColumnLoading && steps.length === 1)
+      ? steps.length + 1
+      : Math.max(steps.length + 1, 3)
   const gridColumns = Math.max(numColumns, 3)
   const activeColumnIndex = steps.length
   const containerRef = useRef(null)
@@ -880,13 +888,6 @@ export function FunnelExploration() {
                 key={i}
                 colIndex={i}
                 header={columnHeader(i, direction)}
-                className={
-                  steps.length === 0 && i === 2
-                    ? 'sm:hidden'
-                    : steps.length === 0 && i === 1
-                      ? 'sm:[grid-column:span_2]'
-                      : undefined
-                }
                 active={isReachable}
                 // Active column gets live results; previously-active (now
                 // selected) columns get the candidate list that was visible at

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -418,7 +418,9 @@ function ExplorationColumn({
           ) : (
             <span className="flex flex-col items-center gap-2">
               <FlagIcon className="size-4.5" />
-              {"You've reached the end of this journey"}
+              {direction === EXPLORATION_DIRECTIONS.BACKWARD
+                ? "You've reached the beginning of this journey"
+                : "You've reached the end of this journey"}
             </span>
           )}
         </div>


### PR DESCRIPTION
We detect whether the journey has ended: when the active column has finished loading returning no results and at least one step is selected.

This helps to hide pointless column when journey ends - `numColumns` caps at `number of steps + 1` (instead of the fixed minimum of 3), so the empty next step column won't be rendered.

When there's only 1 step and active column is loading, `numColumns` is also capped similarily - to prevent 3rd column from flashing briefly while the API call is in flight, only to disappear if it turns out the journey has ended.

Column 3 remains visible while changing selection at column 2.


Additionally, when browsing the journey backwards, the "end" message signals reaching "beginning" of the journey.