### PR TITLE
Add non-catch-all version of dashboard route

### DIFF
--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -734,6 +734,7 @@ defmodule PlausibleWeb.Router do
       put "/:domain/settings", SiteController, :update_settings
 
       get "/:domain/export", StatsController, :csv_export
+      get "/:domain", StatsController, :stats
       get "/:domain/*path", StatsController, :stats
     end
   end

--- a/test/plausible_web/components/billing/billing_test.exs
+++ b/test/plausible_web/components/billing/billing_test.exs
@@ -330,7 +330,7 @@ defmodule PlausibleWeb.Components.BillingTest do
         )
 
       assert element_exists?(html, "[data-test-id='total-pageviews-dashboard-link']")
-      assert html =~ "/my-site.example.com/?period=custom"
+      assert html =~ "/my-site.example.com?period=custom"
     end
 
     test "renders no total link when no domain is provided" do
@@ -354,8 +354,8 @@ defmodule PlausibleWeb.Components.BillingTest do
 
       html = render_monthly_pageview_usage(usage, 10_000)
 
-      assert html =~ "/example.com/?period=custom"
-      assert html =~ "/app.example.com/?period=custom"
+      assert html =~ "/example.com?period=custom"
+      assert html =~ "/app.example.com?period=custom"
     end
 
     test "dashboard links include the billing cycle date range" do
@@ -367,7 +367,7 @@ defmodule PlausibleWeb.Components.BillingTest do
         )
 
       assert html =~
-               "/my-site.example.com/?period=custom&amp;from=2024-01-01&amp;to=2024-01-31"
+               "/my-site.example.com?period=custom&amp;from=2024-01-01&amp;to=2024-01-31"
     end
   end
 

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -140,7 +140,8 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
 
       conn = post(conn, "/sites/invitations/#{transfer.transfer_id}/accept")
 
-      assert redirected_to(conn, 302) == "/#{URI.encode_www_form(site.domain)}/"
+      assert redirected_to(conn, 302) ==
+               Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :success) =~
                "You now have access to"

--- a/test/plausible_web/controllers/invitation_controller_test.exs
+++ b/test/plausible_web/controllers/invitation_controller_test.exs
@@ -20,7 +20,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :success) ==
                "You now have access to #{site.domain}"
 
-      assert redirected_to(conn) == "/#{URI.encode_www_form(site.domain)}/"
+      assert redirected_to(conn) == Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain)
 
       refute Repo.exists?(from(i in Plausible.Teams.Invitation, where: i.email == ^user.email))
 
@@ -53,7 +53,7 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
       invitation = invite_guest(site, user.email, role: :editor, inviter: owner)
 
       c1 = post(conn, "/sites/invitations/#{invitation.invitation_id}/accept")
-      assert redirected_to(c1) == "/#{URI.encode_www_form(site.domain)}/"
+      assert redirected_to(c1) == Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain)
 
       assert Phoenix.Flash.get(c1.assigns.flash, :success) ==
                "You now have access to #{site.domain}"
@@ -78,7 +78,8 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
 
       conn = post(conn, "/sites/invitations/#{transfer.transfer_id}/accept")
 
-      assert redirected_to(conn, 302) == "/#{URI.encode_www_form(site.domain)}/"
+      assert redirected_to(conn, 302) ==
+               Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :success) =~
                "You now have access to"
@@ -209,7 +210,8 @@ defmodule PlausibleWeb.Site.InvitationControllerTest do
           "/sites/invitations/#{transfer.transfer_id}/accept?skip_site_members_transfer=true"
         )
 
-      assert redirected_to(conn, 302) == "/#{URI.encode_www_form(site.domain)}/"
+      assert redirected_to(conn, 302) ==
+               Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain)
 
       assert Phoenix.Flash.get(conn.assigns.flash, :success) =~
                "You now have access to"

--- a/test/plausible_web/controllers/site_controller_test.exs
+++ b/test/plausible_web/controllers/site_controller_test.exs
@@ -638,7 +638,7 @@ defmodule PlausibleWeb.SiteControllerTest do
             }
           })
 
-        assert redirected_to(conn) == "/example.com/"
+        assert redirected_to(conn) == "/example.com"
       end
     end
 

--- a/test/plausible_web/live/customer_support/sites_test.exs
+++ b/test/plausible_web/live/customer_support/sites_test.exs
@@ -28,7 +28,10 @@ defmodule PlausibleWeb.Live.CustomerSupport.SitesTest do
                  ~s|a[href$="#{URI.encode_www_form(site.domain)}/settings/general"]|
                )
 
-        assert element_exists?(html, ~s|a[href="/#{URI.encode_www_form(site.domain)}/"]|)
+        assert element_exists?(
+                 html,
+                 ~s|a[href="#{Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain)}"]|
+               )
       end
 
       test "404", %{conn: conn} do

--- a/test/plausible_web/live/customer_support/teams_test.exs
+++ b/test/plausible_web/live/customer_support/teams_test.exs
@@ -178,7 +178,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.TeamsTest do
         html = render(lv)
         text = text(html)
 
-        assert element_exists?(html, ~s|a[href="/primary.example.com%2Ftest/"]|)
+        assert element_exists?(html, ~s|a[href="/primary.example.com%2Ftest"]|)
         assert element_exists?(html, ~s|a[href="/primary.example.com%2Ftest/settings/general"]|)
 
         assert text =~ "primary.example.com/test"

--- a/test/plausible_web/live/verification_test.exs
+++ b/test/plausible_web/live/verification_test.exs
@@ -195,7 +195,7 @@ defmodule PlausibleWeb.Live.VerificationTest do
         build(:pageview)
       ])
 
-      assert_redirect(lv, "/#{URI.encode_www_form(site.domain)}/")
+      assert_redirect(lv, Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain))
     end
 
     @tag :ce_build_only

--- a/test/plausible_web/live/verification_test.exs
+++ b/test/plausible_web/live/verification_test.exs
@@ -207,7 +207,7 @@ defmodule PlausibleWeb.Live.VerificationTest do
 
       populate_stats(site, [build(:pageview)])
 
-      assert_redirect(lv, "/#{URI.encode_www_form(site.domain)}/")
+      assert_redirect(lv, Routes.stats_path(PlausibleWeb.Endpoint, :stats, site.domain))
     end
 
     for {installation_type_param, expected_text, saved_installation_type} <- [


### PR DESCRIPTION
Currently dashboard links are generated with trailing slash across the application. This PR adds a route without the catch-all part which affects the router helpers so the link is generated without the trailing slash as shown here:

```
iex(6)> PlausibleWeb.Router.Helpers.stats_path(PlausibleWeb.Endpoint, :stats, "plausible.io", [])
"/plausible.io/"
iex(7)> r PlausibleWeb.Router
{:reloaded, [PlausibleWeb.Router, PlausibleWeb.Router.Helpers]}
iex(8)> PlausibleWeb.Router.Helpers.stats_path(PlausibleWeb.Endpoint, :stats, "plausible.io", [])
"/plausible.io"
```

The trailing slash appears in live demo stats, this is an attempt to suppress it.
<img width="559" height="234" alt="Screenshot 2026-05-07 at 14 15 05" src="https://github.com/user-attachments/assets/30f489bf-3d4b-41ab-9f73-ffd7d2830720" />
