### PR TITLE
Exclude selected wilcard pattern matches from subsequent step suggestions

### DIFF
--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -435,12 +435,16 @@ defmodule Plausible.Stats.Exploration do
         }
       end)
 
-    types = %{name: :string, pathname: :string}
+    if to_exclude != [] do
+      types = %{name: :string, pathname: :string}
 
-    from m in subquery(query),
-      left_join: g in values(to_exclude, types),
-      on: g.name == m.name and g.pathname == m.pathname,
-      where: g.name == "" or m.includes_subpaths
+      from m in subquery(query),
+        left_join: g in values(to_exclude, types),
+        on: g.name == m.name and g.pathname == m.pathname,
+        where: g.name == "" or m.includes_subpaths
+    else
+      query
+    end
   end
 
   # Expand each (name, pathname, user_id) row into all prefix paths via

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -299,6 +299,15 @@ defmodule Plausible.Stats.Exploration do
         from(s in q, where: ^step_condition)
       end)
 
+    last_step = List.last(steps)
+
+    q_matches =
+      if last_step && last_step.includes_subpaths do
+        exclude_wildcard_matches(q_matches, last_step)
+      else
+        q_matches
+      end
+
     # Fan out each q_combined row into up to two output rows (exact + wildcard)
     # using ARRAY JOIN over a small boolean array.
     #
@@ -397,6 +406,15 @@ defmodule Plausible.Stats.Exploration do
     from(m in subquery(query),
       where: m.visitors > 0
     )
+  end
+
+  defp exclude_wildcard_matches(query, step) do
+    pattern = wildcard_pattern(step.pathname)
+
+    from m in query,
+      where:
+        selected_as(:name) != ^step.name or
+          not fragment("match(?, ?)", selected_as(:pathname), ^pattern)
   end
 
   defp exclude_goal_matches(query, goals) do
@@ -647,9 +665,7 @@ defmodule Plausible.Stats.Exploration do
   defp step_condition(step, count) when count <= @max_steps do
     cond do
       step.includes_subpaths ->
-        escaped = Regex.escape(step.pathname)
-
-        pattern = "^#{escaped}(/.+)?$"
+        pattern = wildcard_pattern(step.pathname)
 
         dynamic(
           [s],
@@ -673,6 +689,12 @@ defmodule Plausible.Stats.Exploration do
             field(s, ^:"pathname#{count}") == ^step.pathname
         )
     end
+  end
+
+  defp wildcard_pattern(pathname) when is_binary(pathname) do
+    escaped = Regex.escape(pathname)
+
+    "^#{escaped}(/.+)?$"
   end
 
   defp maybe_search(query, search_term) do

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -298,15 +298,7 @@ defmodule Plausible.Stats.Exploration do
 
         from(s in q, where: ^step_condition)
       end)
-
-    last_step = List.last(steps)
-
-    q_matches =
-      if last_step && last_step.includes_subpaths do
-        exclude_wildcard_matches(q_matches, last_step)
-      else
-        q_matches
-      end
+      |> maybe_exclude_step_matches(List.last(steps))
 
     # Fan out each q_combined row into up to two output rows (exact + wildcard)
     # using ARRAY JOIN over a small boolean array.
@@ -408,7 +400,7 @@ defmodule Plausible.Stats.Exploration do
     )
   end
 
-  defp exclude_wildcard_matches(query, step) do
+  defp maybe_exclude_step_matches(query, %{includes_subpaths: true} = step) do
     pattern = wildcard_pattern(step.pathname)
 
     from m in query,
@@ -416,6 +408,21 @@ defmodule Plausible.Stats.Exploration do
         selected_as(:name) != ^step.name or
           not fragment("match(?, ?)", selected_as(:pathname), ^pattern)
   end
+
+  defp maybe_exclude_step_matches(query, %{is_goal: true, name: "pageview"} = step) do
+    if String.contains?(step.pathname, "*") do
+      pattern = Filters.Utils.page_regex(step.pathname)
+
+      from m in query,
+        where:
+          selected_as(:name) != ^step.name or
+            not fragment("match(?, ?)", selected_as(:pathname), ^pattern)
+    else
+      query
+    end
+  end
+
+  defp maybe_exclude_step_matches(query, _), do: query
 
   defp exclude_goal_matches(query, goals) do
     to_exclude =

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -1056,6 +1056,124 @@ defmodule Plausible.Stats.ExplorationTest do
         assert next_step7.step.is_goal
         assert next_step7.visitors == 1
       end
+
+      test "suggestions matching implicit wildcard from previous step are excluded" do
+        now = DateTime.utc_now()
+        site = new_site()
+
+        populate_stats(site, [
+          build(:pageview,
+            user_id: 123,
+            pathname: "/a",
+            timestamp: DateTime.shift(now, minute: -300)
+          ),
+          build(:pageview,
+            user_id: 123,
+            pathname: "/a/b",
+            timestamp: DateTime.shift(now, minute: -290)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/a/b",
+            timestamp: DateTime.shift(now, minute: -300)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/a",
+            timestamp: DateTime.shift(now, minute: -290)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/a/b",
+            timestamp: DateTime.shift(now, minute: -300)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/a-blog",
+            timestamp: DateTime.shift(now, minute: -290)
+          )
+        ])
+
+        query = QueryBuilder.build!(site, input_date_range: :all)
+
+        journey = [
+          %Exploration.Journey.Step{
+            name: "pageview",
+            pathname: "/a",
+            includes_subpaths: true,
+            subpaths_count: 2
+          }
+        ]
+
+        assert {:ok, [next_step]} = Exploration.next_steps(site, query, journey)
+
+        assert next_step.step.label == "/a-blog"
+      end
+
+      test "suggestions matching goal pattern from previous step are excluded" do
+        now = DateTime.utc_now()
+        site = new_site()
+
+        Plausible.Goals.create(site, %{"page_path" => "/a*"})
+
+        populate_stats(site, [
+          build(:pageview,
+            user_id: 123,
+            pathname: "/a",
+            timestamp: DateTime.shift(now, minute: -300)
+          ),
+          build(:pageview,
+            user_id: 123,
+            pathname: "/a/b",
+            timestamp: DateTime.shift(now, minute: -290)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/a/b",
+            timestamp: DateTime.shift(now, minute: -300)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/a",
+            timestamp: DateTime.shift(now, minute: -290)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/a/b",
+            timestamp: DateTime.shift(now, minute: -300)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/a-blog",
+            timestamp: DateTime.shift(now, minute: -290)
+          ),
+          build(:pageview,
+            user_id: 126,
+            pathname: "/a",
+            timestamp: DateTime.shift(now, minute: -300)
+          ),
+          build(:pageview,
+            user_id: 126,
+            pathname: "/blog",
+            timestamp: DateTime.shift(now, minute: -290)
+          )
+        ])
+
+        query = QueryBuilder.build!(site, input_date_range: :all)
+
+        journey = [
+          %Exploration.Journey.Step{
+            label: "Visit /a*",
+            name: "pageview",
+            pathname: "/a*",
+            is_goal: true
+          }
+        ]
+
+        assert {:ok, [next_step]} = Exploration.next_steps(site, query, journey)
+
+        assert next_step.step.label == "/blog"
+      end
     end
 
     describe "implicit wildcard pathnames" do


### PR DESCRIPTION
### Changes

This PR ensures that if either w pageview goal pattern or implicit wildcard were selected in the previous step, all matching entries are excluded from the suggestions for the next step.

It also fixes a crash bug due to empty list of goals to exclude from the combined query.

### Tests
- [x] Automated tests have been added

