### PR TITLE
Fixup: Bump npm package version

### DIFF
--- a/tracker/npm_package/package.json
+++ b/tracker/npm_package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plausible-analytics/tracker",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Plausible Analytics official frontend tracking library",
   "scripts": {
     "test": "echo \"Error: Testing done in the tracker folder\" && exit 1"


### PR DESCRIPTION
After merging https://github.com/plausible/analytics/commit/49448f5b16a5923ce06b200833a04de0e037b5e9 the NPM release [workflow](https://github.com/plausible/analytics/actions/runs/25378129985/job/74419700611) ran and succeeded to publish the package but failed to push the code changes. This PR manually syncs the npm package version with what was published: https://www.npmjs.com/package/@plausible-analytics/tracker