### PR TITLE
Upgrade available only to owners and billing roles

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -1,4 +1,9 @@
 defmodule Plausible.Billing do
+  @moduledoc """
+  Handles Plausible billing subscription lifecycle events (creation, update, cancellation, payment success), 
+  Paddle API, team assignment, and notification logic. Provides helpers for formatting prices, 
+  managing subscription status, and updating team-related billing state.
+  """
   use Plausible
   use Plausible.Repo
   require Plausible.Billing.Subscription.Status

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -6,6 +6,8 @@ defmodule Plausible.Billing do
   alias Plausible.Billing.Subscription
   alias Plausible.Teams
 
+  defmacro allowed_roles(), do: [:owner, :billing]
+
   def subscription_created(params) do
     Repo.transaction(fn ->
       handle_subscription_created(params)

--- a/lib/plausible_web/components/billing/billing.ex
+++ b/lib/plausible_web/components/billing/billing.ex
@@ -4,6 +4,8 @@ defmodule PlausibleWeb.Components.Billing do
   use PlausibleWeb, :component
   use Plausible
 
+  require Plausible.Billing
+
   import PlausibleWeb.Components.Icons
 
   alias Plausible.Billing.{Plan, Plans, EnterprisePlan}
@@ -423,7 +425,7 @@ defmodule PlausibleWeb.Components.Billing do
       end
 
     cond do
-      not is_nil(current_role) and current_role not in [:owner, :billing] ->
+      not is_nil(current_role) and current_role not in Plausible.Billing.allowed_roles() ->
         ~H"ask your team owner to upgrade their subscription."
 
       upgrade_assistance_required? ->

--- a/lib/plausible_web/controllers/billing_controller.ex
+++ b/lib/plausible_web/controllers/billing_controller.ex
@@ -1,14 +1,17 @@
 defmodule PlausibleWeb.BillingController do
   use PlausibleWeb, :controller
   use Plausible.Repo
+
   require Logger
   require Plausible.Billing.Subscription.Status
+  require Plausible.Billing
+
   alias Plausible.Billing
   alias Plausible.Billing.Subscription
 
   plug PlausibleWeb.RequireAccountPlug
 
-  plug Plausible.Plugs.AuthorizeTeamAccess, [:owner, :billing]
+  plug Plausible.Plugs.AuthorizeTeamAccess, Billing.allowed_roles()
 
   def ping_subscription(%Plug.Conn{} = conn, _params) do
     subscribed? = Plausible.Teams.Billing.has_active_subscription?(conn.assigns.current_team)

--- a/lib/plausible_web/controllers/settings_controller.ex
+++ b/lib/plausible_web/controllers/settings_controller.ex
@@ -13,9 +13,6 @@ defmodule PlausibleWeb.SettingsController do
        when action in [:update_team_name]
 
   plug Plausible.Plugs.AuthorizeTeamAccess,
-       [:owner, :billing] when action in [:subscription]
-
-  plug Plausible.Plugs.AuthorizeTeamAccess,
        [:owner]
        when action in [
               :team_danger_zone,

--- a/lib/plausible_web/live/subscription_settings.ex
+++ b/lib/plausible_web/live/subscription_settings.ex
@@ -5,6 +5,8 @@ defmodule PlausibleWeb.Live.SubscriptionSettings do
   use PlausibleWeb, :live_view
   use Plausible
 
+  require Plausible.Billing
+
   import PlausibleWeb.Components.Billing.Helpers
 
   alias Plausible.Teams
@@ -13,7 +15,8 @@ defmodule PlausibleWeb.Live.SubscriptionSettings do
   def mount(_params, _session, socket) do
     team = socket.assigns.current_team
 
-    if Teams.setup?(team) && socket.assigns.current_team_role not in [:owner, :billing] do
+    if Teams.setup?(team) &&
+         socket.assigns.current_team_role not in Plausible.Billing.allowed_roles() do
       {:ok, redirect(socket, to: Routes.site_path(socket, :index))}
     else
       subscription = Teams.Billing.get_subscription(team)

--- a/lib/plausible_web/live/subscription_settings.ex
+++ b/lib/plausible_web/live/subscription_settings.ex
@@ -12,42 +12,47 @@ defmodule PlausibleWeb.Live.SubscriptionSettings do
 
   def mount(_params, _session, socket) do
     team = socket.assigns.current_team
-    subscription = Teams.Billing.get_subscription(team)
-    invoices = Plausible.Billing.paddle_api().get_invoices(subscription)
-    pageview_usage = Teams.Billing.monthly_pageview_usage(team)
-    site_usage = Teams.Billing.site_usage(team)
-    team_member_usage = Teams.Billing.team_member_usage(team)
 
-    usage = %{
-      monthly_pageviews: pageview_usage,
-      sites: site_usage,
-      team_members: team_member_usage
-    }
+    if Teams.setup?(team) && socket.assigns.current_team_role not in [:owner, :billing] do
+      {:ok, redirect(socket, to: Routes.site_path(socket, :index))}
+    else
+      subscription = Teams.Billing.get_subscription(team)
+      invoices = Plausible.Billing.paddle_api().get_invoices(subscription)
+      pageview_usage = Teams.Billing.monthly_pageview_usage(team)
+      site_usage = Teams.Billing.site_usage(team)
+      team_member_usage = Teams.Billing.team_member_usage(team)
 
-    notification_type = Plausible.Billing.Quota.usage_notification_type(team, usage)
+      usage = %{
+        monthly_pageviews: pageview_usage,
+        sites: site_usage,
+        team_members: team_member_usage
+      }
 
-    total_pageview_usage_domain =
-      if site_usage == 1 do
-        [site] = Plausible.Teams.owned_sites(team)
-        site.domain
-      else
-        on_ee(do: team && consolidated_view_domain(team), else: nil)
-      end
+      notification_type = Plausible.Billing.Quota.usage_notification_type(team, usage)
 
-    socket =
-      socket
-      |> assign(:subscription, subscription)
-      |> assign(:invoices, invoices)
-      |> assign(:pageview_limit, Teams.Billing.monthly_pageview_limit(subscription))
-      |> assign(:pageview_usage, pageview_usage)
-      |> assign(:site_usage, site_usage)
-      |> assign(:site_limit, Teams.Billing.site_limit(team))
-      |> assign(:team_member_limit, Teams.Billing.team_member_limit(team))
-      |> assign(:team_member_usage, team_member_usage)
-      |> assign(:notification_type, notification_type)
-      |> assign(:total_pageview_usage_domain, total_pageview_usage_domain)
+      total_pageview_usage_domain =
+        if site_usage == 1 do
+          [site] = Plausible.Teams.owned_sites(team)
+          site.domain
+        else
+          on_ee(do: team && consolidated_view_domain(team), else: nil)
+        end
 
-    {:ok, socket}
+      socket =
+        socket
+        |> assign(:subscription, subscription)
+        |> assign(:invoices, invoices)
+        |> assign(:pageview_limit, Teams.Billing.monthly_pageview_limit(subscription))
+        |> assign(:pageview_usage, pageview_usage)
+        |> assign(:site_usage, site_usage)
+        |> assign(:site_limit, Teams.Billing.site_limit(team))
+        |> assign(:team_member_limit, Teams.Billing.team_member_limit(team))
+        |> assign(:team_member_usage, team_member_usage)
+        |> assign(:notification_type, notification_type)
+        |> assign(:total_pageview_usage_domain, total_pageview_usage_domain)
+
+      {:ok, socket}
+    end
   end
 
   def render(assigns) do

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -47,7 +47,7 @@
                 :if={
                   ee?() and Plausible.Teams.on_trial?(@conn.assigns[:current_team]) and
                     (not Plausible.Teams.setup?(@conn.assigns[:current_team]) or
-                       @conn.assigns[:current_team_role] in [:owner, :billing])
+                       @conn.assigns[:current_team_role] in Plausible.Billing.allowed_roles())
                 }
                 class="hidden sm:block"
               >

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -44,7 +44,11 @@
                 </.styled_link>
               </li>
               <li
-                :if={ee?() and Plausible.Teams.on_trial?(@conn.assigns[:current_team])}
+                :if={
+                  ee?() and Plausible.Teams.on_trial?(@conn.assigns[:current_team]) and
+                    (not Plausible.Teams.setup?(@conn.assigns[:current_team]) or
+                       @conn.assigns[:current_team_role] in [:owner, :billing])
+                }
                 class="hidden sm:block"
               >
                 <div class="flex items-center p-1 rounded-lg bg-yellow-100 dark:bg-yellow-600/35 overflow-hidden">

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -13,7 +13,7 @@
       <.mobile_nav_dropdown
         name="settings"
         options={options}
-        selected_fn={&is_current_tab(@current_path, &1)}
+        selected_fn={&current_tab?(@current_path, &1)}
         href_base="/settings/"
       />
 
@@ -26,7 +26,7 @@
             </p>
           </div>
           <Layout.settings_sidebar
-            selected_fn={&is_current_tab(@current_path, &1)}
+            selected_fn={&current_tab?(@current_path, &1)}
             options={options["Account"]}
           />
         </div>
@@ -39,7 +39,7 @@
             </p>
           </div>
           <Layout.settings_sidebar
-            selected_fn={&is_current_tab(@current_path, &1)}
+            selected_fn={&current_tab?(@current_path, &1)}
             options={options["Team"]}
           />
         </div>

--- a/lib/plausible_web/templates/layout/site_settings.html.heex
+++ b/lib/plausible_web/templates/layout/site_settings.html.heex
@@ -18,13 +18,13 @@
         options={options}
         name="tab"
         href_base={"/#{URI.encode_www_form(@site.domain)}/settings/"}
-        selected_fn={&is_current_tab(@conn, &1)}
+        selected_fn={&current_tab?(@conn, &1)}
       />
 
       <div class="hidden lg:block py-4 sticky top-0" data-testid="site_settings_sidebar">
         <Layout.settings_sidebar
           prefix={"/#{URI.encode_www_form(@site.domain)}"}
-          selected_fn={&is_current_tab(@conn, &1)}
+          selected_fn={&current_tab?(@conn, &1)}
           options={options}
         />
       </div>

--- a/lib/plausible_web/templates/stats/site_locked.html.heex
+++ b/lib/plausible_web/templates/stats/site_locked.html.heex
@@ -29,7 +29,7 @@
           <p class="mt-4 text-gray-600 dark:text-gray-300 text-center text-sm">
             This shared link is locked because the owner of the site does not have access to the Shared Links feature. To restore it, the owner must upgrade to a suitable plan.
           </p>
-        <% %{site_role: role} when role in [:owner, :billing] -> %>
+        <% %{site_role: role} when role in Plausible.Billing.allowed_roles() -> %>
           <div class="mt-4 text-gray-600 dark:text-gray-300 text-center text-sm">
             <p>
               It looks like you don't have a valid subscription for this dashboard.

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -246,15 +246,15 @@ defmodule PlausibleWeb.LayoutView do
     render(layout, Map.put(assigns, :inner_layout, content))
   end
 
-  def is_current_tab(_, nil) do
+  def current_tab?(_, nil) do
     false
   end
 
-  def is_current_tab(path, tab) when is_binary(path) do
+  def current_tab?(path, tab) when is_binary(path) do
     String.ends_with?(path, tab)
   end
 
-  def is_current_tab(conn, tab) do
+  def current_tab?(conn, tab) do
     full_path = Path.join(conn.path_info)
 
     one_up =

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -6,6 +6,8 @@ defmodule PlausibleWeb.LayoutView do
   alias PlausibleWeb.Components.Billing.Notice
   alias PlausibleWeb.Components.Layout
 
+  require Plausible.Billing
+
   def plausible_url do
     PlausibleWeb.Endpoint.url()
   end
@@ -123,7 +125,7 @@ defmodule PlausibleWeb.LayoutView do
         "Team",
         [
           %{key: "General", value: "team/general", icon: :adjustments_horizontal},
-          if(ee?() and current_team_role in [:owner, :billing],
+          if(ee?() and current_team_role in Plausible.Billing.allowed_roles(),
             do: %{key: "Subscription", value: "billing/subscription", icon: :subscription}
           ),
           if(current_team_role in [:owner, :billing, :admin, :editor],

--- a/lib/plausible_web/views/stats_view.ex
+++ b/lib/plausible_web/views/stats_view.ex
@@ -2,6 +2,8 @@ defmodule PlausibleWeb.StatsView do
   use PlausibleWeb, :view
   use Plausible
 
+  require Plausible.Billing
+
   def plausible_url do
     PlausibleWeb.Endpoint.url()
   end

--- a/test/plausible_web/controllers/settings_controller_test.exs
+++ b/test/plausible_web/controllers/settings_controller_test.exs
@@ -585,6 +585,91 @@ defmodule PlausibleWeb.SettingsControllerTest do
         assert element_exists?(html, "[data-test-id='total-pageviews-dashboard-link']")
       end
     end
+
+    @tag :ee_only
+    test "allows owner of a setup team to access the page", %{conn: conn, user: user} do
+      team = new_user(team: [setup_complete: true]) |> team_of()
+      add_member(team, user: user, role: :owner)
+
+      conn =
+        conn
+        |> set_current_team(team)
+        |> get(Routes.settings_path(conn, :subscription))
+
+      assert html_response(conn, 200)
+    end
+
+    @tag :ee_only
+    test "allows billing role of a setup team to access the page", %{conn: conn, user: user} do
+      owner = new_user(team: [setup_complete: true])
+      team = team_of(owner)
+      add_member(team, user: user, role: :billing)
+
+      conn =
+        conn
+        |> set_current_team(team)
+        |> get(Routes.settings_path(conn, :subscription))
+
+      assert html_response(conn, 200)
+    end
+
+    @tag :ee_only
+    test "redirects admin role of a setup team away from the page", %{conn: conn, user: user} do
+      owner = new_user(team: [setup_complete: true])
+      team = team_of(owner)
+      add_member(team, user: user, role: :admin)
+
+      conn =
+        conn
+        |> set_current_team(team)
+        |> get(Routes.settings_path(conn, :subscription))
+
+      assert redirected_to(conn, 302) == Routes.site_path(conn, :index)
+    end
+
+    @tag :ee_only
+    test "redirects editor role of a setup team away from the page", %{conn: conn, user: user} do
+      owner = new_user(team: [setup_complete: true])
+      team = team_of(owner)
+      add_member(team, user: user, role: :editor)
+
+      conn =
+        conn
+        |> set_current_team(team)
+        |> get(Routes.settings_path(conn, :subscription))
+
+      assert redirected_to(conn, 302) == Routes.site_path(conn, :index)
+    end
+
+    @tag :ee_only
+    test "redirects viewer role of a setup team away from the page", %{conn: conn, user: user} do
+      owner = new_user(team: [setup_complete: true])
+      team = team_of(owner)
+      add_member(team, user: user, role: :viewer)
+
+      conn =
+        conn
+        |> set_current_team(team)
+        |> get(Routes.settings_path(conn, :subscription))
+
+      assert redirected_to(conn, 302) == Routes.site_path(conn, :index)
+    end
+
+    test "allows any role on a non-setup (personal) team to access the page", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+
+      refute Plausible.Teams.setup?(team)
+
+      conn =
+        conn
+        |> set_current_team(team)
+        |> get(Routes.settings_path(conn, :subscription))
+
+      assert html_response(conn, 200)
+    end
   end
 
   describe "GET /security" do

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -214,6 +214,84 @@ defmodule PlausibleWeb.SiteControllerTest do
       assert resp =~ nag_message
     end
 
+    @tag :ee_only
+    test "shows upgrade button in header when user is on trial and team is not setup",
+         %{conn: conn, user: user} do
+      new_site(owner: user)
+
+      conn = get(conn, "/sites")
+      resp = html_response(conn, 200)
+
+      assert element_exists?(
+               resp,
+               ~s|a[href="#{Routes.settings_path(conn, :subscription)}"]|
+             )
+
+      assert text_of_element(
+               resp,
+               ~s|a[href="#{Routes.settings_path(conn, :subscription)}"]|
+             ) =~ "Upgrade"
+    end
+
+    @tag :ee_only
+    test "shows upgrade button in header when user is on trial and is owner of a setup team",
+         %{conn: conn, user: user} do
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+      team = Plausible.Teams.complete_setup(team)
+      conn = set_current_team(conn, team)
+
+      conn = get(conn, "/sites")
+      resp = html_response(conn, 200)
+
+      assert element_exists?(
+               resp,
+               ~s|a[href="#{Routes.settings_path(conn, :subscription)}"]|
+             )
+    end
+
+    @tag :ee_only
+    test "shows upgrade button in header when user is on trial and has billing role in a setup team",
+         %{conn: base_conn} do
+      member = new_user()
+      owner = new_user(trial_expiry_date: Date.add(Date.utc_today(), 30))
+      {:ok, team} = Plausible.Teams.get_or_create(owner)
+      team = Plausible.Teams.complete_setup(team)
+      add_member(team, user: member, role: :billing)
+
+      {:ok, conn: conn} = log_in(%{user: member, conn: base_conn})
+      conn = set_current_team(conn, team)
+
+      conn = get(conn, "/sites")
+      resp = html_response(conn, 200)
+
+      assert element_exists?(
+               resp,
+               ~s|a[href="#{Routes.settings_path(conn, :subscription)}"]|
+             )
+    end
+
+    @tag :ee_only
+    test "does not show upgrade button in header when user is on trial but has non-billing role in a setup team",
+         %{conn: base_conn} do
+      for role <- [:admin, :editor, :viewer] do
+        member = new_user()
+        owner = new_user()
+        {:ok, team} = Plausible.Teams.get_or_create(owner)
+        team = Plausible.Teams.complete_setup(team)
+        add_member(team, user: member, role: role)
+
+        {:ok, conn: conn} = log_in(%{user: member, conn: base_conn})
+        conn = set_current_team(conn, team)
+        resp = conn |> get("/sites") |> html_response(200)
+
+        refute element_exists?(
+                 resp,
+                 ~s|a[href="#{Routes.settings_path(conn, :subscription)}"]|
+               ),
+               "expected no Upgrade button for role #{role}"
+      end
+    end
+
     test "filters by domain", %{conn: conn, user: user} do
       _site1 = new_site(domain: "alpha.example.com", owner: user)
       _site2 = new_site(domain: "beta.example.com", owner: user)

--- a/test/support/dev/controllers/dev_subscription_controller.ex
+++ b/test/support/dev/controllers/dev_subscription_controller.ex
@@ -9,9 +9,11 @@ defmodule PlausibleWeb.DevSubscriptionController do
     alias Plausible.Teams.Team
     alias Plausible.Teams
 
+    require Plausible.Billing
+
     plug PlausibleWeb.RequireAccountPlug
 
-    plug Plausible.Plugs.AuthorizeTeamAccess, [:owner, :billing]
+    plug Plausible.Plugs.AuthorizeTeamAccess, Plausible.Billing.allowed_roles()
 
     def create_form(conn, %{"plan_id" => plan_id}) do
       render(conn, "create_dev_subscription.html",


### PR DESCRIPTION
### Changes

The prominent "Upgrade" button rendered on every page, should be only visible to `:owner` and `:billing` roles in case of set up teams. Similarly, the subscription settings LV should be only accessible directly only for these roles. No such restrictions apply to personal teams.

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
