### PR TITLE
Avoid reload of the current column on deselecting entry

### DIFF
--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -578,7 +578,7 @@ function ExplorationColumn({
           </span>
         )}
 
-        {showSearch && (
+        {!headerConversionRate && showSearch && (
           <input
             data-testid="search-input"
             type="text"
@@ -589,7 +589,7 @@ function ExplorationColumn({
           />
         )}
 
-        {!showSearch && headerConversionRate && (
+        {headerConversionRate && (
           <span className="shrink-0 text-xs font-semibold text-gray-900 dark:text-gray-100">
             {headerConversionRate}
           </span>

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -980,6 +980,7 @@ function useExplorationData(site, dashboardState, inViewport) {
         if (isRateLimitedError(err)) {
           setState((prev) => ({
             ...prev,
+            frozen: truncateFrozenAt(prev.frozen, prev.steps.length),
             rateLimited: true,
             activeResults: [],
             ...(includeFunnel ? { provisional: {} } : {})
@@ -987,6 +988,7 @@ function useExplorationData(site, dashboardState, inViewport) {
         } else {
           setState((prev) => ({
             ...prev,
+            frozen: truncateFrozenAt(prev.frozen, prev.steps.length),
             activeResults: [],
             ...(includeFunnel ? { funnel: [] } : {})
           }))

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -534,6 +534,7 @@ function ExplorationColumn({
   headerConversionRate,
   active,
   loading,
+  loadingInBackground,
   results,
   selected,
   selectedVisitors,
@@ -561,6 +562,8 @@ function ExplorationColumn({
 
   const showSearch = active && !selected && (results.length > 0 || filter)
 
+  const onSelectHandler = loadingInBackground ? () => {} : onSelect
+
   return (
     <div
       data-exploration-column={colIndex}
@@ -578,7 +581,7 @@ function ExplorationColumn({
           </span>
         )}
 
-        {!headerConversionRate && showSearch && (
+        {showSearch && (
           <input
             data-testid="search-input"
             type="text"
@@ -589,7 +592,7 @@ function ExplorationColumn({
           />
         )}
 
-        {headerConversionRate && (
+        {!showSearch && headerConversionRate && (
           <span className="shrink-0 text-xs font-semibold text-gray-900 dark:text-gray-100">
             {headerConversionRate}
           </span>
@@ -629,7 +632,7 @@ function ExplorationColumn({
               selectedConversionRate={selectedConversionRate}
               stepMaxVisitors={stepMaxVisitors}
               colIndex={colIndex}
-              onSelect={onSelect}
+              onSelect={onSelectHandler}
             />
           ))}
         </ul>
@@ -1162,13 +1165,17 @@ export function FunnelExploration() {
               const isActive = i === activeColumnIndex
               const isReachable = steps.length >= i
 
+              const colFilter = isActive ? activeFilter : ''
+
               const colResults = isActive
-                ? activeResults.length > 0
+                ? activeResults.length > 0 || colFilter
                   ? activeResults
                   : (frozen[i] ?? [])
                 : (frozen[i] ?? [])
+              const colLoadingInBackground =
+                isActive && (initialLoading || activeLoading)
               const colLoading =
-                isActive && (initialLoading || activeLoading) && !frozen[i]
+                colLoadingInBackground && (!frozen[i] || colFilter)
 
               const colSelectedVisitors =
                 provisional[i]?.visitors ?? funnel[i]?.visitors ?? null
@@ -1193,13 +1200,14 @@ export function FunnelExploration() {
                   header={columnHeader(i, direction)}
                   headerConversionRate={colHeaderConversionRate}
                   active={isReachable}
+                  loadingInBackground={colLoadingInBackground}
                   loading={colLoading}
                   results={colResults}
                   selected={steps[i] ?? null}
                   selectedVisitors={colSelectedVisitors}
                   selectedConversionRate={colSelectedConversionRate}
                   maxVisitors={funnel[0]?.visitors ?? null}
-                  filter={isActive ? activeFilter : ''}
+                  filter={colFilter}
                   onFilterChange={isActive ? setActiveFilter : () => {}}
                   onSelect={(step) => selectStep(i, step)}
                   rateLimited={isActive && rateLimited}

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -589,7 +589,7 @@ function ExplorationColumn({
           />
         )}
 
-        {headerConversionRate && (
+        {!showSearch && headerConversionRate && (
           <span className="shrink-0 text-xs font-semibold text-gray-900 dark:text-gray-100">
             {headerConversionRate}
           </span>
@@ -695,7 +695,7 @@ function useExplorationData(site, dashboardState, inViewport) {
           steps: prev.steps.slice(0, columnIndex),
           activeResults: [],
           activeFilter: '',
-          frozen: truncateFrozenAt(prev.frozen, columnIndex),
+          frozen: truncateFrozenAt(prev.frozen, columnIndex + 1),
           provisional: {},
           rateLimited: false
         }
@@ -1162,8 +1162,13 @@ export function FunnelExploration() {
               const isActive = i === activeColumnIndex
               const isReachable = steps.length >= i
 
-              const colResults = isActive ? activeResults : (frozen[i] ?? [])
-              const colLoading = isActive && (initialLoading || activeLoading)
+              const colResults = isActive
+                ? activeResults.length > 0
+                  ? activeResults
+                  : (frozen[i] ?? [])
+                : (frozen[i] ?? [])
+              const colLoading =
+                isActive && (initialLoading || activeLoading) && !frozen[i]
 
               const colSelectedVisitors =
                 provisional[i]?.visitors ?? funnel[i]?.visitors ?? null

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -1166,16 +1166,16 @@ export function FunnelExploration() {
               const isReachable = steps.length >= i
 
               const colFilter = isActive ? activeFilter : ''
+              const colFrozen = frozen[i] ?? []
 
-              const colResults = isActive
-                ? activeResults.length > 0 || colFilter
+              const colResults =
+                isActive && (activeResults.length > 0 || colFilter)
                   ? activeResults
-                  : (frozen[i] ?? [])
-                : (frozen[i] ?? [])
+                  : colFrozen
               const colLoadingInBackground =
                 isActive && (initialLoading || activeLoading)
               const colLoading =
-                colLoadingInBackground && (!frozen[i] || colFilter)
+                colLoadingInBackground && (!frozen[i] || !!colFilter)
 
               const colSelectedVisitors =
                 provisional[i]?.visitors ?? funnel[i]?.visitors ?? null


### PR DESCRIPTION
### Changes

This PR prevents flicker of the step column when an entry in it is deselected. The frozen version of the deselected column is preserved and displayed until the step and funnel request completes.


