### PR TITLE
Fix wildcard pathname regex used for funnel steps and prev step exclusion

### DIFF
--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -705,7 +705,7 @@ defmodule Plausible.Stats.Exploration do
   defp wildcard_pattern(pathname) when is_binary(pathname) do
     escaped = Regex.escape(pathname)
 
-    "^#{escaped}(/.+)?$"
+    "^#{escaped}(/.*)?$"
   end
 
   defp maybe_search(query, search_term) do

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -283,6 +283,67 @@ defmodule Plausible.Stats.ExplorationTest do
         assert step2.conversion_rate == "50"
         assert step2.conversion_rate_step == "50"
       end
+
+      test "handles wildcard step properly" do
+        journey = [
+          %Exploration.Journey.Step{
+            name: "pageview",
+            pathname: "/sites",
+            includes_subpaths: true,
+            subpaths_count: 2,
+            is_goal: true
+          },
+          %Exploration.Journey.Step{name: "pageview", pathname: "/dashboard"}
+        ]
+
+        site = new_site()
+        now = DateTime.utc_now()
+
+        populate_stats(site, [
+          build(:pageview,
+            user_id: 123,
+            pathname: "/sites",
+            timestamp: DateTime.shift(now, minute: -50)
+          ),
+          build(:pageview,
+            user_id: 123,
+            pathname: "/dashboard",
+            timestamp: DateTime.shift(now, minute: -40)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/sites/settings",
+            timestamp: DateTime.shift(now, minute: -50)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/sites-are-cool",
+            timestamp: DateTime.shift(now, minute: -50)
+          ),
+          build(:pageview,
+            user_id: 126,
+            pathname: "/sites/",
+            timestamp: DateTime.shift(now, minute: -50)
+          )
+        ])
+
+        query = QueryBuilder.build!(site, input_date_range: :all)
+
+        assert {:ok, [step1, step2]} = Exploration.journey_funnel(query, journey)
+
+        assert step1.step.pathname == "/sites"
+        assert step1.visitors == 3
+        assert step1.dropoff == 0
+        assert step1.dropoff_percentage == "0"
+        assert step1.conversion_rate == "100"
+        assert step1.conversion_rate_step == "0"
+        assert step2.step.pathname == "/dashboard"
+        assert step2.visitors == 1
+        assert step2.dropoff == 2
+        assert step2.dropoff_percentage == "66.67"
+        assert step2.conversion_rate == "33.33"
+        assert step2.conversion_rate_step == "33.33"
+      end
     end
 
     describe "interesting_funnel" do


### PR DESCRIPTION
### Changes

The pathname regular expression turned out to be out of sync with how we defined wildcard pathname events in suggestions. It didn't matter when we were normalizing pathnames. However, since we have dropped the normalization for consistency, this inconsistency has crept it.

### Tests
- [x] Automated tests have been added

