### PR TITLE
Fix issue with billing role not being able to create personal segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - Fixed incline/decline percentages not showing in top stats in comparison mode
 - Fixed issue with timestamps being rendered incorrectly in segment menus and modals for some timezones
 - Fixed main graph being clipped when the browser's root font size is smaller than the default 16px
+- Fixed issue with users with billing role not being able to create personal segments
 
 ## v3.2.0 - 2026-01-16
 

--- a/lib/plausible/segments/segments.ex
+++ b/lib/plausible/segments/segments.ex
@@ -31,7 +31,7 @@ defmodule Plausible.Segments do
            )
          )}
 
-      site_role in @roles_with_personal_segments or site_role in @roles_with_maybe_site_segments ->
+      site_role in roles_with_personal_segments() or site_role in roles_with_maybe_site_segments() ->
         fields = fields ++ [:owner_id]
 
         {:ok,
@@ -456,8 +456,8 @@ defmodule Plausible.Segments do
     |> Plausible.Times.to_naive_datetime!(timezone)
   end
 
-  def roles_with_personal_segments(), do: [:viewer, :editor, :admin, :owner, :super_admin]
-  def roles_with_maybe_site_segments(), do: [:editor, :admin, :owner, :super_admin]
+  def roles_with_personal_segments(), do: @roles_with_personal_segments
+  def roles_with_maybe_site_segments(), do: @roles_with_maybe_site_segments
 
   def site_segments_available?(%Plausible.Site{} = site),
     do: Plausible.Billing.Feature.SiteSegments.check_availability(site.team) == :ok

--- a/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/segments_controller_test.exs
@@ -80,15 +80,29 @@ defmodule PlausibleWeb.Api.Internal.SegmentsControllerTest do
              ) == 500
     end
 
-    for %{role: role, type: type} <- [
-          %{role: :viewer, type: :personal},
-          %{role: :editor, type: :personal},
-          %{role: :editor, type: :site}
+    for %{role: role, type: type, membership_type: membership_type} <- [
+          %{membership_type: :site_guest, role: :viewer, type: :personal},
+          %{membership_type: :site_guest, role: :editor, type: :personal},
+          %{membership_type: :site_guest, role: :editor, type: :site},
+          %{membership_type: :team_member, role: :viewer, type: :personal},
+          %{membership_type: :team_member, role: :billing, type: :personal},
+          %{membership_type: :team_member, role: :editor, type: :personal},
+          %{membership_type: :team_member, role: :editor, type: :site},
+          %{membership_type: :team_member, role: :admin, type: :personal},
+          %{membership_type: :team_member, role: :admin, type: :site},
+          %{membership_type: :team_member, role: :owner, type: :personal},
+          %{membership_type: :team_member, role: :owner, type: :site}
         ] do
-      test "#{role} can create segment with type \"#{type}\" successfully",
+      test "#{role} (#{Phoenix.Naming.humanize(membership_type)}) can create segment with type \"#{type}\" successfully",
            %{conn: conn, user: user} do
         site = new_site()
-        add_guest(site, user: user, role: unquote(role))
+
+        add_site_guest_or_team_member(site,
+          user: user,
+          role: unquote(role),
+          membership_type: unquote(membership_type)
+        )
+
         insert(:goal, site: site, event_name: "Conversion")
 
         response =


### PR DESCRIPTION
### Changes

Noticed a small bug when testing https://github.com/plausible/analytics/pull/6326. This PR allows users with billing role to create personal segments.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
