### PR TITLE
Refactor from pointsRef to points state

### DIFF
--- a/assets/js/dashboard/components/graph.tsx
+++ b/assets/js/dashboard/components/graph.tsx
@@ -101,7 +101,7 @@ function InnerGraph<T extends GraphYValues>({
   highlightedIndex
 }: GraphProps<T>) {
   const [extraMarginLeft, setExtraMarginLeft] = useState(0)
-
+  const [points, setPoints] = useState<Point<T>[]>([])
   const marginLeft = defaultMarginLeft + extraMarginLeft
   const xLeftEdge = marginLeft
   const xRightEdge = width - marginRight
@@ -128,7 +128,7 @@ function InnerGraph<T extends GraphYValues>({
     const svg = d3.select(svgRef.current)
 
     const cleanup = () => {
-      pointsRef.current = null
+      setPoints([])
       svg.selectAll('*').remove()
     }
 
@@ -291,7 +291,7 @@ function InnerGraph<T extends GraphYValues>({
       }
     }
 
-    pointsRef.current = points
+    setPoints(points)
 
     // Unhide chart
     svg.attr('opacity', 1)
@@ -331,8 +331,7 @@ function InnerGraph<T extends GraphYValues>({
 
   useEffect(() => {
     const currentSvg = svgRef.current
-    if (currentSvg && pointsRef.current) {
-      const points = pointsRef.current
+    if (currentSvg && points.length) {
       const svg = d3.select(currentSvg)
 
       svg.on(
@@ -350,7 +349,7 @@ function InnerGraph<T extends GraphYValues>({
                 ? {
                     index: closestIndexToPointer,
                     x: points[closestIndexToPointer].x,
-                    values: points[closestIndexToPointer].values
+                    values: points[closestIndexToPointer].values,
                   }
                 : null,
             xPointer,
@@ -371,7 +370,7 @@ function InnerGraph<T extends GraphYValues>({
 
   useEffect(() => {
     const currentSvg = svgRef.current
-    if (currentSvg && pointsRef.current) {
+    if (currentSvg && points.length) {
       const svg = d3.select(currentSvg)
       svg.on(
         'gotpointercapture',
@@ -387,11 +386,11 @@ function InnerGraph<T extends GraphYValues>({
         svg.on('gotpointercapture', null)
       }
     }
-  }, [onGotPointerCapture, isInHoverableArea, data])
+  }, [onGotPointerCapture, points])
 
   useEffect(() => {
     const currentSvg = svgRef.current
-    if (currentSvg && pointsRef.current) {
+    if (currentSvg && points.length) {
       const svg = d3.select(currentSvg)
       svg.on(
         'pointerenter',
@@ -407,11 +406,11 @@ function InnerGraph<T extends GraphYValues>({
         svg.on('pointerenter', null)
       }
     }
-  }, [onPointerEnter, isInHoverableArea, data])
+  }, [onPointerEnter, points])
 
   useEffect(() => {
     const currentSvg = svgRef.current
-    if (currentSvg && pointsRef.current) {
+    if (currentSvg && points.length) {
       const svg = d3.select(currentSvg)
       svg.on(
         'lostpointercapture pointerleave',
@@ -428,11 +427,11 @@ function InnerGraph<T extends GraphYValues>({
         svg.on('lostpointercapture pointerleave', null)
       }
     }
-  }, [onPointerLeave, isInHoverableArea, data])
+  }, [onPointerLeave, points])
 
   useEffect(() => {
     const currentSvg = svgRef.current
-    if (currentSvg && pointsRef.current) {
+    if (currentSvg && points.length) {
       const svg = d3.select(currentSvg)
       const points = pointsRef.current
       if (typeof onClick !== 'function') {
@@ -470,45 +469,39 @@ function InnerGraph<T extends GraphYValues>({
   }, [onClick, isInHoverableArea, data])
 
   useEffect(() => {
-    if (pointsRef.current) {
-      const currentPoints = pointsRef.current
-      currentPoints.forEach(({ dots }, index) =>
-        dots.forEach((g) =>
-          g.attr(
-            'data-active',
-            highlightedIndex !== null && index === highlightedIndex ? '' : null
-          )
+    points.forEach(({ dots }, index) =>
+      dots.forEach((g) =>
+        g.attr(
+          'data-active',
+          highlightedIndex !== null && index === highlightedIndex ? '' : null
         )
       )
+    )
 
-      if (svgRef.current) {
-        const svg = d3.select(svgRef.current)
-        let line = svg.select<SVGLineElement>(
-          `#${highlightIndicatorGroupId} line`
-        )
-        const shouldShowLine = typeof highlightedIndex === 'number'
-        if (shouldShowLine) {
-          const { x } = currentPoints[highlightedIndex]
-          if (line.empty()) {
-            line = svg.select(`#${highlightIndicatorGroupId}`).append('line')
-          }
-          line
-            .attr('x1', 0)
-            .attr('x2', 0)
-            .attr('y1', marginTop - HIGHLIGHT_LINE_VERTICAL_SPILL_PX)
-            .attr(
-              'y2',
-              height - marginBottom + HIGHLIGHT_LINE_VERTICAL_SPILL_PX
-            )
-            .attr('class', currentlySelectedLineClass)
-            .attr('transform', `translate(${x}, 0)`)
+    if (svgRef.current) {
+      const svg = d3.select(svgRef.current)
+      let line = svg.select<SVGLineElement>(
+        `#${highlightIndicatorGroupId} line`
+      )
+      const shouldShowLine = typeof highlightedIndex === 'number'
+      if (shouldShowLine) {
+        const { x } = points[highlightedIndex]
+        if (line.empty()) {
+          line = svg.select(`#${highlightIndicatorGroupId}`).append('line')
         }
-        if (!shouldShowLine && !line.empty()) {
-          line.remove()
-        }
+        line
+          .attr('x1', 0)
+          .attr('x2', 0)
+          .attr('y1', marginTop - HIGHLIGHT_LINE_VERTICAL_SPILL_PX)
+          .attr('y2', height - marginBottom + HIGHLIGHT_LINE_VERTICAL_SPILL_PX)
+          .attr('class', currentlySelectedLineClass)
+          .attr('transform', `translate(${x}, 0)`)
+      }
+      if (!shouldShowLine && !line.empty()) {
+        line.remove()
       }
     }
-  }, [highlightedIndex, data, height, marginBottom, marginTop])
+  }, [height, highlightedIndex, marginBottom, marginTop, points])
 
   return (
     <svg

--- a/assets/js/dashboard/components/graph.tsx
+++ b/assets/js/dashboard/components/graph.tsx
@@ -109,9 +109,8 @@ function InnerGraph<T extends GraphYValues>({
   const yBottomEdge = height - marginBottom
 
   const svgRef = useRef<SVGSVGElement | null>(null)
-  const pointsRef = useRef<Point<T>[] | null>(null)
 
-  // Effect to fully redraw chart from scratch
+  // Effect to redraw the chart from scratch
   useEffect(() => {
     if (!svgRef.current) {
       return
@@ -349,7 +348,7 @@ function InnerGraph<T extends GraphYValues>({
                 ? {
                     index: closestIndexToPointer,
                     x: points[closestIndexToPointer].x,
-                    values: points[closestIndexToPointer].values,
+                    values: points[closestIndexToPointer].values
                   }
                 : null,
             xPointer,
@@ -366,7 +365,7 @@ function InnerGraph<T extends GraphYValues>({
         }
       }
     }
-  }, [onPointerMove, isInHoverableArea, data])
+  }, [onPointerMove, isInHoverableArea, points])
 
   useEffect(() => {
     const currentSvg = svgRef.current
@@ -433,7 +432,6 @@ function InnerGraph<T extends GraphYValues>({
     const currentSvg = svgRef.current
     if (currentSvg && points.length) {
       const svg = d3.select(currentSvg)
-      const points = pointsRef.current
       if (typeof onClick !== 'function') {
         svg.on('click', null)
       } else {
@@ -466,7 +464,7 @@ function InnerGraph<T extends GraphYValues>({
         svg.on('click', null)
       }
     }
-  }, [onClick, isInHoverableArea, data])
+  }, [onClick, isInHoverableArea, points])
 
   useEffect(() => {
     points.forEach(({ dots }, index) =>


### PR DESCRIPTION
### Changes

Refactors pointsRef to points state, no functional changes. 

The ref apporach caused issued with effects not re-running when they should have, and a hacky fix was in place by making the effects depend on `data`, even though `data` isn't referenced in the effects. This allows us to remove the hacky fix. 

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
