### PR TITLE
One liner regression fix: wrap IndexBreakdown dimension cell text on mobile

### DIFF
--- a/assets/js/dashboard/stats/reports/index-breakdown.tsx
+++ b/assets/js/dashboard/stats/reports/index-breakdown.tsx
@@ -567,7 +567,7 @@ export function IndexBreakdownRenderer({
                       key={col.key}
                       className={classNames(
                         col.width ?? 'grow w-full',
-                        col.align === 'right' ? 'text-right' : 'truncate'
+                        col.align === 'right' ? 'text-right' : 'md:truncate'
                       )}
                     >
                       {col.renderCell(row, isActive)}


### PR DESCRIPTION
### Changes

Do not apply the `truncate` class on mobile in IndexBreakdowns. Text should wrap on multiple lines as it did before (and does in other legacy ListReports).

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
