### PR TITLE
Fix realtime top stats in limited to segment shared link

### DIFF
--- a/assets/js/dashboard/stats/graph/fetch-top-stats.test.ts
+++ b/assets/js/dashboard/stats/graph/fetch-top-stats.test.ts
@@ -325,7 +325,7 @@ describe(`${topStatsQueries.name}`, () => {
         resolvedFilters: inputDashboardState.filters,
         ...inputDashboardState
       }
-      const queries = topStatsQueries(dashboardState, metrics)
+      const queries = topStatsQueries(dashboardState, metrics, null)
       expect(queries).toEqual(expectedQueries)
     }
   )

--- a/assets/js/dashboard/stats/graph/fetch-top-stats.ts
+++ b/assets/js/dashboard/stats/graph/fetch-top-stats.ts
@@ -12,12 +12,15 @@ import { createStatsQuery, ReportParams, StatsQuery } from '../../stats-query'
 import {
   hasConversionGoalFilter,
   hasPageFilter,
-  isRealTimeDashboard
+  isRealTimeDashboard,
+  remapToApiFilters
 } from '../../util/filters'
+import { isSegmentFilter } from '../../filtering/segments'
 
 export function topStatsQueries(
   dashboardState: DashboardState,
-  metrics: Metric[]
+  metrics: Metric[],
+  limitedToSegmentId: number | null
 ): [StatsQuery, StatsQuery | null] {
   let currentVisitorsQuery = null
 
@@ -26,7 +29,16 @@ export function topStatsQueries(
       metrics: ['visitors']
     })
 
-    currentVisitorsQuery.filters = []
+    const filters = limitedToSegmentId
+      ? dashboardState.filters.filter((f) => {
+          const [_op, _key, clauses] = f
+          return (
+            isSegmentFilter(f) && clauses[0] === limitedToSegmentId.toString()
+          )
+        })
+      : []
+
+    currentVisitorsQuery.filters = remapToApiFilters(filters)
   }
   const topStatsQuery = constructTopStatsQuery(dashboardState, metrics)
 
@@ -35,12 +47,14 @@ export function topStatsQueries(
 
 export async function fetchTopStats(
   site: PlausibleSite,
-  dashboardState: DashboardState
+  dashboardState: DashboardState,
+  limitedToSegmentId: number | null
 ) {
   const metrics = chooseMetrics(site, dashboardState)
   const [topStatsQuery, currentVisitorsQuery] = topStatsQueries(
     dashboardState,
-    metrics
+    metrics,
+    limitedToSegmentId
   )
   const topStatsPromise = api.stats(site, topStatsQuery)
 

--- a/assets/js/dashboard/stats/graph/visitor-graph.tsx
+++ b/assets/js/dashboard/stats/graph/visitor-graph.tsx
@@ -13,6 +13,7 @@ import { getStaleTime } from '../../hooks/api-client'
 import { MainGraph, MainGraphContainer, useMainGraphWidth } from './main-graph'
 import { useGraphIntervalContext } from './graph-interval-context'
 import { useSetImportsIncluded } from './imports-included-context'
+import { useSegmentsContext } from '../../filtering/segments-context'
 
 // height of at least one row of top stats
 const DEFAULT_TOP_STATS_LOADING_HEIGHT_PX = 85
@@ -29,6 +30,8 @@ export default function VisitorGraph({
   const { dashboardState } = useDashboardStateContext()
   const isRealtime = dashboardState.period === DashboardPeriod.realtime
   const queryClient = useQueryClient()
+  const { limitedToSegment } = useSegmentsContext()
+  const limitedToSegmentId = limitedToSegment ? limitedToSegment.id : null
 
   const { selectedInterval } = useGraphIntervalContext()
 
@@ -47,7 +50,7 @@ export default function VisitorGraph({
     queryKey: ['top-stats', { dashboardState }] as const,
     queryFn: async ({ queryKey }) => {
       const [_, opts] = queryKey
-      return await fetchTopStats(site, opts.dashboardState)
+      return await fetchTopStats(site, opts.dashboardState, limitedToSegmentId)
     },
     placeholderData: (previousData) => previousData,
     staleTime: ({ queryKey }) => {


### PR DESCRIPTION
### Changes

Currently the realtime Top Stats are broken in shared links that are limited to a segment. Precisely, the "current visitors" query is what the backend rejects -- `StatsController` enforces a segment filter via a plug, but the FE simply strips all filters from this query (including the enforced segment one).

Previous behaviour was to skip the plug and allow the current visitors query without the "limited to segment" filter, therefore returning data that is completely out of scope for the given dashboard. Instead of sticking to that behaviour and building an additional flag and ignore it in the new `/query` endpoint too, I've made the new current visitors metric respect the segment filter. It now removes all other filters **except** the limited segment one.

Note: This is a quick and dirty fix. I've made some good progress with improving the API v2 interface on the frontend. Planning to have currentVisitors apiState available via a new context (so that the response could be used wherever necessary, i.e. in top stats or the top-bar). That allows us to keep top-stats itself to a single query, with a solid Tanstack QueryKey, etc...

The tests will therefore change too.

### Tests
- [x] In upcoming PR...

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
