### PR TITLE
Fix error on cycling through intervals with hotkey

### DIFF
--- a/assets/js/dashboard/components/graph.tsx
+++ b/assets/js/dashboard/components/graph.tsx
@@ -482,7 +482,8 @@ function InnerGraph<T extends GraphYValues>({
       let line = svg.select<SVGLineElement>(
         `#${highlightIndicatorGroupId} line`
       )
-      const shouldShowLine = typeof highlightedIndex === 'number'
+      const shouldShowLine =
+        typeof highlightedIndex === 'number' && points[highlightedIndex]
       if (shouldShowLine) {
         const { x } = points[highlightedIndex]
         if (line.empty()) {


### PR DESCRIPTION
### Steps to reproduce

1. Hover graph. 
2. Press the key `I` to cycle through intervals. 
3. Keep cycling through intervals with `I` with increasing rapidity

### Expected

Tooltip and vertical line disappears after cycling, cycling works

### Actual

Rocket emoji dashboard crash

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
