### PR TITLE
fix graph for brave, chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - Fixed top bar not scrolling horizontally on mobile
 - Fixed incline/decline percentages not showing in top stats in comparison mode
 - Fixed issue with timestamps being rendered incorrectly in segment menus and modals for some timezones
+- Fixed main graph being clipped when the browser's root font size is smaller than the default 16px
 
 ## v3.2.0 - 2026-01-16
 

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -547,7 +547,11 @@ export const MainGraphContainer = React.forwardRef<
   { children: ReactNode }
 >((props, ref) => {
   return (
-    <div className="relative mt-4 mb-3 h-92 w-full" ref={ref}>
+    <div
+      className="relative mt-4 mb-3 w-full"
+      style={{ height: `${height}px` }}
+      ref={ref}
+    >
       {props.children}
     </div>
   )


### PR DESCRIPTION
### Changes

Main graph being clipped when the browser's root font size is smaller than the default 16px

in Brave and Chromium (maybe other browsers too) the Graph looked like this: 
<img width="991" height="475" alt="image" src="https://github.com/user-attachments/assets/1d2a53ae-f1f4-4cf5-b480-578bdeacda7e" />

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
