### PR TITLE
Return explicit journey end event

### DIFF
--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -104,7 +104,7 @@ function stepsToJourneyParam(steps) {
   )
 }
 
-function parseFetchedResults(results) {
+function maybeEmptyResults(results) {
   if (
     results.length === 0 ||
     (results.length === 1 && results[0].step.name === JOURNEY_END_EVENT)
@@ -820,7 +820,7 @@ function useExplorationData(site, dashboardState, inViewport) {
                 if (!isStale())
                   setState((prev) => ({
                     ...prev,
-                    activeResults: parseFetchedResults(r?.next ?? []),
+                    activeResults: maybeEmptyResults(r?.next ?? []),
                     rateLimited: false
                   }))
               })
@@ -865,7 +865,7 @@ function useExplorationData(site, dashboardState, inViewport) {
               if (!isStale())
                 setState((prev) => ({
                   ...prev,
-                  activeResults: parseFetchedResults(r?.next ?? []),
+                  activeResults: maybeEmptyResults(r?.next ?? []),
                   rateLimited: false
                 }))
             })
@@ -916,7 +916,7 @@ function useExplorationData(site, dashboardState, inViewport) {
         setState((prev) => {
           const next = {
             ...prev,
-            activeResults: parseFetchedResults(response?.next ?? []),
+            activeResults: maybeEmptyResults(response?.next ?? []),
             rateLimited: false
           }
           if (includeFunnel) {

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -105,11 +105,9 @@ function stepsToJourneyParam(steps) {
 }
 
 function parseFetchedResults(results) {
-  if (results.length === 0) {
-    return []
-  } else if (
-    results.length === 1 &&
-    results[0].step.name === JOURNEY_END_EVENT
+  if (
+    results.length === 0 ||
+    (results.length === 1 && results[0].step.name === JOURNEY_END_EVENT)
   ) {
     return []
   } else {

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -102,6 +102,19 @@ function stepsToJourneyParam(steps) {
   )
 }
 
+function parseFetchedResults(results) {
+  if (results.length === 0) {
+    return []
+  } else if (
+    results.length === 1 &&
+    results[0].step.name === '__journey_end__'
+  ) {
+    return []
+  } else {
+    return results
+  }
+}
+
 // Keep only entries with index < fromIndex, discarding everything at or after.
 // Used to truncate frozen candidate snapshots when the journey is shortened.
 function truncateFrozenAt(frozen, fromIndex) {
@@ -801,7 +814,7 @@ function useExplorationData(site, dashboardState, inViewport) {
                 if (!isStale())
                   setState((prev) => ({
                     ...prev,
-                    activeResults: r?.next ?? [],
+                    activeResults: parseFetchedResults(r?.next ?? []),
                     rateLimited: false
                   }))
               })
@@ -846,7 +859,7 @@ function useExplorationData(site, dashboardState, inViewport) {
               if (!isStale())
                 setState((prev) => ({
                   ...prev,
-                  activeResults: r?.next ?? [],
+                  activeResults: parseFetchedResults(r?.next ?? []),
                   rateLimited: false
                 }))
             })
@@ -897,7 +910,7 @@ function useExplorationData(site, dashboardState, inViewport) {
         setState((prev) => {
           const next = {
             ...prev,
-            activeResults: response?.next ?? [],
+            activeResults: parseFetchedResults(response?.next ?? []),
             rateLimited: false
           }
           if (includeFunnel) {

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -104,10 +104,12 @@ function stepsToJourneyParam(steps) {
   )
 }
 
-function maybeEmptyResults(results) {
+function maybeEmptyResults(results, activeFilter) {
   if (
     results.length === 0 ||
-    (results.length === 1 && results[0].step.name === JOURNEY_END_EVENT)
+    (!activeFilter &&
+      results.length === 1 &&
+      results[0].step.name === JOURNEY_END_EVENT)
   ) {
     return []
   } else {
@@ -820,7 +822,10 @@ function useExplorationData(site, dashboardState, inViewport) {
                 if (!isStale())
                   setState((prev) => ({
                     ...prev,
-                    activeResults: maybeEmptyResults(r?.next ?? []),
+                    activeResults: maybeEmptyResults(
+                      r?.next ?? [],
+                      prev.activeFilter
+                    ),
                     rateLimited: false
                   }))
               })
@@ -865,7 +870,10 @@ function useExplorationData(site, dashboardState, inViewport) {
               if (!isStale())
                 setState((prev) => ({
                   ...prev,
-                  activeResults: maybeEmptyResults(r?.next ?? []),
+                  activeResults: maybeEmptyResults(
+                    r?.next ?? [],
+                    prev.activeFilter
+                  ),
                   rateLimited: false
                 }))
             })
@@ -916,7 +924,10 @@ function useExplorationData(site, dashboardState, inViewport) {
         setState((prev) => {
           const next = {
             ...prev,
-            activeResults: maybeEmptyResults(response?.next ?? []),
+            activeResults: maybeEmptyResults(
+              response?.next ?? [],
+              prev.activeFilter
+            ),
             rateLimited: false
           }
           if (includeFunnel) {

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -367,7 +367,8 @@ function CandidateCard({
   colIndex,
   onSelect
 }) {
-  const isCustomEvent = step.name !== 'pageview'
+  const isJourneyEnd = step.name === '__journey_end__'
+  const isCustomEvent = step.name !== 'pageview' && step.name !== '__journey_end__'
   const isGoal = step.is_goal
 
   const visitorsToShow =
@@ -395,12 +396,16 @@ function CandidateCard({
     ? 'bg-gray-100/60 dark:bg-gray-850'
     : 'hover:bg-gray-100/60 dark:hover:bg-gray-850'
 
+  const pointer = isJourneyEnd ? 'pointer-events-none' : ''
+
+  const onSelectHandler = isJourneyEnd ? () => {} : onSelect
+
   return (
     <li>
       <button
         data-exploration-step={isSelected ? colIndex : undefined}
-        className={`group relative w-full text-left text-sm rounded-sm overflow-hidden focus:outline-none ${rowBg}`}
-        onClick={() => onSelect(isSelected ? null : step)}
+        className={`group relative w-full text-left text-sm rounded-sm overflow-hidden focus:outline-none ${rowBg} ${pointer}`}
+        onClick={() => onSelectHandler(isSelected ? null : step)}
       >
         <div
           className={`absolute top-0 left-0 h-full rounded-sm transition-[width] ease-in-out ${barBg}`}

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -22,6 +22,8 @@ import { ChevronUpDownIcon, ChevronRightIcon } from '@heroicons/react/20/solid'
 import { FlagIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import { popover } from '../components/popover'
 
+const JOURNEY_END_EVENT = '__journey_end__'
+
 const DIRECTION = { FORWARD: 'forward', BACKWARD: 'backward' }
 
 const DIRECTION_OPTIONS = [
@@ -107,7 +109,7 @@ function parseFetchedResults(results) {
     return []
   } else if (
     results.length === 1 &&
-    results[0].step.name === '__journey_end__'
+    results[0].step.name === JOURNEY_END_EVENT
   ) {
     return []
   } else {
@@ -367,8 +369,9 @@ function CandidateCard({
   colIndex,
   onSelect
 }) {
-  const isJourneyEnd = step.name === '__journey_end__'
-  const isCustomEvent = step.name !== 'pageview' && step.name !== '__journey_end__'
+  const isJourneyEnd = step.name === JOURNEY_END_EVENT
+  const isCustomEvent =
+    step.name !== 'pageview' && step.name !== JOURNEY_END_EVENT
   const isGoal = step.is_goal
 
   const visitorsToShow =

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -143,7 +143,7 @@ defmodule Plausible.Stats.Exploration do
            query,
            [],
            [],
-           MapSet.new(),
+           MapSet.new([{Journey.Step.journey_end_event(), ""}]),
            max_steps,
            max_candidates,
            include_wildcard?
@@ -241,7 +241,6 @@ defmodule Plausible.Stats.Exploration do
 
     q_matches =
       from(s in subquery(q_steps),
-        where: selected_as(:name) != "",
         select: %{
           user_id: s.user_id,
           name: selected_as(field(s, ^next_name), :name),
@@ -286,8 +285,12 @@ defmodule Plausible.Stats.Exploration do
     from(m in subquery(q_all_combined_matches),
       select: %{
         step: %Journey.Step{
-          label: selected_as(m.label, :label),
-          name: m.name,
+          label:
+            selected_as(
+              fragment("if(? != '', ?, ?)", m.name, m.label, ^Journey.Step.journey_end_label()),
+              :label
+            ),
+          name: fragment("if(? != '', ?, ?)", m.name, m.name, ^Journey.Step.journey_end_event()),
           pathname: m.pathname,
           includes_subpaths: m.includes_subpaths,
           subpaths_count: m.subpaths_count,

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -7,9 +7,9 @@ defmodule Plausible.Stats.Exploration do
   import Plausible.Stats.SQL.Fragments
   import Plausible.Stats.Util, only: [percentage: 2]
 
-  alias Plausible.Stats.Exploration.Journey
   alias Plausible.ClickhouseRepo
   alias Plausible.Stats.Base
+  alias Plausible.Stats.Exploration.Journey
   alias Plausible.Stats.Filters
   alias Plausible.Stats.Query
 

--- a/extra/lib/plausible/stats/journey/step.ex
+++ b/extra/lib/plausible/stats/journey/step.ex
@@ -12,6 +12,15 @@ defmodule Plausible.Stats.Exploration.Journey.Step do
             subpaths_count: 0,
             is_goal: false
 
+  @journey_end_event "__journey_end__"
+  @journey_end_label "no further action"
+
+  @spec journey_end_event() :: String.t()
+  def journey_end_event, do: @journey_end_event
+
+  @spec journey_end_label() :: String.t()
+  def journey_end_label, do: @journey_end_label
+
   @spec from(map()) :: t()
   def from(step) do
     new(step.name, step.pathname, step.includes_subpaths, step.subpaths_count, step.is_goal)
@@ -21,10 +30,15 @@ defmodule Plausible.Stats.Exploration.Journey.Step do
   def new(name, pathname, includes_subpaths \\ false, subpaths_count \\ 0, is_goal \\ false)
       when is_boolean(includes_subpaths) and is_integer(subpaths_count) do
     label =
-      if name != "pageview" do
-        name
-      else
-        pathname
+      cond do
+        name == @journey_end_event ->
+          @journey_end_label
+
+        name != "pageview" ->
+          name
+
+        true ->
+          pathname
       end
 
     %__MODULE__{

--- a/lib/plausible/goal.ex
+++ b/lib/plausible/goal.ex
@@ -1,9 +1,16 @@
 defmodule Plausible.Goal do
   use Plausible
   use Ecto.Schema
+
   import Ecto.Changeset
 
   @type t() :: %__MODULE__{}
+
+  on_ee do
+    @journey_end_event Plausible.Stats.Exploration.Journey.Step.journey_end_event()
+  else
+    @journey_end_event nil
+  end
 
   schema "goals" do
     field :event_name, :string
@@ -152,6 +159,10 @@ defmodule Plausible.Goal do
     cond do
       value == "engagement" ->
         {:error, "The event name 'engagement' is reserved and cannot be used as a goal"}
+
+      not is_nil(@journey_end_event) and value == @journey_end_event ->
+        {:error,
+         "The event name '#{@journey_end_event}' is reserved and cannot be used as a goal"}
 
       value && String.match?(value, ~r/^.+/) ->
         :ok

--- a/lib/plausible/goal.ex
+++ b/lib/plausible/goal.ex
@@ -1,4 +1,8 @@
 defmodule Plausible.Goal do
+  @moduledoc """
+  Goal schema.
+  """
+
   use Plausible
   use Ecto.Schema
 

--- a/lib/plausible/goal.ex
+++ b/lib/plausible/goal.ex
@@ -164,7 +164,7 @@ defmodule Plausible.Goal do
       value == "engagement" ->
         {:error, "The event name 'engagement' is reserved and cannot be used as a goal"}
 
-      not is_nil(@journey_end_event) and value == @journey_end_event ->
+      journey_end_event?(value) ->
         {:error,
          "The event name '#{@journey_end_event}' is reserved and cannot be used as a goal"}
 
@@ -237,6 +237,14 @@ defmodule Plausible.Goal do
       true ->
         []
     end
+  end
+
+  on_ee do
+    defp journey_end_event?(name) do
+      name == @journey_end_event
+    end
+  else
+    defp journey_end_event?(_name), do: always(false)
   end
 end
 

--- a/test/plausible/goals_test.exs
+++ b/test/plausible/goals_test.exs
@@ -346,6 +346,17 @@ defmodule Plausible.GoalsTest do
   end
 
   on_ee do
+    @journey_end_event Plausible.Stats.Exploration.Journey.Step.journey_end_event()
+
+    test "create/2 fails to create a goal with '#{@journey_end_event}' as event_name (reserved)" do
+      site = new_site()
+      assert {:error, changeset} = Goals.create(site, %{"event_name" => @journey_end_event})
+
+      assert {"The event name '#{@journey_end_event}' is reserved and cannot be used as a goal",
+              _} =
+               changeset.errors[:event_name]
+    end
+
     test "create/2 sets site.updated_at for revenue goal" do
       site_1 = new_site(updated_at: DateTime.add(DateTime.utc_now(), -3600))
 

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -6,6 +6,9 @@ defmodule Plausible.Stats.ExplorationTest do
     alias Plausible.Stats.Exploration
     alias Plausible.Stats.QueryBuilder
 
+    @journey_end_event Exploration.Journey.Step.journey_end_event()
+    @journey_end_label Exploration.Journey.Step.journey_end_label()
+
     setup do
       site = new_site()
 
@@ -720,6 +723,7 @@ defmodule Plausible.Stats.ExplorationTest do
 
         assert {:ok,
                 [
+                  %{step: %{name: @journey_end_event}},
                   %{step: %{pathname: "/:dashboard"}}
                 ]} =
                  Exploration.next_steps(site, query, journey,
@@ -1166,9 +1170,12 @@ defmodule Plausible.Stats.ExplorationTest do
           }
         ]
 
-        assert {:ok, [next_step]} = Exploration.next_steps(site, query, journey)
+        assert {:ok, [next_step1, next_step2]} = Exploration.next_steps(site, query, journey)
 
-        assert next_step.step.label == "/a-blog"
+        assert next_step1.step.label == @journey_end_label
+        assert next_step1.visitors == 2
+        assert next_step2.step.label == "/a-blog"
+        assert next_step2.visitors == 1
       end
 
       test "suggestions matching goal pattern from previous step are excluded" do
@@ -1231,9 +1238,12 @@ defmodule Plausible.Stats.ExplorationTest do
           }
         ]
 
-        assert {:ok, [next_step]} = Exploration.next_steps(site, query, journey)
+        assert {:ok, [next_step1, next_step2]} = Exploration.next_steps(site, query, journey)
 
-        assert next_step.step.label == "/blog"
+        assert next_step1.step.label == @journey_end_label
+        assert next_step1.visitors == 3
+        assert next_step2.step.label == "/blog"
+        assert next_step2.visitors == 1
       end
     end
 

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -575,6 +575,67 @@ defmodule Plausible.Stats.ExplorationTest do
         assert next_step.visitors == 1
       end
 
+      test "allows to filter by journey end event label" do
+        site = new_site()
+        now = DateTime.utc_now()
+
+        populate_stats(site, [
+          build(:pageview,
+            user_id: 123,
+            pathname: "/home",
+            timestamp: DateTime.shift(now, minute: -50)
+          ),
+          build(:pageview,
+            user_id: 123,
+            pathname: "/login",
+            timestamp: DateTime.shift(now, minute: -40)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/home",
+            timestamp: DateTime.shift(now, minute: -30)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/login",
+            timestamp: DateTime.shift(now, minute: -20)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/dashboard",
+            timestamp: DateTime.shift(now, minute: -10)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/home",
+            timestamp: DateTime.shift(now, minute: -50)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/login",
+            timestamp: DateTime.shift(now, minute: -40)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/dashboard",
+            timestamp: DateTime.shift(now, minute: -30)
+          )
+        ])
+
+        query = QueryBuilder.build!(site, input_date_range: :all)
+
+        journey = [
+          %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
+          %Exploration.Journey.Step{name: "pageview", pathname: "/login"}
+        ]
+
+        assert {:ok, [next_step]} =
+                 Exploration.next_steps(site, query, journey, search_term: "no further")
+
+        assert next_step.step.label == "no further action"
+        assert next_step.visitors == 1
+      end
+
       test "includes root path (/) in suggestions" do
         site = new_site()
 

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -664,6 +664,40 @@ defmodule Plausible.Stats.ExplorationTest do
         assert next_step2.visitors == 1
       end
 
+      test "there can be multiple journey suggestions for a single user/session" do
+        site = new_site()
+
+        now = DateTime.utc_now()
+
+        ago = fn ms -> DateTime.shift(now, minute: -1 * ms) end
+
+        populate_stats(site, [
+          build(:pageview, user_id: 123, pathname: "/home", timestamp: ago.(100)),
+          build(:pageview, user_id: 123, pathname: "/login", timestamp: ago.(99)),
+          build(:pageview, user_id: 123, pathname: "/dashboard", timestamp: ago.(98)),
+          build(:pageview, user_id: 123, pathname: "/home", timestamp: ago.(97)),
+          build(:pageview, user_id: 123, pathname: "/login", timestamp: ago.(96)),
+          build(:pageview, user_id: 123, pathname: "/sites", timestamp: ago.(95))
+        ])
+
+        journey = [
+          %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
+          %Exploration.Journey.Step{name: "pageview", pathname: "/login"}
+        ]
+
+        query = QueryBuilder.build!(site, input_date_range: :all)
+
+        assert {:ok,
+                [
+                  %{step: %{pathname: "/dashboard"}, visitors: 1},
+                  %{step: %{pathname: "/sites"}, visitors: 1}
+                ]} =
+                 Exploration.next_steps(site, query, journey,
+                   search_term: "",
+                   direction: :forward
+                 )
+      end
+
       test "does not suggest the same path/pathname as in previous step (regression test)" do
         site = new_site()
 


### PR DESCRIPTION
### Changes

This PR implements explicit listing of journey end. It's currently displayed like any other item among the suggestions, subject to the same sorting order and limit of number of displayed entries (if it's small enough, it won't make it to the list).

The visual representation might be improved in follow-up work (dedicated icon? some behavior on click?).

<img width="1162" height="610" alt="image" src="https://github.com/user-attachments/assets/e5a393a0-95b6-494d-99ca-decb6a815661" />

### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests



