### PR TITLE
Standardize all filter and segment modals styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - "Top referrers" and "Search terms" breakdowns are rendered side by side with other "Sources" tabs instead of replacing them
 - Improved top bar and top stats UI/styling
 - Moved graph interval picker, export button, imported data toggle and notices out of the graph and into a new options menu in the top bar
+- Standardised and improved segment and filter modals styling
 
 ### Fixed
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -51,6 +51,71 @@
   }
 }
 
+@layer components {
+  /*
+   * Button component classes shared between the React `Button` component
+   * (assets/js/dashboard/components/button.tsx) and the Phoenix `button`
+   * component (lib/plausible_web/components/generic.ex). Update here only.
+   */
+  .btn-base {
+    @apply whitespace-nowrap truncate inline-flex items-center justify-center
+      gap-x-2 text-sm font-medium rounded-md cursor-pointer
+      disabled:cursor-not-allowed;
+  }
+
+  .btn-sm {
+    @apply px-3 py-2;
+  }
+
+  .btn-md {
+    @apply px-3.5 py-2.5;
+  }
+
+  .btn-theme-primary {
+    @apply border border-indigo-600 bg-indigo-600 text-white
+      hover:bg-indigo-700 focus-visible:outline-indigo-600
+      disabled:border-transparent disabled:bg-indigo-400/60
+      disabled:dark:bg-indigo-600/30 disabled:dark:text-white/35;
+  }
+
+  .btn-theme-secondary {
+    @apply border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-700
+      text-gray-800 dark:text-gray-100 hover:bg-gray-50 hover:text-gray-900
+      dark:hover:bg-gray-600 dark:hover:border-gray-600 dark:hover:text-white
+      disabled:text-gray-700/40 dark:disabled:text-gray-500
+      dark:disabled:bg-gray-800 dark:disabled:border-gray-800;
+  }
+
+  .btn-theme-yellow {
+    @apply border border-yellow-600/90 bg-yellow-600/90 text-white
+      hover:bg-yellow-600 focus-visible:outline-yellow-600
+      disabled:border-yellow-400/60 disabled:bg-yellow-400/60
+      disabled:dark:border-yellow-600/30 disabled:dark:bg-yellow-600/30
+      disabled:dark:text-white/35;
+  }
+
+  .btn-theme-danger {
+    @apply border border-gray-300 dark:border-gray-800 text-red-600 bg-white
+      dark:bg-gray-800 hover:text-red-700 dark:hover:text-red-400
+      dark:text-red-500 active:text-red-800 disabled:text-red-700/40
+      disabled:hover:shadow-none dark:disabled:text-red-500/35
+      dark:disabled:bg-gray-800;
+  }
+
+  .btn-theme-ghost {
+    @apply border border-transparent text-gray-700 dark:text-gray-300
+      hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100
+      dark:hover:bg-gray-800 hover:border-gray-100 dark:hover:border-gray-800
+      disabled:text-gray-500 disabled:dark:text-gray-600
+      disabled:hover:bg-transparent disabled:hover:border-transparent;
+  }
+
+  .btn-theme-icon {
+    @apply border border-transparent text-gray-400 dark:text-gray-400
+      hover:text-gray-900 dark:hover:text-gray-100;
+  }
+}
+
 @theme {
   /* Color aliases from tailwind.config.js */
 

--- a/assets/js/dashboard/components/button.tsx
+++ b/assets/js/dashboard/components/button.tsx
@@ -3,7 +3,8 @@ import classNames from 'classnames'
 
 /**
  * Themes and sizes are kept in sync with the Phoenix `button` component in
- * `lib/plausible_web/components/generic.ex`. Update both together.
+ * `lib/plausible_web/components/generic.ex`. The actual Tailwind classes live
+ * in `assets/css/app.css` (.btn-base, .btn-{sm,md}, .btn-theme-*).
  */
 
 export type ButtonTheme =
@@ -16,26 +17,20 @@ export type ButtonTheme =
 
 export type ButtonSize = 'sm' | 'md'
 
-const buttonBaseClass =
-  'whitespace-nowrap truncate inline-flex items-center justify-center gap-x-2 text-sm font-medium rounded-md cursor-pointer disabled:cursor-not-allowed'
+const buttonBaseClass = 'btn-base'
 
 const buttonSizes: Record<ButtonSize, string> = {
-  sm: 'px-3 py-2',
-  md: 'px-3.5 py-2.5'
+  sm: 'btn-sm',
+  md: 'btn-md'
 }
 
 const buttonThemes: Record<ButtonTheme, string> = {
-  primary:
-    'border border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700 focus-visible:outline-indigo-600 disabled:border-transparent disabled:bg-indigo-400/60 disabled:dark:bg-indigo-600/30 disabled:dark:text-white/35',
-  secondary:
-    'border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-50 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:border-gray-600 dark:hover:text-white disabled:text-gray-700/40 dark:disabled:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:border-gray-800',
-  yellow:
-    'border border-yellow-600/90 bg-yellow-600/90 text-white hover:bg-yellow-600 focus-visible:outline-yellow-600 disabled:border-yellow-400/60 disabled:bg-yellow-400/60 disabled:dark:border-yellow-600/30 disabled:dark:bg-yellow-600/30 disabled:dark:text-white/35',
-  danger:
-    'border border-gray-300 dark:border-gray-800 text-red-600 bg-white dark:bg-gray-800 hover:text-red-700 dark:hover:text-red-400 dark:text-red-500 active:text-red-800 disabled:text-red-700/40 disabled:hover:shadow-none dark:disabled:text-red-500/35 dark:disabled:bg-gray-800',
-  ghost:
-    'border border-transparent text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-100 dark:hover:border-gray-800 disabled:text-gray-500 disabled:dark:text-gray-600 disabled:hover:bg-transparent disabled:hover:border-transparent',
-  icon: 'border border-transparent text-gray-400 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
+  primary: 'btn-theme-primary',
+  secondary: 'btn-theme-secondary',
+  yellow: 'btn-theme-yellow',
+  danger: 'btn-theme-danger',
+  ghost: 'btn-theme-ghost',
+  icon: 'btn-theme-icon'
 }
 
 export const buttonClassName = ({

--- a/assets/js/dashboard/components/button.tsx
+++ b/assets/js/dashboard/components/button.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import classNames from 'classnames'
+
+/**
+ * Themes and sizes are kept in sync with the Phoenix `button` component in
+ * `lib/plausible_web/components/generic.ex`. Update both together.
+ */
+
+export type ButtonTheme =
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'yellow'
+  | 'ghost'
+  | 'icon'
+
+export type ButtonSize = 'sm' | 'md'
+
+const buttonBaseClass =
+  'whitespace-nowrap truncate inline-flex items-center justify-center gap-x-2 text-sm font-medium rounded-md cursor-pointer disabled:cursor-not-allowed'
+
+const buttonSizes: Record<ButtonSize, string> = {
+  sm: 'px-3 py-2',
+  md: 'px-3.5 py-2.5'
+}
+
+const buttonThemes: Record<ButtonTheme, string> = {
+  primary:
+    'border border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700 focus-visible:outline-indigo-600 disabled:border-transparent disabled:bg-indigo-400/60 disabled:dark:bg-indigo-600/30 disabled:dark:text-white/35',
+  secondary:
+    'border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-50 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:border-gray-600 dark:hover:text-white disabled:text-gray-700/40 dark:disabled:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:border-gray-800',
+  yellow:
+    'border border-yellow-600/90 bg-yellow-600/90 text-white hover:bg-yellow-600 focus-visible:outline-yellow-600 disabled:border-yellow-400/60 disabled:bg-yellow-400/60 disabled:dark:border-yellow-600/30 disabled:dark:bg-yellow-600/30 disabled:dark:text-white/35',
+  danger:
+    'border border-gray-300 dark:border-gray-800 text-red-600 bg-white dark:bg-gray-800 hover:text-red-700 dark:hover:text-red-400 dark:text-red-500 active:text-red-800 disabled:text-red-700/40 disabled:hover:shadow-none dark:disabled:text-red-500/35 dark:disabled:bg-gray-800',
+  ghost:
+    'border border-transparent text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-100 dark:hover:border-gray-800 disabled:text-gray-500 disabled:dark:text-gray-600 disabled:hover:bg-transparent disabled:hover:border-transparent',
+  icon: 'border border-transparent text-gray-400 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
+}
+
+export const buttonClassName = ({
+  theme = 'primary',
+  size = 'md',
+  className
+}: {
+  theme?: ButtonTheme
+  size?: ButtonSize
+  className?: string
+} = {}): string =>
+  classNames(buttonBaseClass, buttonSizes[size], buttonThemes[theme], className)
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  theme?: ButtonTheme
+  size?: ButtonSize
+}
+
+export const Button = ({
+  theme = 'primary',
+  size = 'md',
+  type = 'button',
+  className,
+  ...rest
+}: ButtonProps) => (
+  <button
+    type={type}
+    className={buttonClassName({ theme, size, className })}
+    {...rest}
+  />
+)

--- a/assets/js/dashboard/components/modal-layout.tsx
+++ b/assets/js/dashboard/components/modal-layout.tsx
@@ -21,7 +21,7 @@ export function ModalLayout({
       allowScroll={allowScroll}
       onClose={onClose}
     >
-      <div className="flex flex-col gap-6 py-2">
+      <div className="flex flex-col gap-6 p-1 md:py-2 md:px-0">
         <div className="flex items-center justify-between gap-3">
           <h1 className="text-base font-bold leading-tight dark:text-gray-100">
             {title}

--- a/assets/js/dashboard/components/modal-layout.tsx
+++ b/assets/js/dashboard/components/modal-layout.tsx
@@ -1,0 +1,46 @@
+import React, { ReactNode } from 'react'
+import { XMarkIcon } from '@heroicons/react/20/solid'
+import ModalWithRouting from '../stats/modals/modal'
+
+export function ModalLayout({
+  title,
+  onClose,
+  children,
+  maxWidth = '460px',
+  allowScroll = true
+}: {
+  title: ReactNode
+  onClose: () => void
+  children: ReactNode
+  maxWidth?: string
+  allowScroll?: boolean
+}) {
+  return (
+    <ModalWithRouting
+      maxWidth={maxWidth}
+      allowScroll={allowScroll}
+      onClose={onClose}
+    >
+      <div className="flex flex-col gap-6 py-2">
+        <div className="flex items-center justify-between gap-3">
+          <h1 className="text-base font-bold leading-tight dark:text-gray-100">
+            {title}
+          </h1>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close modal"
+            className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+          >
+            <XMarkIcon className="size-4.5" />
+          </button>
+        </div>
+        {children}
+      </div>
+    </ModalWithRouting>
+  )
+}
+
+export function ModalFooter({ children }: { children: ReactNode }) {
+  return <div className="flex gap-x-3 items-center justify-end">{children}</div>
+}

--- a/assets/js/dashboard/components/remove-filter-button.tsx
+++ b/assets/js/dashboard/components/remove-filter-button.tsx
@@ -1,9 +1,0 @@
-/** @format */
-
-import classNames from 'classnames'
-
-export const removeFilterButtonClassname = classNames(
-  'flex items-center py-1',
-  'text-sm font-medium whitespace-nowrap',
-  'text-indigo-600 dark:text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-600'
-)

--- a/assets/js/dashboard/nav-menu/filter-pill.tsx
+++ b/assets/js/dashboard/nav-menu/filter-pill.tsx
@@ -37,7 +37,7 @@ export function FilterPill({
   return (
     <div
       className={classNames(
-        'flex h-8 shadow rounded-md bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm items-center',
+        'flex h-8 shadow-sm rounded-md bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm items-center',
         className
       )}
     >

--- a/assets/js/dashboard/segments/segment-authorship.tsx
+++ b/assets/js/dashboard/segments/segment-authorship.tsx
@@ -24,17 +24,20 @@ export function SegmentAuthorship({
   const showUpdatedAt = updated_at !== inserted_at
 
   return (
-    <div className={className}>
-      <div>
+    <span className={className}>
+      <span>
         {`Created at ${formatDayShort(dateForSite(inserted_at, site))}`}
         {!showUpdatedAt && !!authorLabel && ` by ${authorLabel}`}
-      </div>
+      </span>
       {showUpdatedAt && (
-        <div>
-          {`Last updated at ${formatDayShort(dateForSite(updated_at, site))}`}
-          {!!authorLabel && ` by ${authorLabel}`}
-        </div>
+        <>
+          {' • '}
+          <span>
+            {`Last updated at ${formatDayShort(dateForSite(updated_at, site))}`}
+            {!!authorLabel && ` by ${authorLabel}`}
+          </span>
+        </>
       )}
-    </div>
+    </span>
   )
 }

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -27,8 +27,6 @@ import { Role, UserContextValue, useUserContext } from '../user-context'
 import { useSiteContext } from '../site-context'
 import { Button, buttonClassName } from '../components/button'
 
-const inModalPillClassName = '!shadow-none !bg-gray-100 dark:!bg-gray-750'
-
 const inModalSectionLabelClassName = 'text-sm font-semibold dark:text-gray-100'
 
 interface ApiRequestProps {
@@ -246,7 +244,7 @@ const RelatedSharedLinks = ({ sharedLinks }: { sharedLinks: string[] }) => {
         className="flex-wrap"
         direction="horizontal"
         pills={sharedLinks.map((name) => ({
-          className: inModalPillClassName,
+          className: 'dark:!shadow-gray-950/60',
           plainText: name,
           children: name,
           interactive: false
@@ -502,7 +500,7 @@ const FiltersInSegment = ({
         className="flex-wrap"
         direction="horizontal"
         pills={segment_data.filters.map((filter) => ({
-          className: inModalPillClassName,
+          className: 'dark:!shadow-gray-950/60',
           plainText: plainFilterText({ labels: segment_data.labels }, filter),
           children: styledFilterText({ labels: segment_data.labels }, filter),
           interactive: false

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -27,7 +27,7 @@ import { Role, UserContextValue, useUserContext } from '../user-context'
 import { useSiteContext } from '../site-context'
 import { Button, buttonClassName } from '../components/button'
 
-const inModalPillClassName = '!shadow-none !bg-gray-100'
+const inModalPillClassName = '!shadow-none !bg-gray-100 dark:!bg-gray-750'
 
 const inModalSectionLabelClassName = 'text-sm font-semibold dark:text-gray-100'
 

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useState } from 'react'
-import ModalWithRouting from '../stats/modals/modal'
+import { ModalLayout, ModalFooter } from '../components/modal-layout'
 import {
   canRemoveFilter,
   getSearchToRemoveSegmentFilter,
@@ -24,8 +24,12 @@ import { ApiError, get } from '../api'
 import { ErrorPanel } from '../components/error-panel'
 import { useSegmentsContext } from '../filtering/segments-context'
 import { Role, UserContextValue, useUserContext } from '../user-context'
-import { removeFilterButtonClassname } from '../components/remove-filter-button'
 import { useSiteContext } from '../site-context'
+import { Button, buttonClassName } from '../components/button'
+
+const inModalPillClassName = '!shadow-none !bg-gray-100'
+
+const inModalSectionLabelClassName = 'text-sm font-semibold dark:text-gray-100'
 
 interface ApiRequestProps {
   status: MutationStatus
@@ -38,37 +42,6 @@ interface SegmentModalProps {
   siteSegmentsAvailable: boolean
   onClose: () => void
   namePlaceholder: string
-}
-
-const primaryNeutralButtonClassName = 'button !px-3'
-
-const primaryNegativeButtonClassName = classNames(
-  'button !px-3.5',
-  'items-center !bg-red-500 dark:!bg-red-500 hover:!bg-red-600 dark:hover:!bg-red-700 whitespace-nowrap',
-  'disabled:!bg-red-400 disabled:cursor-not-allowed'
-)
-
-const secondaryButtonClassName = classNames(
-  'button !px-3.5',
-  'border !border-gray-300 dark:!border-gray-700 !bg-white dark:!bg-gray-700 !text-gray-800 dark:!text-gray-100 hover:!text-gray-900 hover:!shadow-sm dark:hover:!bg-gray-600 dark:hover:!text-white'
-)
-
-const SegmentActionModal = ({
-  children,
-  onClose
-}: {
-  children: ReactNode
-  onClose: () => void
-}) => {
-  return (
-    <ModalWithRouting
-      maxWidth="460px"
-      className="p-6 min-h-fit"
-      onClose={onClose}
-    >
-      <div className="mb-8 dark:text-gray-100">{children}</div>
-    </ModalWithRouting>
-  )
 }
 
 export const CreateSegmentModal = ({
@@ -107,8 +80,7 @@ export const CreateSegmentModal = ({
     })
 
   return (
-    <SegmentActionModal onClose={onClose}>
-      <FormTitle className="mb-8">Create segment</FormTitle>
+    <ModalLayout title="Create segment" onClose={onClose}>
       <SegmentNameInput
         value={name}
         onChange={setName}
@@ -116,7 +88,10 @@ export const CreateSegmentModal = ({
       />
       <SegmentTypeSelector value={type} onChange={onSegmentTypeChange} />
       {disabled && <SegmentTypeDisabledMessage message={disabledMessage} />}
-      <ButtonsRow>
+      <ModalFooter>
+        <Button theme="secondary" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
         <SaveSegmentButton
           disabled={status === 'pending' || disabled}
           onSave={() => {
@@ -127,10 +102,7 @@ export const CreateSegmentModal = ({
             onSave({ name: saveableName, type })
           }}
         />
-        <button className={secondaryButtonClassName} onClick={onClose}>
-          Cancel
-        </button>
-      </ButtonsRow>
+      </ModalFooter>
       {error !== null && (
         <ErrorPanel
           className="mt-4"
@@ -142,7 +114,7 @@ export const CreateSegmentModal = ({
           onClose={reset}
         />
       )}
-    </SegmentActionModal>
+    </ModalLayout>
   )
 }
 
@@ -183,55 +155,62 @@ export const DeleteSegmentModal = ({
     (!!linksQuery.data?.length && !confirmed)
 
   return (
-    <SegmentActionModal onClose={onClose}>
-      <FormTitle className="mb-4">
-        Delete {SEGMENT_TYPE_LABELS[segment.type].toLowerCase()}
-        <span className="break-all">{` "${segment.name}"?`}</span>
-      </FormTitle>
-      {linksQuery.status === 'pending' && (
-        <div className="loading sm">
-          <div />
-        </div>
-      )}
-      {linksQuery.status === 'success' && !!linksQuery.data?.length && (
-        <ErrorPanel
-          errorMessage={
-            <span className="break-normal">
-              {getLinksDeleteNotice(linksQuery.data)}
-            </span>
-          }
-        />
-      )}
-      {linksQuery.status === 'error' && (
-        <ErrorPanel
-          errorMessage="Error loading related shared links"
-          onRetry={linksQuery.refetch}
-        />
-      )}
+    <ModalLayout
+      title={`Delete ${SEGMENT_TYPE_LABELS[segment.type].toLowerCase()}`}
+      onClose={onClose}
+    >
+      <div className="flex flex-col gap-y-2">
+        <p className="text-sm dark:text-gray-100">
+          {`You're about to delete `}
+          <span className="break-all font-semibold">{`"${segment.name}"`}</span>
+          {`. Are you sure?`}
+        </p>
+        {linksQuery.status === 'pending' && (
+          <div className="loading sm">
+            <div />
+          </div>
+        )}
+        {linksQuery.status === 'success' && !!linksQuery.data?.length && (
+          <ErrorPanel
+            errorMessage={
+              <span className="break-normal">
+                {getLinksDeleteNotice(linksQuery.data)}
+              </span>
+            }
+          />
+        )}
+        {linksQuery.status === 'error' && (
+          <ErrorPanel
+            errorMessage="Error loading related shared links"
+            onRetry={linksQuery.refetch}
+          />
+        )}
+      </div>
       {!!segment.segment_data && (
-        <div className="mt-4">
-          <FiltersInSegment segment_data={segment.segment_data} />
-        </div>
+        <FiltersInSegment
+          segment_data={segment.segment_data}
+          className={linksQuery.data?.length ? undefined : 'mb-4'}
+        />
       )}
       {!!linksQuery.data?.length && (
         <>
-          <div className="mt-4">
-            <RelatedSharedLinks sharedLinks={linksQuery.data} />
-          </div>
-          <div className="mt-4">
-            <Checkbox
-              id="confirm"
-              checked={confirmed}
-              onChange={(e) => setConfirmed(e.currentTarget.checked)}
-            >
-              Yes, delete the associated shared links
-            </Checkbox>
-          </div>
+          <RelatedSharedLinks sharedLinks={linksQuery.data} />
+          <Checkbox
+            id="confirm"
+            checked={confirmed}
+            onChange={(e) => setConfirmed(e.currentTarget.checked)}
+          >
+            Yes, delete the associated shared links
+          </Checkbox>
         </>
       )}
-      <ButtonsRow>
-        <button
-          className={primaryNegativeButtonClassName}
+      <ModalFooter>
+        <Button theme="secondary" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          theme="danger"
+          size="sm"
           disabled={deleteDisabled}
           onClick={
             deleteDisabled
@@ -242,11 +221,8 @@ export const DeleteSegmentModal = ({
           }
         >
           Delete
-        </button>
-        <button className={secondaryButtonClassName} onClick={onClose}>
-          Cancel
-        </button>
-      </ButtonsRow>
+        </Button>
+      </ModalFooter>
       {error !== null && (
         <ErrorPanel
           className="mt-4"
@@ -258,58 +234,27 @@ export const DeleteSegmentModal = ({
           onClose={reset}
         />
       )}
-    </SegmentActionModal>
+    </ModalLayout>
   )
 }
 
 const RelatedSharedLinks = ({ sharedLinks }: { sharedLinks: string[] }) => {
   return (
-    <>
-      <SecondaryTitle>Shared links</SecondaryTitle>
-      <div className="mt-2">
-        <FilterPillsList
-          className="flex-wrap"
-          direction="horizontal"
-          pills={sharedLinks.map((name) => ({
-            className: 'dark:!shadow-gray-950/60',
-            plainText: name,
-            children: name,
-            interactive: false
-          }))}
-        />
-      </div>
-    </>
+    <div className="flex flex-col gap-y-2">
+      <p className={inModalSectionLabelClassName}>Shared links</p>
+      <FilterPillsList
+        className="flex-wrap"
+        direction="horizontal"
+        pills={sharedLinks.map((name) => ({
+          className: inModalPillClassName,
+          plainText: name,
+          children: name,
+          interactive: false
+        }))}
+      />
+    </div>
   )
 }
-
-const FormTitle = ({
-  className,
-  children
-}: {
-  className?: string
-  children?: ReactNode
-}) => (
-  <h1
-    className={classNames(
-      'text-lg font-medium text-gray-900 dark:text-gray-100 leading-7',
-      className
-    )}
-  >
-    {children}
-  </h1>
-)
-
-const ButtonsRow = ({
-  className,
-  children
-}: {
-  className?: string
-  children?: ReactNode
-}) => (
-  <div className={classNames('mt-8 flex gap-x-3 items-center', className)}>
-    {children}
-  </div>
-)
 
 const SegmentNameInput = ({
   namePlaceholder,
@@ -321,7 +266,7 @@ const SegmentNameInput = ({
   onChange: (value: string) => void
 }) => {
   return (
-    <>
+    <div className="flex flex-col">
       <label
         htmlFor="name"
         className="block mb-1.5 text-sm font-medium dark:text-gray-100 text-gray-700 dark:text-gray-300"
@@ -336,7 +281,7 @@ const SegmentNameInput = ({
         id="name"
         className="block px-3.5 py-2.5 w-full text-sm dark:text-gray-300 rounded-md border border-gray-300 dark:border-gray-750 dark:bg-gray-750 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
       />
-    </>
+    </div>
   )
 }
 
@@ -361,7 +306,7 @@ const SegmentTypeSelector = ({
   ]
 
   return (
-    <div className="mt-6 flex flex-col gap-y-4">
+    <div className="flex flex-col gap-y-2">
       {options.map(({ type, name, description }) => (
         <div key={type}>
           <div className="flex">
@@ -378,7 +323,7 @@ const SegmentTypeSelector = ({
               className="block ml-3 text-sm font-medium dark:text-gray-100 flex flex-col flex-inline"
             >
               <div>{name}</div>
-              <div className="text-gray-500 dark:text-gray-400 mb-2 text-sm">
+              <div className="text-gray-500 dark:text-gray-400 text-sm font-normal">
                 {description}
               </div>
             </label>
@@ -454,14 +399,13 @@ const SaveSegmentButton = ({
   onSave: () => void
 }) => {
   return (
-    <button
-      className={primaryNeutralButtonClassName}
-      type="button"
+    <Button
+      size="sm"
       disabled={disabled}
       onClick={disabled ? () => {} : onSave}
     >
       Save
-    </button>
+    </Button>
   )
 }
 
@@ -506,8 +450,7 @@ export const UpdateSegmentModal = ({
     })
 
   return (
-    <SegmentActionModal onClose={onClose}>
-      <FormTitle className="mb-8">Update segment</FormTitle>
+    <ModalLayout title="Update segment" onClose={onClose}>
       <SegmentNameInput
         value={name}
         onChange={setName}
@@ -515,7 +458,10 @@ export const UpdateSegmentModal = ({
       />
       <SegmentTypeSelector value={type} onChange={onSegmentTypeChange} />
       {disabled && <SegmentTypeDisabledMessage message={disabledMessage} />}
-      <ButtonsRow>
+      <ModalFooter>
+        <Button theme="secondary" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
         <SaveSegmentButton
           disabled={status === 'pending' || disabled}
           onSave={() => {
@@ -526,10 +472,7 @@ export const UpdateSegmentModal = ({
             onSave({ id: segment.id, name: saveableName, type })
           }}
         />
-        <button className={secondaryButtonClassName} onClick={onClose}>
-          Cancel
-        </button>
-      </ButtonsRow>
+      </ModalFooter>
       {error !== null && (
         <ErrorPanel
           className="mt-4"
@@ -541,33 +484,33 @@ export const UpdateSegmentModal = ({
           onClose={reset}
         />
       )}
-    </SegmentActionModal>
+    </ModalLayout>
   )
 }
 
-const FiltersInSegment = ({ segment_data }: { segment_data: SegmentData }) => {
+const FiltersInSegment = ({
+  segment_data,
+  className
+}: {
+  segment_data: SegmentData
+  className?: string
+}) => {
   return (
-    <>
-      <SecondaryTitle>Filters in segment</SecondaryTitle>
-      <div className="mt-2">
-        <FilterPillsList
-          className="flex-wrap"
-          direction="horizontal"
-          pills={segment_data.filters.map((filter) => ({
-            className: 'dark:!shadow-gray-950/60',
-            plainText: plainFilterText({ labels: segment_data.labels }, filter),
-            children: styledFilterText({ labels: segment_data.labels }, filter),
-            interactive: false
-          }))}
-        />
-      </div>
-    </>
+    <div className={classNames('flex flex-col gap-y-2', className)}>
+      <p className={inModalSectionLabelClassName}>Filters in segment</p>
+      <FilterPillsList
+        className="flex-wrap"
+        direction="horizontal"
+        pills={segment_data.filters.map((filter) => ({
+          className: inModalPillClassName,
+          plainText: plainFilterText({ labels: segment_data.labels }, filter),
+          children: styledFilterText({ labels: segment_data.labels }, filter),
+          interactive: false
+        }))}
+      />
+    </div>
   )
 }
-
-const SecondaryTitle = ({ children }: { children: ReactNode }) => (
-  <h2 className="font-bold dark:text-gray-100">{children}</h2>
-)
 
 /** Keep this component styled the same as checkboxes in PlausibleWeb.Live.Installation.Instructions */
 const Checkbox = ({
@@ -642,66 +585,74 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
     limitedToSegment
   )
 
+  const onClose = () => navigate({ path: rootRoute.path, search: (s) => s })
+
   return (
-    <ModalWithRouting maxWidth="460px">
-      <div className="dark:text-gray-100 mb-8">
-        <div className="flex justify-between items-center">
-          <div className="flex items-center gap-x-2">
-            <h1 className="text-xl font-bold break-all">
-              {data ? data.name : 'Segment details'}
-            </h1>
+    <ModalLayout title="Segment details" onClose={onClose}>
+      <div className="flex flex-col gap-y-6 dark:text-gray-100">
+        <div className="text-sm flex flex-col gap-y-0.5">
+          <h2 className="font-semibold break-all">
+            <Placeholder placeholder="Segment name">
+              {data?.name ?? false}
+            </Placeholder>
+          </h2>
+          <div className="text-gray-500 dark:text-gray-400">
+            <Placeholder placeholder="Segment type">
+              {data?.segment_data ? SEGMENT_TYPE_LABELS[data.type] : false}
+            </Placeholder>
+            {!!data?.segment_data && (
+              <>
+                {' • '}
+                <SegmentAuthorship
+                  segment={data}
+                  showOnlyPublicData={
+                    !user.loggedIn || user.role === Role.public
+                  }
+                />
+              </>
+            )}
           </div>
         </div>
-
-        <div className="mt-2 text-sm/5">
-          <Placeholder placeholder={'Segment type'}>
-            {data?.segment_data ? SEGMENT_TYPE_LABELS[data.type] : false}
-          </Placeholder>
-        </div>
-        <div className="my-4 border-b border-gray-300 dark:border-gray-700" />
         {!!data?.segment_data && (
           <>
-            <FiltersInSegment segment_data={data.segment_data} />
-
-            <SegmentAuthorship
-              segment={data}
-              showOnlyPublicData={!user.loggedIn || user.role === Role.public}
-              className="mt-4 text-sm"
+            <FiltersInSegment
+              segment_data={data.segment_data}
+              className="mb-4"
             />
-            <div className="mt-4">
-              <ButtonsRow>
-                {canExpandSegment({ segment: data, user }) && (
-                  <AppNavigationLink
-                    className={primaryNeutralButtonClassName}
-                    path={rootRoute.path}
-                    search={(s) => ({
-                      ...s,
-                      filters: data.segment_data.filters,
-                      labels: data.segment_data.labels
-                    })}
-                    state={{
-                      expandedSegment: data
-                    }}
-                  >
-                    Edit segment
-                  </AppNavigationLink>
-                )}
 
-                {showClearButton && (
-                  <button
-                    className={removeFilterButtonClassname}
-                    onClick={() =>
-                      navigate({
-                        path: rootRoute.path,
-                        search: getSearchToRemoveSegmentFilter()
-                      })
-                    }
-                  >
-                    Remove filter
-                  </button>
-                )}
-              </ButtonsRow>
-            </div>
+            <ModalFooter>
+              {showClearButton && (
+                <Button
+                  theme="secondary"
+                  size="sm"
+                  onClick={() =>
+                    navigate({
+                      path: rootRoute.path,
+                      search: getSearchToRemoveSegmentFilter()
+                    })
+                  }
+                >
+                  Remove filter
+                </Button>
+              )}
+
+              {canExpandSegment({ segment: data, user }) && (
+                <AppNavigationLink
+                  className={buttonClassName({ size: 'sm' })}
+                  path={rootRoute.path}
+                  search={(s) => ({
+                    ...s,
+                    filters: data.segment_data.filters,
+                    labels: data.segment_data.labels
+                  })}
+                  state={{
+                    expandedSegment: data
+                  }}
+                >
+                  Edit segment
+                </AppNavigationLink>
+              )}
+            </ModalFooter>
           </>
         )}
         {error !== null && (
@@ -716,6 +667,6 @@ export const SegmentModal = ({ id }: { id: SavedSegment['id'] }) => {
           />
         )}
       </div>
-    </ModalWithRouting>
+    </ModalLayout>
   )
 }

--- a/assets/js/dashboard/stats/modals/breakdown-table.tsx
+++ b/assets/js/dashboard/stats/modals/breakdown-table.tsx
@@ -44,7 +44,7 @@ export const BreakdownTable = <TListItem extends { name: string }>({
     onClose ?? (() => navigate({ path: rootRoute.path, search: (s) => s }))
 
   return (
-    <>
+    <div className="min-h-[66vh] md:min-h-120 flex flex-col flex-1">
       <div className="flex justify-between items-center gap-4">
         <div className="flex items-center gap-4 w-full">
           <h1 className="shrink-0 mb-0.5 text-base md:text-lg font-bold dark:text-gray-100">
@@ -84,7 +84,7 @@ export const BreakdownTable = <TListItem extends { name: string }>({
           />
         )}
       </div>
-    </>
+    </div>
   )
 }
 

--- a/assets/js/dashboard/stats/modals/filter-modal-group.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-group.js
@@ -37,9 +37,9 @@ export default function FilterModalGroup({
 
   return (
     <>
-      <div className="mt-6">
+      <div>
         {showTitle && (
-          <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          <div className="text-sm font-medium">
             {formattedFilters[filterGroup]}
           </div>
         )}

--- a/assets/js/dashboard/stats/modals/filter-modal-group.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-group.js
@@ -39,7 +39,7 @@ export default function FilterModalGroup({
     <>
       <div>
         {showTitle && (
-          <div className="text-sm font-medium">
+          <div className="text-sm font-medium text-gray-800 dark:text-gray-200">
             {formattedFilters[filterGroup]}
           </div>
         )}

--- a/assets/js/dashboard/stats/modals/filter-modal.js
+++ b/assets/js/dashboard/stats/modals/filter-modal.js
@@ -1,8 +1,7 @@
 import React from 'react'
-import { XMarkIcon } from '@heroicons/react/20/solid'
 import { useParams } from 'react-router-dom'
 
-import Modal from './modal'
+import { ModalLayout, ModalFooter } from '../../components/modal-layout'
 import {
   EVENT_PROPS_PREFIX,
   FILTER_GROUP_TO_MODAL_TYPE,
@@ -21,7 +20,7 @@ import { rootRoute } from '../../router'
 import { useAppNavigate } from '../../navigation/use-app-navigate'
 import { SegmentModal } from '../../segments/segment-modals'
 import { findAppliedSegmentFilter } from '../../filtering/segments'
-import { removeFilterButtonClassname } from '../../components/remove-filter-button'
+import { Button } from '../../components/button'
 
 function partitionFilters(modalType, filters) {
   const otherFilters = []
@@ -178,27 +177,15 @@ class FilterModal extends React.Component {
 
   render() {
     return (
-      <Modal maxWidth="460px" allowScroll={true} onClose={this.closeModal}>
-        <div className="flex items-center justify-between gap-3">
-          <h1 className="text-base md:text-lg font-bold dark:text-gray-100">
-            Filter by {formatFilterGroup(this.props.modalType)}
-          </h1>
-          <button
-            type="button"
-            onClick={this.closeModal}
-            aria-label="Close modal"
-            className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-          >
-            <XMarkIcon className="size-5" />
-          </button>
-        </div>
-
-        <div className="mt-2 md:mt-4 border-b border-gray-300 dark:border-gray-700"></div>
-        <main>
-          <form
-            className="flex flex-col"
-            onSubmit={this.handleSubmit.bind(this)}
-          >
+      <ModalLayout
+        title={`Filter by ${formatFilterGroup(this.props.modalType)}`}
+        onClose={this.closeModal}
+      >
+        <form
+          className="flex flex-col gap-y-6"
+          onSubmit={this.handleSubmit.bind(this)}
+        >
+          <div className="flex flex-col gap-y-3 mb-2">
             {this.getFilterGroups().map((filterGroup) => (
               <FilterModalGroup
                 key={filterGroup}
@@ -210,33 +197,38 @@ class FilterModal extends React.Component {
                 onDeleteRow={this.onDeleteRow.bind(this)}
               />
             ))}
+          </div>
 
-            <div className="mt-6 mb-3 flex gap-x-4 items-center justify-start">
-              <button
-                type="submit"
-                className="button !px-3"
-                disabled={this.isDisabled()}
+          <ModalFooter>
+            {this.state.hasRelevantFilters ? (
+              <Button
+                theme="secondary"
+                size="sm"
+                onClick={() => {
+                  this.selectFiltersAndCloseModal(this.state.otherFilters)
+                }}
               >
-                Apply filter
-              </button>
+                {FILTER_MODAL_TO_FILTER_GROUP[this.props.modalType].length > 1
+                  ? 'Remove filters'
+                  : 'Remove filter'}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                theme="secondary"
+                size="sm"
+                onClick={this.closeModal}
+              >
+                Cancel
+              </Button>
+            )}
 
-              {this.state.hasRelevantFilters && (
-                <button
-                  type="button"
-                  className={removeFilterButtonClassname}
-                  onClick={() => {
-                    this.selectFiltersAndCloseModal(this.state.otherFilters)
-                  }}
-                >
-                  {FILTER_MODAL_TO_FILTER_GROUP[this.props.modalType].length > 1
-                    ? 'Remove filters'
-                    : 'Remove filter'}
-                </button>
-              )}
-            </div>
-          </form>
-        </main>
-      </Modal>
+            <Button type="submit" size="sm" disabled={this.isDisabled()}>
+              Apply filter
+            </Button>
+          </ModalFooter>
+        </form>
+      </ModalLayout>
     )
   }
 }

--- a/assets/js/dashboard/stats/modals/modal.js
+++ b/assets/js/dashboard/stats/modals/modal.js
@@ -77,7 +77,7 @@ class Modal extends React.Component {
             <div className="[--gap:1rem] sm:[--gap:2rem] md:[--gap:3.2rem] flex h-full w-full items-center md:items-start justify-center p-[var(--gap)] box-border">
               <div
                 ref={this.node}
-                className={`max-h-[calc(100dvh_-_var(--gap)*2)] min-h-[66vh] md:min-h-120 w-full flex flex-col bg-white p-3 md:px-6 md:py-4 ${this.getOverflowClass()} box-border transition-[height] duration-200 ease-in shadow-2xl rounded-lg dark:bg-gray-900 focus:outline-hidden`}
+                className={`max-h-[calc(100dvh_-_var(--gap)*2)] w-full flex flex-col bg-white p-3 md:px-6 md:py-4 ${this.getOverflowClass()} box-border transition-[height] duration-200 ease-in shadow-2xl rounded-lg dark:bg-gray-900 focus:outline-hidden`}
                 style={this.getStyle()}
                 // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
                 tabIndex={0}

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -33,26 +33,23 @@ defmodule PlausibleWeb.Components.Generic do
     }
   }
 
+  # Themes/sizes/base are defined as component classes in
+  # assets/css/app.css and mirrored by the React `Button` component in
+  # assets/js/dashboard/components/button.tsx. Update there only.
   @button_themes %{
-    "primary" =>
-      "border border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700 focus-visible:outline-indigo-600 disabled:border-transparent disabled:bg-indigo-400/60 disabled:dark:bg-indigo-600/30 disabled:dark:text-white/35",
-    "secondary" =>
-      "border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-50 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:border-gray-600 dark:hover:text-white disabled:text-gray-700/40 dark:disabled:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:border-gray-800",
-    "yellow" =>
-      "border border-yellow-600/90 bg-yellow-600/90 text-white hover:bg-yellow-600 focus-visible:outline-yellow-600 disabled:border-yellow-400/60 disabled:bg-yellow-400/60 disabled:dark:border-yellow-600/30 disabled:dark:bg-yellow-600/30 disabled:dark:text-white/35",
-    "danger" =>
-      "border border-gray-300 dark:border-gray-800 text-red-600 bg-white dark:bg-gray-800 hover:text-red-700 dark:hover:text-red-400 dark:text-red-500 active:text-red-800 disabled:text-red-700/40 disabled:hover:shadow-none dark:disabled:text-red-500/35 dark:disabled:bg-gray-800",
-    "ghost" =>
-      "border border-transparent text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-100 dark:hover:border-gray-800 disabled:text-gray-500 disabled:dark:text-gray-600 disabled:hover:bg-transparent disabled:hover:border-transparent",
-    "icon" =>
-      "border border-transparent text-gray-400 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+    "primary" => "btn-theme-primary",
+    "secondary" => "btn-theme-secondary",
+    "yellow" => "btn-theme-yellow",
+    "danger" => "btn-theme-danger",
+    "ghost" => "btn-theme-ghost",
+    "icon" => "btn-theme-icon"
   }
 
-  @button_base_class "whitespace-nowrap truncate inline-flex items-center justify-center gap-x-2 text-sm font-medium rounded-md cursor-pointer disabled:cursor-not-allowed"
+  @button_base_class "btn-base"
 
   @button_sizes %{
-    "sm" => "px-3 py-2",
-    "md" => "px-3.5 py-2.5"
+    "sm" => "btn-sm",
+    "md" => "btn-md"
   }
 
   attr(:type, :string, default: "button")

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -35,16 +35,16 @@ defmodule PlausibleWeb.Components.Generic do
 
   @button_themes %{
     "primary" =>
-      "border border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700 focus-visible:outline-indigo-600 disabled:bg-indigo-400/60 disabled:dark:bg-indigo-600/30 disabled:dark:text-white/35",
+      "border border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700 focus-visible:outline-indigo-600 disabled:border-transparent disabled:bg-indigo-400/60 disabled:dark:bg-indigo-600/30 disabled:dark:text-white/35",
     "secondary" =>
       "border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:bg-gray-50 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:border-gray-600 dark:hover:text-white disabled:text-gray-700/40 dark:disabled:text-gray-500 dark:disabled:bg-gray-800 dark:disabled:border-gray-800",
     "yellow" =>
-      "bg-yellow-600/90 text-white hover:bg-yellow-600 focus-visible:outline-yellow-600 disabled:bg-yellow-400/60 disabled:dark:bg-yellow-600/30 disabled:dark:text-white/35",
+      "border border-yellow-600/90 bg-yellow-600/90 text-white hover:bg-yellow-600 focus-visible:outline-yellow-600 disabled:border-yellow-400/60 disabled:bg-yellow-400/60 disabled:dark:border-yellow-600/30 disabled:dark:bg-yellow-600/30 disabled:dark:text-white/35",
     "danger" =>
       "border border-gray-300 dark:border-gray-800 text-red-600 bg-white dark:bg-gray-800 hover:text-red-700 dark:hover:text-red-400 dark:text-red-500 active:text-red-800 disabled:text-red-700/40 disabled:hover:shadow-none dark:disabled:text-red-500/35 dark:disabled:bg-gray-800",
     "ghost" =>
-      "text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:text-gray-500 disabled:dark:text-gray-600 disabled:hover:bg-transparent",
-    "icon" => "text-gray-400 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+      "border border-transparent text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-100 dark:hover:border-gray-800 disabled:text-gray-500 disabled:dark:text-gray-600 disabled:hover:bg-transparent disabled:hover:border-transparent",
+    "icon" => "border border-transparent text-gray-400 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
   }
 
   @button_base_class "whitespace-nowrap truncate inline-flex items-center justify-center gap-x-2 text-sm font-medium rounded-md cursor-pointer disabled:cursor-not-allowed"

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -44,7 +44,8 @@ defmodule PlausibleWeb.Components.Generic do
       "border border-gray-300 dark:border-gray-800 text-red-600 bg-white dark:bg-gray-800 hover:text-red-700 dark:hover:text-red-400 dark:text-red-500 active:text-red-800 disabled:text-red-700/40 disabled:hover:shadow-none dark:disabled:text-red-500/35 dark:disabled:bg-gray-800",
     "ghost" =>
       "border border-transparent text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 hover:border-gray-100 dark:hover:border-gray-800 disabled:text-gray-500 disabled:dark:text-gray-600 disabled:hover:bg-transparent disabled:hover:border-transparent",
-    "icon" => "border border-transparent text-gray-400 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+    "icon" =>
+      "border border-transparent text-gray-400 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
   }
 
   @button_base_class "whitespace-nowrap truncate inline-flex items-center justify-center gap-x-2 text-sm font-medium rounded-md cursor-pointer disabled:cursor-not-allowed"


### PR DESCRIPTION
### Changes

- Add a shared ModalLayout/ModalFooter to give every modal the same header, body spacing, and button alignment
- Add a shared Button component (matching the Phoenix variant) and switch all modal buttons to it for consistent sizing and theming
- Align footer buttons to the right in all modal footers
- Restructure the segment details modal: fixed "Segment details" title, with the segment name, type, and authorship shown inline in the body
- Update the delete segment modal with a clearer title and a confirmation message
- Make filter pills better visible inside modals with a gray background
- Add a Cancel button to the filter modal when no filters are applied
- Refine button theme borders so ghost, yellow, and icon variants line up at the same height as bordered buttons, and fix the visible border on disabled primary buttons

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
