### PR TITLE
Fix match_day_of_week for year_over_year comparisons in day and 24h periods

### DIFF
--- a/lib/plausible/stats/comparisons.ex
+++ b/lib/plausible/stats/comparisons.ex
@@ -156,14 +156,28 @@ defmodule Plausible.Stats.Comparisons do
   defp get_comparison_datetime_range(
          %Query{
            input_date_range: input_range,
-           include: %{compare: :year_over_year}
+           include: %{compare: :year_over_year} = include
          } = source_query
        )
        when input_range in [:"24h", :day] do
     comparison_start = DateTime.shift(source_query.utc_time_range.first, year: -1)
     comparison_end = DateTime.shift(source_query.utc_time_range.last, year: -1)
 
-    DateTimeRange.new!(comparison_start, comparison_end)
+    if include.compare_match_day_of_week do
+      source_first_date = Times.to_date(source_query.utc_time_range.first, source_query.timezone)
+      comparison_first_date = Times.to_date(comparison_start, source_query.timezone)
+
+      day_to_match = Date.day_of_week(source_first_date)
+      matched_date = shift_to_nearest(day_to_match, comparison_first_date, source_first_date)
+      days_shifted = Date.diff(matched_date, comparison_first_date)
+
+      DateTimeRange.new!(
+        DateTime.shift(comparison_start, day: days_shifted),
+        DateTime.shift(comparison_end, day: days_shifted)
+      )
+    else
+      DateTimeRange.new!(comparison_start, comparison_end)
+    end
   end
 
   defp get_comparison_datetime_range(

--- a/test/plausible/stats/comparisons_test.exs
+++ b/test/plausible/stats/comparisons_test.exs
@@ -442,6 +442,65 @@ defmodule Plausible.Stats.ComparisonsTest do
     |> Enum.count()
   end
 
+  describe "with period set to today" do
+    test "handles YoY comparison mode matching exact date", %{site: site} do
+      query =
+        QueryBuilder.build!(site,
+          metrics: [:visitors],
+          input_date_range: :day,
+          include: [compare: :year_over_year],
+          now: ~U[2023-03-15 18:30:00Z]
+        )
+
+      comparison_query = Comparisons.get_comparison_query(query)
+
+      assert comparison_query.utc_time_range.first == ~U[2022-03-15 00:00:00Z]
+      assert comparison_query.utc_time_range.last == ~U[2022-03-15 18:30:00Z]
+    end
+
+    test "handles YoY comparison mode with match_day_of_week enabled",
+         %{site: site} do
+      query =
+        QueryBuilder.build!(site,
+          metrics: [:visitors],
+          input_date_range: :day,
+          include: [compare: :year_over_year, compare_match_day_of_week: true],
+          now: ~U[2023-03-15 18:30:00Z]
+        )
+
+      comparison_query = Comparisons.get_comparison_query(query)
+
+      # today range: 2023-03-15 (Wednesday) 00:00:00 to 18:30:00 UTC
+      # Year ago: 2022-03-15 (Tuesday); nearest Wednesday is 2022-03-16 (+1 day)
+      assert comparison_query.utc_time_range.first == ~U[2022-03-16 00:00:00Z]
+      assert comparison_query.utc_time_range.last == ~U[2022-03-16 18:30:00Z]
+    end
+
+    test "handles YoY + match_day_of_week comparison for a non-UTC timezone" do
+      site = insert(:site, timezone: "US/Eastern")
+
+      # 2023-03-14 20:30:00 (Tuesday) in US/Eastern
+      utc_now = ~U[2023-03-15 00:30:00Z]
+
+      query =
+        QueryBuilder.build!(site,
+          metrics: [:visitors],
+          input_date_range: :day,
+          include: [compare: :year_over_year, compare_match_day_of_week: true],
+          now: utc_now
+        )
+
+      comparison_query = Comparisons.get_comparison_query(query)
+
+      # Year ago: March 14, 2022 is Monday
+      # Nearest Tuesday: March 15, 2022 (+1 day)
+      # Comparison start in US/Eastern: 2022-03-15T00:00:00
+      assert comparison_query.utc_time_range.first == ~U[2022-03-15 04:00:00Z]
+      # Comparison end in US/Eastern: 2022-03-15T20:30:00
+      assert comparison_query.utc_time_range.last == ~U[2022-03-16 00:30:00Z]
+    end
+  end
+
   describe "with period set to 24h" do
     test "shifts back 24h period when mode is previous_period", %{site: site} do
       query =
@@ -475,6 +534,24 @@ defmodule Plausible.Stats.ComparisonsTest do
       # Year over year shifts back exactly 1 year
       assert comparison_query.utc_time_range.first == ~U[2022-03-14 18:30:00Z]
       assert comparison_query.utc_time_range.last == ~U[2022-03-15 18:30:00Z]
+    end
+
+    test "handles YoY with match_day_of_week enabled", %{site: site} do
+      query =
+        QueryBuilder.build!(site,
+          metrics: [:visitors],
+          input_date_range: :"24h",
+          include: [compare: :year_over_year, compare_match_day_of_week: true],
+          now: ~U[2023-03-15 18:30:00Z]
+        )
+
+      comparison_query = Comparisons.get_comparison_query(query)
+
+      # Main 24h range: 2023-03-14 18:30:00 (Tue) -> 2023-03-15 18:30:00 (Wed)
+      # Year ago: 2022-03-14 18:30:00 (Mon) -> 2022-03-15 18:30:00 (Tue)
+      # Nearest Tuesday to Monday: March 15, 2022 (+1 day shift)
+      assert comparison_query.utc_time_range.first == ~U[2022-03-15 18:30:00Z]
+      assert comparison_query.utc_time_range.last == ~U[2022-03-16 18:30:00Z]
     end
 
     test "custom time zone works with 24h comparison" do


### PR DESCRIPTION
### Changes

Currently, the `Last 24h` and `today` periods are not respecting `match_day_of_week` in `year_over_year` comparison mode.

For `Last 24h` it was never implemented. For the `today` period it used to work before https://github.com/plausible/analytics/pull/6205 because it didn't get the special "datetime" treatment (therefore, it fell into the default `get_comparison_date_range(%Query{include: %{compare: :year_over_year}} = source_query)` function clause, and got `maybe_match_day_of_week` called on the result).

This PR implements the missing piece and adds tests.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Does not require a changelog update -- both last 24 hours period and today comparison matching the exact number of hours are part of the current release. 

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [X] This PR does not change the UI
