### PR TITLE
Journey improvements: dashboard state change, truncate 0s, empty states

### DIFF
--- a/assets/js/dashboard/components/lazy-loader.js
+++ b/assets/js/dashboard/components/lazy-loader.js
@@ -15,5 +15,9 @@ export default function LazyLoader(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inView])
 
-  return <div ref={ref} className="flex-1 flex flex-col">{props.children}</div>
+  return (
+    <div ref={ref} className="flex-1 flex flex-col">
+      {props.children}
+    </div>
+  )
 }

--- a/assets/js/dashboard/components/lazy-loader.js
+++ b/assets/js/dashboard/components/lazy-loader.js
@@ -15,5 +15,5 @@ export default function LazyLoader(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inView])
 
-  return <div ref={ref}>{props.children}</div>
+  return <div ref={ref} className="flex-1 flex flex-col">{props.children}</div>
 }

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -362,7 +362,7 @@ function ExplorationColumn({
   // from the funnel data so the column still renders the selected step.
   // If the candidate list exists but the selected step isn't in it (e.g. it
   // dropped out of the top suggestions after a dashboard state change), inject
-  // it at the top so the connector always has a target to attach to.
+  // it to the bottom so the connector always has a target to attach to.
   const slicedResults = results.slice(0, 10)
   const selectedInResults =
     selected && slicedResults.some(({ step }) => isSameStep(step, selected))

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -355,10 +355,21 @@ function ExplorationColumn({
   // user can quickly switch to another option. If we don't have the candidate
   // list (e.g. preloaded journey), fall back to a synthetic single item built
   // from the funnel data so the column still renders the selected step.
+  // If the candidate list exists but the selected step isn't in it (e.g. it
+  // dropped out of the top suggestions after a dashboard state change), inject
+  // it at the top so the connector always has a target to attach to.
+  const slicedResults = results.slice(0, 10)
+  const selectedInResults =
+    selected && slicedResults.some(({ step }) => isSameStep(step, selected))
   const listItems =
     selected && results.length === 0
       ? [{ step: selected, visitors: selectedVisitors ?? 0 }]
-      : results.slice(0, 10)
+      : selected && !selectedInResults
+        ? [
+            ...slicedResults,
+            { step: selected, visitors: selectedVisitors ?? 0 }
+          ]
+        : slicedResults
 
   return (
     <div
@@ -565,11 +576,12 @@ export function FunnelExploration() {
   // real funnel response arrives. Prevents from flashing "0 visitors"
   // during the loading window.
   const [provisionalFunnelEntries, setProvisionalFunnelEntries] = useState({})
-  // Workaround for force refreshing connectors between steps
-  // when dashboardState changes. Currently the connectors
-  // logic extracts part of the state from DOM, which shouldn't be the
-  // case. It will eventually be properlu rewritten and the workaround
-  // will no longer be needed.
+  // PathConnectors recalculates connector positions via getBoundingClientRect
+  // whenever its `steps` prop changes or the container resizes. However when
+  // dashboardState changes, frozen candidate lists are re-fetched and columns
+  // may re-render with different item counts, shifting the selected-step rows
+  // without `steps` itself changing. Bumping this key remounts PathConnectors
+  // in that case, triggering a fresh layout read after the new content paints.
   const [connectorsKey, setConnectorsKey] = useState(randomKey)
   // Tracks the steps/direction/dashboardState values from the previous effect
   // run so we can tell whether the journey changed (needs funnel) or only the
@@ -583,6 +595,14 @@ export function FunnelExploration() {
   // Used to discard stale preload-driven candidate fetches that resolve
   // after the user has already navigated away from the preloaded prefix.
   const journeyVersionRef = useRef(0)
+  // Always up-to-date refs so the site/dashboardState change effect can read
+  // current steps and direction without adding them to its dependency array.
+  const stepsRef = useRef(steps)
+  const directionRef = useRef(direction)
+  useEffect(() => {
+    stepsRef.current = steps
+    directionRef.current = direction
+  })
 
   function handleSelect(columnIndex, selected) {
     journeyVersionRef.current++
@@ -666,9 +686,9 @@ export function FunnelExploration() {
 
   // Frozen candidate lists were fetched against a specific site +
   // dashboard filter context. When either changes the cached candidates
-  // become stale, so drop them and invalidate any in-flight preload
-  // backfills. We skip the initial run so we don't clobber the freshly
-  // populated state on mount.
+  // become stale, so re-fetch candidates for each selected step position
+  // and repopulate frozenColumnResults. We skip the initial run so we
+  // don't clobber the freshly populated state on mount.
   const initialFilterContextRef = useRef(true)
   useEffect(() => {
     if (initialFilterContextRef.current) {
@@ -676,7 +696,39 @@ export function FunnelExploration() {
       return
     }
     journeyVersionRef.current++
-    setFrozenColumnResults({})
+    const capturedVersion = journeyVersionRef.current
+
+    const currentSteps = stepsRef.current
+    const currentDirection = directionRef.current
+
+    if (currentSteps.length === 0) {
+      setFrozenColumnResults({})
+      return
+    }
+
+    // Re-fetch candidates for each selected step (columns 0..steps.length-1).
+    // Column i shows candidates that were fetched with the journey up to step i-1,
+    // i.e. steps.slice(0, i) as the journey prefix.
+    const fetches = currentSteps.map((_, i) =>
+      fetchNextWithFunnel(
+        site,
+        dashboardState,
+        currentSteps.slice(0, i),
+        '',
+        currentDirection,
+        false
+      ).then((r) => ({ index: i, results: r?.next || [] }))
+    )
+
+    Promise.all(fetches).then((entries) => {
+      if (journeyVersionRef.current !== capturedVersion) return
+      const newFrozen = {}
+      entries.forEach(({ index, results }) => {
+        newFrozen[index] = results
+      })
+      setFrozenColumnResults(newFrozen)
+      setConnectorsKey(randomKey)
+    })
   }, [site, dashboardState])
 
   // On first render fire the interesting-funnel preload and skip the normal
@@ -782,8 +834,6 @@ export function FunnelExploration() {
       .finally(() => {
         if (!cancelled) setActiveColumnLoading(false)
       })
-
-    setConnectorsKey(randomKey)
 
     return () => {
       cancelled = true
@@ -894,9 +944,10 @@ export function FunnelExploration() {
                 // Active column gets live results; previously-active (now
                 // selected) columns get the candidate list that was visible at
                 // the moment of selection so the user can switch options
-                // without losing context. Pre-selected columns (e.g. populated
-                // by interesting-funnel preload) have no frozen results and
-                // fall back to a single-item display sourced from funnel data.
+                // without losing context. If no frozen results exist yet
+                // (e.g. briefly after a dashboardState change triggers a
+                // re-fetch), the column falls back to a single-item display
+                // sourced from funnel data until the fetch completes.
                 results={
                   isActive ? activeColumnResults : frozenColumnResults[i] || []
                 }

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -933,72 +933,76 @@ export function FunnelExploration() {
 
         {noData ? (
           <div className="flex-1 flex items-center justify-center font-medium text-gray-500 dark:text-gray-400">
-            No journey data found for the selected period
+            No data yet
           </div>
         ) : (
-        <div
-          ref={containerRef}
-          className="relative grid gap-6 overflow-x-auto -mx-5 px-5 -mb-3 pb-3 [scrollbar-width:thin] [scrollbar-color:theme(colors.gray.300)_transparent] dark:[scrollbar-color:theme(colors.gray.600)_transparent]"
-          style={{
-            gridTemplateColumns: `repeat(${gridColumns}, minmax(20rem, 1fr))`
-          }}
-        >
-          {Array.from({ length: numColumns }, (_, i) => {
-            const isActive = i === activeColumnIndex
-            const isReachable = steps.length >= i
+          <div
+            ref={containerRef}
+            className="relative grid gap-6 overflow-x-auto -mx-5 px-5 -mb-3 pb-3 [scrollbar-width:thin] [scrollbar-color:theme(colors.gray.300)_transparent] dark:[scrollbar-color:theme(colors.gray.600)_transparent]"
+            style={{
+              gridTemplateColumns: `repeat(${gridColumns}, minmax(20rem, 1fr))`
+            }}
+          >
+            {Array.from({ length: numColumns }, (_, i) => {
+              const isActive = i === activeColumnIndex
+              const isReachable = steps.length >= i
 
-            return (
-              <ExplorationColumn
-                key={i}
-                colIndex={i}
-                header={columnHeader(i, direction)}
-                active={isReachable}
-                // Active column gets live results; previously-active (now
-                // selected) columns get the candidate list that was visible at
-                // the moment of selection so the user can switch options
-                // without losing context. If no frozen results exist yet
-                // (e.g. briefly after a dashboardState change triggers a
-                // re-fetch), the column falls back to a single-item display
-                // sourced from funnel data until the fetch completes.
-                results={
-                  isActive ? activeColumnResults : frozenColumnResults[i] || []
-                }
-                loading={
-                  isActive ? initialLoading || activeColumnLoading : false
-                }
-                selected={steps[i] || null}
-                selectedVisitors={
-                  provisionalFunnelEntries[i]?.visitors ??
-                  funnel[i]?.visitors ??
-                  null
-                }
-                selectedConversionRate={
-                  provisionalFunnelEntries[i]?.conversion_rate ??
-                  funnel[i]?.conversion_rate ??
-                  null
-                }
-                maxVisitors={funnel[0]?.visitors ?? null}
-                onSelect={(selected) => handleSelect(i, selected)}
-                onFilterChange={isActive ? setActiveColumnFilter : () => {}}
-                filter={isActive ? activeColumnFilter : ''}
-                direction={direction}
-                onDirectionChange={i === 0 ? handleDirectionSelect : undefined}
-                headerConversionRate={
-                  funnel[i]?.conversion_rate != null
-                    ? i === 0
-                      ? '100%'
-                      : `${parseFloat(funnel[i].conversion_rate).toFixed(1)}%`
-                    : null
-                }
-              />
-            )
-          })}
-          <PathConnectors
-            key={connectorsKey}
-            containerRef={containerRef}
-            steps={steps}
-          />
-        </div>
+              return (
+                <ExplorationColumn
+                  key={i}
+                  colIndex={i}
+                  header={columnHeader(i, direction)}
+                  active={isReachable}
+                  // Active column gets live results; previously-active (now
+                  // selected) columns get the candidate list that was visible at
+                  // the moment of selection so the user can switch options
+                  // without losing context. If no frozen results exist yet
+                  // (e.g. briefly after a dashboardState change triggers a
+                  // re-fetch), the column falls back to a single-item display
+                  // sourced from funnel data until the fetch completes.
+                  results={
+                    isActive
+                      ? activeColumnResults
+                      : frozenColumnResults[i] || []
+                  }
+                  loading={
+                    isActive ? initialLoading || activeColumnLoading : false
+                  }
+                  selected={steps[i] || null}
+                  selectedVisitors={
+                    provisionalFunnelEntries[i]?.visitors ??
+                    funnel[i]?.visitors ??
+                    null
+                  }
+                  selectedConversionRate={
+                    provisionalFunnelEntries[i]?.conversion_rate ??
+                    funnel[i]?.conversion_rate ??
+                    null
+                  }
+                  maxVisitors={funnel[0]?.visitors ?? null}
+                  onSelect={(selected) => handleSelect(i, selected)}
+                  onFilterChange={isActive ? setActiveColumnFilter : () => {}}
+                  filter={isActive ? activeColumnFilter : ''}
+                  direction={direction}
+                  onDirectionChange={
+                    i === 0 ? handleDirectionSelect : undefined
+                  }
+                  headerConversionRate={
+                    funnel[i]?.conversion_rate != null
+                      ? i === 0
+                        ? '100%'
+                        : `${parseFloat(funnel[i].conversion_rate).toFixed(1)}%`
+                      : null
+                  }
+                />
+              )
+            })}
+            <PathConnectors
+              key={connectorsKey}
+              containerRef={containerRef}
+              steps={steps}
+            />
+          </div>
         )}
       </div>
     </LazyLoader>

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -434,9 +434,7 @@ function ExplorationColumn({
           ) : (
             <span className="flex flex-col items-center gap-2">
               <FlagIcon className="size-4.5" />
-              {direction === EXPLORATION_DIRECTIONS.BACKWARD
-                ? "You've reached the beginning of this journey"
-                : "You've reached the end of this journey"}
+              No further steps found for the selected period and filters
             </span>
           )}
         </div>

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -885,9 +885,16 @@ export function FunnelExploration() {
     prevStepsLengthRef.current = steps.length
   }, [steps.length])
 
+  const noData =
+    !initialLoading &&
+    !activeColumnLoading &&
+    steps.length === 0 &&
+    funnel.length === 0 &&
+    activeColumnResults.length === 0
+
   return (
     <LazyLoader onVisible={() => setInViewport(true)}>
-      <div className="flex flex-col gap-4 pt-4">
+      <div className="flex-1 flex flex-col gap-4 pt-4">
         <div className="flex flex-wrap items-center gap-x-3">
           <h4 className="flex-1 text-base font-semibold dark:text-gray-100">
             {funnel.length >= 2
@@ -924,6 +931,11 @@ export function FunnelExploration() {
           </Tooltip>
         </div>
 
+        {noData ? (
+          <div className="flex-1 flex items-center justify-center font-medium text-gray-500 dark:text-gray-400">
+            No journey data found for the selected period
+          </div>
+        ) : (
         <div
           ref={containerRef}
           className="relative grid gap-6 overflow-x-auto -mx-5 px-5 -mb-3 pb-3 [scrollbar-width:thin] [scrollbar-color:theme(colors.gray.300)_transparent] dark:[scrollbar-color:theme(colors.gray.600)_transparent]"
@@ -987,6 +999,7 @@ export function FunnelExploration() {
             steps={steps}
           />
         </div>
+        )}
       </div>
     </LazyLoader>
   )

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -92,6 +92,11 @@ function isSameStep(step, otherStep) {
   )
 }
 
+function truncateFunnelAtFirstZero(funnel) {
+  const cutoff = funnel.findIndex((entry) => entry.visitors === 0)
+  return cutoff === -1 ? funnel : funnel.slice(0, cutoff)
+}
+
 function truncateFrozenResultsAtIndex(frozenResults, fromIndex) {
   const next = {}
   Object.keys(frozenResults).forEach((key) => {
@@ -591,6 +596,9 @@ export function FunnelExploration() {
   const prevDashboardStateRef = useRef(dashboardState)
   const preloadFiredRef = useRef(false)
   const funnelFromPreloadRef = useRef(false)
+  // Set to true when steps are trimmed to match a truncated funnel response.
+  // Prevents the resulting steps change from triggering a redundant funnel re-fetch.
+  const funnelTruncatedStepsRef = useRef(false)
   // Bumped whenever the user actively changes the journey or direction.
   // Used to discard stale preload-driven candidate fetches that resolve
   // after the user has already navigated away from the preloaded prefix.
@@ -760,9 +768,14 @@ export function FunnelExploration() {
           if (cancelled) return
           if (response && response.funnel && response.funnel.length > 0) {
             funnelFromPreloadRef.current = true
-            const preloadedSteps = response.funnel.map(({ step }) => step)
-            setSteps(preloadedSteps)
-            setFunnel(response.funnel)
+            // When dahshboard state changes for an already set journey,
+            // we might end with some of the trailing steps having zero visitors.
+            // In such case we should truncate the journey, allow further candidate
+            // selection (if present) instead of drawing connections
+            // to non-selectable nodes.
+            const truncatedFunnel = truncateFunnelAtFirstZero(response.funnel)
+            setSteps(truncatedFunnel.map(({ step }) => step))
+            setFunnel(truncatedFunnel)
             setFrozenColumnResults(response.candidates)
           } else {
             // Nothing to preload, fall back to a plain next-steps fetch
@@ -803,8 +816,14 @@ export function FunnelExploration() {
     const funnelAlreadyLoaded = funnelFromPreloadRef.current
     funnelFromPreloadRef.current = false
 
+    const funnelTruncatedSteps = funnelTruncatedStepsRef.current
+    funnelTruncatedStepsRef.current = false
+
     const includeFunnel =
-      journeyChanged && steps.length > 0 && !funnelAlreadyLoaded
+      journeyChanged &&
+      steps.length > 0 &&
+      !funnelAlreadyLoaded &&
+      !funnelTruncatedSteps
 
     if (journeyChanged && steps.length === 0) {
       setFunnel([])
@@ -822,7 +841,14 @@ export function FunnelExploration() {
         if (cancelled) return
         setActiveColumnResults(response?.next || [])
         if (includeFunnel) {
-          setFunnel(response?.funnel || [])
+          const truncatedFunnel = truncateFunnelAtFirstZero(
+            response?.funnel || []
+          )
+          setFunnel(truncatedFunnel)
+          if (truncatedFunnel.length < (response?.funnel?.length ?? 0)) {
+            funnelTruncatedStepsRef.current = true
+            setSteps((prev) => prev.slice(0, truncatedFunnel.length))
+          }
           setProvisionalFunnelEntries({})
         }
       })

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -375,7 +375,7 @@ function Behaviours({ importedDataInView, setMode, mode }) {
 
   function noDataYet() {
     return (
-      <div className="font-medium text-gray-500 dark:text-gray-400 py-12 text-center">
+      <div className="flex-1 flex items-center justify-center font-medium text-gray-500 dark:text-gray-400">
         No data yet
       </div>
     )
@@ -383,7 +383,7 @@ function Behaviours({ importedDataInView, setMode, mode }) {
 
   function featureUnavailable() {
     return (
-      <div className="font-medium text-gray-500 dark:text-gray-400 py-12 text-center">
+      <div className="flex-1 flex items-center justify-center font-medium text-gray-500 dark:text-gray-400">
         This feature is unavailable
       </div>
     )

--- a/assets/js/dashboard/stats/behaviours/props.js
+++ b/assets/js/dashboard/stats/behaviours/props.js
@@ -59,7 +59,7 @@ export default function Properties({ propKey, afterFetchData }) {
 
   if (!propKey) {
     return (
-      <div className="font-medium text-gray-500 dark:text-gray-400 py-12 text-center">
+      <div className="flex-1 flex items-center justify-center font-medium text-gray-500 dark:text-gray-400">
         No custom properties found
       </div>
     )


### PR DESCRIPTION
### Changes

This PR:

  - ensures existing journey is updated properly on dashboard state change (e.g. range/filters)
  - remaining steps are truncated if their visitor count turns out 0 for the new setup
  - simplifies the end of the journey message as per @metmarkosaric's suggestion
  - unifies empty state among "Explore" and its sibling tabs - Custom Properties and Goals