### PR TITLE
Add E2E tests for exploration

### DIFF
--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -326,6 +326,7 @@ function DirectionDropdown({ direction, onChange }) {
   return (
     <div ref={containerRef} className="relative shrink-0">
       <button
+        data-testid={`exploration-direction-${direction}`}
         onClick={() => setOpen((o) => !o)}
         className="flex items-center gap-0.5 text-xs font-semibold text-gray-900 dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-200"
       >
@@ -340,6 +341,7 @@ function DirectionDropdown({ direction, onChange }) {
           {DIRECTION_OPTIONS.map(({ value, label }) => (
             <button
               key={value}
+              data-testid={`exploration-direction-${value}`}
               data-selected={direction === value}
               onClick={() => {
                 onChange(value)
@@ -403,7 +405,7 @@ function CandidateCard({
   const onSelectHandler = isJourneyEnd ? () => {} : onSelect
 
   return (
-    <li>
+    <li data-testid="exploration-row">
       <button
         data-exploration-step={isSelected ? colIndex : undefined}
         className={`group relative w-full text-left text-sm rounded-sm overflow-hidden focus:outline-none ${rowBg} ${pointer}`}
@@ -411,12 +413,14 @@ function CandidateCard({
       >
         <div
           className={`absolute top-0 left-0 h-full rounded-sm transition-[width] ease-in-out ${barBg}`}
+          data-testid="metric-bar"
           style={{ width: `${barWidth}%` }}
         />
 
         <div className="relative flex items-center justify-between gap-2 px-2 py-1.5">
           <span
             className={`flex items-center gap-1.5 min-w-0 ${textColor}`}
+            data-testid="metric-label"
             title={
               step.includes_subpaths
                 ? `${step.label} > all (${step.subpaths_count})`
@@ -462,11 +466,11 @@ function VisitorsMetric({ visitors }) {
   if (showTooltip) {
     return (
       <Tooltip info={longNumber} containerRef={{ current: document.body }}>
-        {shortNumber}
+        <span data-testid="metric-value">{shortNumber}</span>
       </Tooltip>
     )
   } else {
-    return shortNumber
+    return <span data-testid="metric-value">{shortNumber}</span>
   }
 }
 
@@ -529,6 +533,7 @@ function MaxDepthColumn({ colIndex, header }) {
   const { explorationMaxJourneySteps: maxJourneySteps } = useSiteContext()
   return (
     <div
+      data-testid={`exploration-column-${colIndex}`}
       data-exploration-column={colIndex}
       className="border border-gray-200 dark:border-gray-750 rounded-lg overflow-hidden"
     >
@@ -587,6 +592,7 @@ function ExplorationColumn({
 
   return (
     <div
+      data-testid={`exploration-column-${colIndex}`}
       data-exploration-column={colIndex}
       className="border border-gray-200 dark:border-gray-750 rounded-lg overflow-hidden"
     >
@@ -1151,7 +1157,10 @@ export function FunnelExploration() {
     <LazyLoader onVisible={() => setInViewport(true)}>
       <div className="flex-1 flex flex-col gap-4 pt-4">
         <div className="flex flex-wrap items-center gap-x-3">
-          <h4 className="flex-1 text-base font-semibold dark:text-gray-100">
+          <h4
+            data-testid="exploration-title"
+            className="flex-1 text-base font-semibold dark:text-gray-100"
+          >
             {funnel.length >= 2
               ? `${funnel.length}-step user journey`
               : 'Explore user journeys'}
@@ -1180,6 +1189,7 @@ export function FunnelExploration() {
             }
           >
             <button
+              data-testid="exploration-deselect-all"
               onClick={reset}
               className={`${popover.toggleButton.classNames.rounded} ${popover.toggleButton.classNames.outline} justify-center !h-7 px-1.5`}
             >

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -21,31 +21,31 @@ import { tabButton } from '../test-utils'
  *   - long event name and long pathname
  *   - 1k events and up with tooltip/label
  *   - bar with computed ratio below minimum
- * - Rapidly reloading dashboard until rate limit error kicks in
- * - Deselecting all
- * - Selecting different entry at first step with an empty journey
- * - Rapidly selecting different entries until rate limit kicks in
- * - Rapidly deselecting and selecting again the same entry until rate limit kicks in
- * - Deselecting entry at first step with with an empty journey
- * - Searching entries in the first step, with match
- * - Searching entries in the first step, with no match
- * - Selecting different entry with filtering applied
- * - Deselecting and selecting again with filtering applied at first
- * - Selecting entry in the second step
- * - Rapidly selecting different entries in the second step until rate limit kicks in
- * - Rapidly deselecting and selecting again the same entry in second step until rate limit kicks in
- * - Filtering for "no further action" in the second step
- * - Resizing viewport for a 3-step journey
- * - Switching from "Starting point" to "End point" and back
- * - Switching to "End point" and exploring a 3-step journey, switching back
- * - Selecting a different 2nd step in a 3-step journey
- * - Deselecting 2nd step in a 3-step journey
- * - Selecting a different 1st step in a 3-step journey
- * - Deselecting 1st step in a 3-step journey
- * - Changing period with a 3-step journey with results present in all steps
- * - Changing period with a 3-step journey where there are no results for any of the steps
- * - Changing period with a 3-step funnel where there are no results for the 3rd step
- * - Exploring journey hitting the 20-step limit
+ * X - Rapidly reloading dashboard until rate limit error kicks in
+ * V - Deselecting all
+ * V - Selecting different entry at first step with an empty journey
+ * X - Rapidly selecting different entries until rate limit kicks in
+ * X - Rapidly deselecting and selecting again the same entry until rate limit kicks in
+ * V - Deselecting entry at first step with with an empty journey
+ * V - Searching entries in the first step, with match
+ * V - Searching entries in the first step, with no match
+ * V - Selecting different entry with filtering applied
+ * V - Deselecting and selecting again with filtering applied at first
+ * V - Selecting entry in the second step
+ * X - Rapidly selecting different entries in the second step until rate limit kicks in
+ * X - Rapidly deselecting and selecting again the same entry in second step until rate limit kicks in
+ * V - Filtering for "no further action" in the second step
+ * X - Resizing viewport for a 3-step journey
+ * V - Switching from "Starting point" to "End point" and back
+ * V - Switching to "End point" and exploring a 3-step journey, switching back
+ * V - Selecting a different 2nd step in a 3-step journey
+ * V - Deselecting 2nd step in a 3-step journey
+ * V - Selecting a different 1st step in a 3-step journey
+ * V - Deselecting 1st step in a 3-step journey
+ * V - Changing period with a 3-step journey with results present in all steps
+ * V - Changing period with a 3-step journey where there are no results for any of the steps
+ * V - Changing period with a 3-step funnel where there are no results for the 3rd step
+ * V - Exploring journey hitting the 20-step limit
  */
 
 const getReport = (page: Page) => page.getByTestId('report-behaviours')
@@ -75,6 +75,7 @@ test('load featured tunnel with only a single step', async ({
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
+  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
@@ -126,6 +127,7 @@ test('load featured tunnel and switch to a period with no events without waiting
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
+  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
@@ -161,6 +163,7 @@ test('load featured tunnel and switch to a period with no events', async ({
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
+  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
@@ -243,6 +246,7 @@ test('load a 3-step featured funnel', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
+  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
@@ -266,12 +270,20 @@ test('load a 3-step featured funnel', async ({ page, request }) => {
   ).toHaveText(['/home', '/login', '/another', '/dashboard', '/journey'])
 
   await expect(
+    firstColumn.getByRole('button', { name: '/home' })
+  ).toHaveAttribute('data-exploration-step', '0')
+
+  await expect(
     firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
   ).toHaveText(['3', '2', '1', '1', '1'])
 
   await expect(
     secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
   ).toHaveText(['/login', 'no further action'])
+
+  await expect(
+    secondColumn.getByRole('button', { name: '/login' })
+  ).toHaveAttribute('data-exploration-step', '1')
 
   await expect(
     secondColumn.getByTestId('exploration-row').getByTestId('metric-value')
@@ -282,9 +294,1033 @@ test('load a 3-step featured funnel', async ({ page, request }) => {
   ).toHaveText(['no further action', '/dashboard'])
 
   await expect(
+    thirdColumn.getByRole('button', { name: '/dashboard' })
+  ).not.toHaveAttribute('data-exploration-step')
+
+  await expect(
     thirdColumn.getByTestId('exploration-row').getByTestId('metric-value')
   ).toHaveText(['1', '1'])
 
   await expect(secondColumn).toHaveText(/1 step after/)
   await expect(thirdColumn).toHaveText(/2 steps after/)
+
+  await test.step('Deselecting all resets the journey', async () => {
+    await report.getByTestId('exploration-deselect-all').click()
+
+    await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home', '/login', '/another', '/dashboard', '/journey'])
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/dashboard' })
+    ).not.toHaveAttribute('data-exploration-step')
+  })
+})
+
+test('select entries in a 1-step journey', async ({ page, request }) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/dashboard',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 125,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/another-home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/journey',
+        timestamp: { minutesAgo: 35 }
+      }
+    ]
+  })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.scrollIntoViewIfNeeded()
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  await expect(
+    report.getByTestId('exploration-direction-forward')
+  ).toBeVisible()
+
+  await report.getByTestId('exploration-deselect-all').click()
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+  const secondColumn = report.getByTestId('exploration-column-1')
+
+  await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/home', '/login', '/another-home', '/dashboard', '/journey'])
+
+  await expect(
+    firstColumn.getByRole('button', { name: '/home' })
+  ).not.toHaveAttribute('data-exploration-step', '0')
+
+  await test.step('select an entry', async () => {
+    await firstColumn.getByRole('button', { name: '/login' }).click()
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/login' })
+    ).toHaveAttribute('data-exploration-step', '0')
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['no further action', '/dashboard'])
+  })
+
+  await test.step('select a different entry', async () => {
+    await firstColumn.getByRole('button', { name: '/another' }).click()
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/another-home' })
+    ).toHaveAttribute('data-exploration-step', '0')
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/journey'])
+  })
+
+  await test.step('select a different entry with no further steps', async () => {
+    await firstColumn.getByRole('button', { name: '/dashboard' }).click()
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/dashboard' })
+    ).toHaveAttribute('data-exploration-step', '0')
+
+    await expect(secondColumn).toHaveText(/No further steps found/)
+  })
+
+  await test.step('deselect an entry', async () => {
+    await firstColumn.getByRole('button', { name: '/dashboard' }).click()
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/dashboard' })
+    ).not.toHaveAttribute('data-exploration-step', '0')
+
+    await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+  })
+
+  await test.step('filter entries with match', async () => {
+    await firstColumn.getByPlaceholder('Search').fill('dash')
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/dashboard'])
+  })
+
+  await test.step('filter entries with no match', async () => {
+    await firstColumn.getByPlaceholder('Search').fill('nosuchthing')
+
+    await expect(firstColumn).toHaveText(/No events found/)
+  })
+
+  await test.step('filter returning more than one entry', async () => {
+    await firstColumn.getByPlaceholder('Search').fill('home')
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home', '/another-home'])
+  })
+
+  await test.step('select an entry with filtering applied', async () => {
+    await firstColumn.getByRole('button', { name: '/home' }).click()
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/login', 'no further action'])
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home', '/another-home'])
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/home' })
+    ).toHaveAttribute('data-exploration-step', '0')
+  })
+
+  await test.step('select another entry with filtering still applied', async () => {
+    await firstColumn.getByRole('button', { name: '/another-home' }).click()
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/journey'])
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home', '/another-home'])
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/another-home' })
+    ).toHaveAttribute('data-exploration-step', '0')
+  })
+
+  await test.step('deselect an entry with filtering still applied', async () => {
+    await firstColumn.getByRole('button', { name: '/another-home' }).click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home', '/login', '/another-home', '/dashboard', '/journey'])
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/another-home' })
+    ).not.toHaveAttribute('data-exploration-step', '0')
+
+    await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+  })
+})
+
+test('select entries in a 3-step journey', async ({ page, request }) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/dashboard',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/logout',
+        timestamp: { minutesAgo: 25 }
+      },
+      {
+        user_id: 125,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 125,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 125,
+        name: 'pageview',
+        pathname: '/dashboard',
+        timestamp: { minutesAgo: 25 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/another-home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/journey',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/somewhere',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 127,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 127,
+        name: 'pageview',
+        pathname: '/blog',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 128,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 40 }
+      }
+    ]
+  })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.scrollIntoViewIfNeeded()
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  await expect(
+    report.getByTestId('exploration-direction-forward')
+  ).toBeVisible()
+
+  await report.getByTestId('exploration-deselect-all').click()
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+  const secondColumn = report.getByTestId('exploration-column-1')
+  const thirdColumn = report.getByTestId('exploration-column-2')
+  const fourthColumn = report.getByTestId('exploration-column-3')
+
+  await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+
+  await firstColumn.getByRole('button', { name: '/home' }).click()
+
+  await expect(
+    secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/login', 'no further action', '/blog'])
+
+  await test.step('filter for "no further action" in the second step', async () => {
+    await secondColumn.getByPlaceholder('Search').fill('no further')
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['no further action'])
+  })
+
+  await secondColumn.getByPlaceholder('Search').fill('')
+
+  await expect(
+    secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/login', 'no further action', '/blog'])
+
+  await test.step('select an entry in the 2nd step', async () => {
+    await secondColumn.getByRole('button', { name: '/login' }).click()
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/dashboard', '/logout'])
+
+    await expect(
+      secondColumn.getByRole('button', { name: '/login' })
+    ).toHaveAttribute('data-exploration-step', '1')
+  })
+
+  await test.step('select a different entry in the 2nd step', async () => {
+    await secondColumn.getByRole('button', { name: '/blog' }).click()
+
+    await expect(thirdColumn).toHaveText(/No further steps found/)
+
+    await expect(
+      secondColumn.getByRole('button', { name: '/blog' })
+    ).toHaveAttribute('data-exploration-step', '1')
+  })
+
+  await test.step('deselect an entry in the 2nd step', async () => {
+    await secondColumn.getByRole('button', { name: '/blog' }).click()
+
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+
+    await expect(
+      secondColumn.getByRole('button', { name: '/blog' })
+    ).not.toHaveAttribute('data-exploration-step', '1')
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/login', 'no further action', '/blog'])
+  })
+
+  await test.step('select a different entry in the 1st step', async () => {
+    await firstColumn.getByRole('button', { name: '/another-home' }).click()
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/another-home' })
+    ).toHaveAttribute('data-exploration-step', '0')
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/journey'])
+
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+  })
+
+  await test.step('select an entry in the 2nd step and 3rd step', async () => {
+    await secondColumn.getByRole('button', { name: '/journey' }).click()
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/somewhere'])
+
+    await thirdColumn.getByRole('button', { name: '/somewhere' }).click()
+
+    await expect(fourthColumn).toHaveText(/No further steps found/)
+  })
+
+  await test.step('deselect an entry at the 1st step', async () => {
+    await firstColumn.getByRole('button', { name: '/another-home' }).click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText([
+      '/home',
+      '/login',
+      '/dashboard',
+      '/another-home',
+      '/blog',
+      '/journey',
+      '/logout',
+      '/somewhere'
+    ])
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/another-home' })
+    ).not.toHaveAttribute('data-exploration-step', '0')
+
+    await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+
+    await expect(fourthColumn).toBeHidden()
+  })
+})
+
+test('explore journey hitting 20 step limit', async ({ page, request }) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  const events = [...Array(21).keys()].map((i) => {
+    return {
+      user_id: 123,
+      name: 'pageview',
+      pathname: `/page${i}`,
+      timestamp: { minutesAgo: 100 - i }
+    }
+  })
+
+  await populateStats({ request, domain, events })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.scrollIntoViewIfNeeded()
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  await expect(
+    report.getByTestId('exploration-direction-forward')
+  ).toBeVisible()
+
+  await report.getByTestId('exploration-deselect-all').click()
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+  const lastColumn = report.getByTestId('exploration-column-20')
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText([
+    '/page0',
+    '/page1',
+    '/page10',
+    '/page11',
+    '/page12',
+    '/page13',
+    '/page14',
+    '/page15',
+    '/page16',
+    '/page17'
+  ])
+
+  await (async () => {
+    for await (const i of [...Array(20).keys()]) {
+      const column = report.getByTestId(`exploration-column-${i}`)
+
+      await column.getByRole('button', { name: `/page${i}` }).click()
+
+      await expect(
+        column.getByRole('button', { name: `/page${i}` })
+      ).toHaveAttribute('data-exploration-step', `${i}`)
+    }
+  })()
+
+  await expect(lastColumn).toHaveText(
+    /You've reached the maximum journey depth/
+  )
+})
+
+test('explore from end point', async ({ page, request }) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/dashboard',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/logout',
+        timestamp: { minutesAgo: 25 }
+      },
+      {
+        user_id: 125,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 125,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 125,
+        name: 'pageview',
+        pathname: '/dashboard',
+        timestamp: { minutesAgo: 25 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/another-home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/journey',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/somewhere',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 127,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 127,
+        name: 'pageview',
+        pathname: '/blog',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 128,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 40 }
+      }
+    ]
+  })
+
+  const firstStepSuggestions = [
+    '/home',
+    '/login',
+    '/dashboard',
+    '/another-home',
+    '/blog',
+    '/journey',
+    '/logout',
+    '/somewhere'
+  ]
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.scrollIntoViewIfNeeded()
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+  const secondColumn = report.getByTestId('exploration-column-1')
+  const thirdColumn = report.getByTestId('exploration-column-2')
+  const fourthColumn = report.getByTestId('exploration-column-3')
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(firstStepSuggestions)
+
+  await test.step('switch to end point, bact to start point and to end point again', async () => {
+    await report.getByTestId('exploration-direction-forward').click()
+    await report.getByTestId('exploration-direction-backward').click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(firstStepSuggestions)
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/home' })
+    ).not.toHaveAttribute('data-exploration-step', '0')
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(firstStepSuggestions)
+
+    await expect(secondColumn).toHaveText(/1 step before/)
+    await expect(secondColumn).toHaveText(/Select an end point to continue/)
+    await expect(thirdColumn).toHaveText(/2 steps before/)
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+    await expect(fourthColumn).toBeHidden()
+
+    await report.getByTestId('exploration-direction-backward').click()
+    await report.getByTestId('exploration-direction-forward').click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(firstStepSuggestions)
+
+    await expect(secondColumn).toHaveText(/1 step after/)
+    await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+    await expect(thirdColumn).toHaveText(/2 steps after/)
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+    await expect(fourthColumn).toBeHidden()
+  })
+
+  await test.step('explore a 3-step journey from an end point', async () => {
+    await report.getByTestId('exploration-direction-forward').click()
+    await report.getByTestId('exploration-direction-backward').click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(firstStepSuggestions)
+
+    await firstColumn.getByRole('button', { name: '/dashboard' }).click()
+
+    await expect(
+      firstColumn.getByRole('button', { name: '/dashboard' })
+    ).toHaveAttribute('data-exploration-step', '0')
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/login'])
+
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+
+    await secondColumn.getByRole('button', { name: '/login' }).click()
+
+    await expect(
+      secondColumn.getByRole('button', { name: '/login' })
+    ).toHaveAttribute('data-exploration-step', '1')
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home'])
+
+    await thirdColumn.getByRole('button', { name: '/home' }).click()
+
+    await expect(
+      thirdColumn.getByRole('button', { name: '/home' })
+    ).toHaveAttribute('data-exploration-step', '2')
+
+    await expect(fourthColumn).toHaveText(/No further steps found/)
+  })
+
+  await test.step('switch back to starting point', async () => {
+    await report.getByTestId('exploration-direction-backward').click()
+    await report.getByTestId('exploration-direction-forward').click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(firstStepSuggestions)
+  })
+})
+
+test('change filters during a 3-step journey', async ({ page, request }) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        user_id: 123,
+        browser: 'Firefox',
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 20 }
+      },
+      {
+        user_id: 123,
+        browser: 'Firefox',
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 19 }
+      },
+      {
+        user_id: 123,
+        browser: 'Chrome',
+        name: 'pageview',
+        pathname: '/dashboard',
+        timestamp: { minutesAgo: 18 }
+      },
+      {
+        user_id: 124,
+        browser: 'Chrome',
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 20 }
+      },
+      {
+        user_id: 124,
+        browser: 'Chrome',
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 19 }
+      },
+      {
+        user_id: 125,
+        browser: 'Safari',
+        name: 'pageview',
+        pathname: '/other',
+        timestamp: { minutesAgo: 20 }
+      },
+      {
+        user_id: 125,
+        browser: 'Safari',
+        name: 'pageview',
+        pathname: '/journey',
+        timestamp: { minutesAgo: 19 }
+      }
+    ]
+  })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.scrollIntoViewIfNeeded()
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  await expect(
+    report.getByTestId('exploration-direction-forward')
+  ).toBeVisible()
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+  const secondColumn = report.getByTestId('exploration-column-1')
+  const thirdColumn = report.getByTestId('exploration-column-2')
+  const fourthColumn = report.getByTestId('exploration-column-3')
+
+  await thirdColumn.getByRole('button', { name: '/dashboard' }).click()
+
+  await expect(
+    thirdColumn.getByRole('button', { name: '/dashboard' })
+  ).toHaveAttribute('data-exploration-step', '2')
+
+  await expect(fourthColumn).toHaveText(/No further steps found/)
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/home', '/login', '/dashboard', '/journey', '/other'])
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+  ).toHaveText(['2', '2', '1', '1', '1'])
+
+  await expect(
+    secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/login'])
+
+  await expect(
+    secondColumn.getByTestId('exploration-row').getByTestId('metric-value')
+  ).toHaveText(['2'])
+
+  await expect(
+    thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['no further action', '/dashboard'])
+
+  await expect(
+    thirdColumn.getByTestId('exploration-row').getByTestId('metric-value')
+  ).toHaveText(['1', '1'])
+
+  await test.step('filtering with journey matches in all 3 steps', async () => {
+    // filter by 'Firefox' browser
+    await page
+      .getByTestId('report-devices')
+      .getByRole('link', { name: 'Firefox' })
+      .click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home'])
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['2'])
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/login'])
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['2'])
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/dashboard'])
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['1'])
+
+    await expect(fourthColumn).toHaveText(/No further steps found/)
+
+    // remove the filter
+    page
+      .getByRole('button', { name: 'Remove filter: Browser is Firefox' })
+      .click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home'])
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['2'])
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/login'])
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['2'])
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/dashboard'])
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['1'])
+
+    await expect(fourthColumn).toHaveText(/No further steps found/)
+  })
+
+  await test.step('filtering with journey matches for 2 first steps', async () => {
+    // filter by 'Chrome' browser
+    await page
+      .getByTestId('report-devices')
+      .getByRole('link', { name: 'Chrome' })
+      .click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home'])
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['1'])
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/login'])
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['1'])
+
+    await expect(thirdColumn).toHaveText(/No further steps found/)
+
+    await expect(fourthColumn).toBeHidden()
+
+    // remove the filter
+    page
+      .getByRole('button', { name: 'Remove filter: Browser is Chrome' })
+      .click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home'])
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['2'])
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/login'])
+
+    await expect(
+      secondColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['2'])
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['no further action', '/dashboard'])
+
+    await expect(
+      thirdColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['1', '1'])
+
+    await expect(
+      thirdColumn.getByRole('button', { name: '/dashboard' })
+    ).not.toHaveAttribute('data-exploration-step', '2')
+
+    await expect(fourthColumn).toBeHidden()
+  })
+
+  // select the 3rd step again
+  await thirdColumn.getByRole('button', { name: '/dashboard' }).click()
+
+  await expect(
+    thirdColumn.getByRole('button', { name: '/dashboard' })
+  ).toHaveAttribute('data-exploration-step', '2')
+
+  await test.step('filtering with journey with no matches for any of the steps', async () => {
+    // filter by 'Chrome' browser
+    await page
+      .getByTestId('report-devices')
+      .getByRole('link', { name: 'Safari' })
+      .click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/journey', '/other'])
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['1', '1'])
+
+    await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+
+    await expect(fourthColumn).toBeHidden()
+
+    // remove the filter
+    page
+      .getByRole('button', { name: 'Remove filter: Browser is Safari' })
+      .click()
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+    ).toHaveText(['/home', '/login', '/dashboard', '/journey', '/other'])
+
+    await expect(
+      firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+    ).toHaveText(['2', '2', '1', '1', '1'])
+
+    await expect(secondColumn).toHaveText(/Select a starting point to continue/)
+
+    await expect(thirdColumn).toHaveText(/Select an event to continue/)
+
+    await expect(fourthColumn).toBeHidden()
+  })
 })

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -1,26 +1,20 @@
 import { test, expect, Page } from '@playwright/test'
-import {
-  setupSite,
-  populateStats
-  // addGoal,
-  // addCustomGoal,
-  // addPageviewGoal
-} from '../fixtures'
+import { setupSite, populateStats, addGoal } from '../fixtures'
 import { tabButton } from '../test-utils'
 
 /*
  * V - Loading featured funnel
  * V - Loading featured funnel when there are no events for a given set of conditions and time range
- * - Rendering entries for:
- *   - pageview
- *   - custom event
- *   - wildcard pathname
- *   - custom goal
- *   - pageview goal
- *   - pageview pattern goal
- *   - long event name and long pathname
- *   - 1k events and up with tooltip/label
- *   - bar with computed ratio below minimum
+ * V - Rendering entries for:
+ * V  - pageview
+ * V  - custom event
+ * V  - wildcard pathname
+ * V  - custom goal
+ * V  - pageview goal
+ * V  - pageview pattern goal
+ * X - long event name and long pathname
+ * X - 1k events and up with tooltip/label
+ * X - bar with computed ratio below minimum
  * X - Rapidly reloading dashboard until rate limit error kicks in
  * V - Deselecting all
  * V - Selecting different entry at first step with an empty journey
@@ -1323,4 +1317,74 @@ test('change filters during a 3-step journey', async ({ page, request }) => {
 
     await expect(fourthColumn).toBeHidden()
   })
+})
+
+test('render various types of entries', async ({ page, request }) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        name: 'pageview',
+        pathname: '/home'
+      },
+      {
+        name: 'pageview',
+        pathname: '/login'
+      },
+      {
+        name: 'checkout'
+      },
+      {
+        name: 'create_site'
+      },
+      {
+        name: 'pageview',
+        pathname: '/blog/first-post'
+      },
+      {
+        name: 'pageview',
+        pathname: '/blog/second-post'
+      }
+    ]
+  })
+
+  await addGoal({
+    request,
+    domain,
+    params: { event_name: 'create_site', display_name: 'Create a site' }
+  })
+
+  await addGoal({ request, domain, params: { page_path: '/login' } })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.scrollIntoViewIfNeeded()
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  await expect(
+    report.getByTestId('exploration-direction-forward')
+  ).toBeVisible()
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText([
+    /\/blog.*all \(2\)/,
+    /Custom event.*checkout/,
+    /Goal.*Create a site/,
+    '/blog/first-post',
+    '/blog/second-post',
+    '/home',
+    /Goal.*Visit \/login/
+  ])
 })

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -2,46 +2,6 @@ import { test, expect, Page } from '@playwright/test'
 import { setupSite, populateStats, addGoal } from '../fixtures'
 import { tabButton } from '../test-utils'
 
-/*
- * V - Loading featured funnel
- * V - Loading featured funnel when there are no events for a given set of conditions and time range
- * V - Rendering entries for:
- * V  - pageview
- * V  - custom event
- * V  - wildcard pathname
- * V  - custom goal
- * V  - pageview goal
- * V  - pageview pattern goal
- * X - long event name and long pathname
- * X - 1k events and up with tooltip/label
- * X - bar with computed ratio below minimum
- * X - Rapidly reloading dashboard until rate limit error kicks in
- * V - Deselecting all
- * V - Selecting different entry at first step with an empty journey
- * X - Rapidly selecting different entries until rate limit kicks in
- * X - Rapidly deselecting and selecting again the same entry until rate limit kicks in
- * V - Deselecting entry at first step with with an empty journey
- * V - Searching entries in the first step, with match
- * V - Searching entries in the first step, with no match
- * V - Selecting different entry with filtering applied
- * V - Deselecting and selecting again with filtering applied at first
- * V - Selecting entry in the second step
- * X - Rapidly selecting different entries in the second step until rate limit kicks in
- * X - Rapidly deselecting and selecting again the same entry in second step until rate limit kicks in
- * V - Filtering for "no further action" in the second step
- * X - Resizing viewport for a 3-step journey
- * V - Switching from "Starting point" to "End point" and back
- * V - Switching to "End point" and exploring a 3-step journey, switching back
- * V - Selecting a different 2nd step in a 3-step journey
- * V - Deselecting 2nd step in a 3-step journey
- * V - Selecting a different 1st step in a 3-step journey
- * V - Deselecting 1st step in a 3-step journey
- * V - Changing period with a 3-step journey with results present in all steps
- * V - Changing period with a 3-step journey where there are no results for any of the steps
- * V - Changing period with a 3-step funnel where there are no results for the 3rd step
- * V - Exploring journey hitting the 20-step limit
- */
-
 const getReport = (page: Page) => page.getByTestId('report-behaviours')
 const getExplorationTabButton = (report: Locator) =>
   tabButton(report, 'Explore')

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, Page } from '@playwright/test'
+import {
+  setupSite,
+  populateStats
+  // addGoal,
+  // addCustomGoal,
+  // addPageviewGoal
+} from '../fixtures'
+import { tabButton } from '../test-utils'
+
+/*
+ * - Loading featured funnel
+ * - Loading featured funnel when there are no events fora given set of conditions and time range
+ * - Rendering entries for:
+ *   - pageview
+ *   - custom event
+ *   - wildcard pathname
+ *   - custom goal
+ *   - pageview goal
+ *   - pageview pattern goal
+ *   - long event name and long pathname
+ *   - 1k events and up with tooltip/label
+ *   - bar with computed ratio below minimum
+ * - Rapidly reloading dashboard until rate limit error kicks in
+ * - Deselecting all
+ * - Selecting different entry at first step with an empty journey
+ * - Rapidly selecting different entries until rate limit kicks in
+ * - Rapidly deselecting and selecting again the same entry until rate limit kicks in
+ * - Deselecting entry at first step with with an empty journey
+ * - Searching entries in the first step, with match
+ * - Searching entries in the first step, with no match
+ * - Selecting different entry with filtering applied
+ * - Deselecting and selecting again with filtering applied at first
+ * - Selecting entry in the second step
+ * - Rapidly selecting different entries in the second step until rate limit kicks in
+ * - Rapidly deselecting and selecting again the same entry in second step until rate limit kicks in
+ * - Filtering for "no further action" in the second step
+ * - Resizing viewport for a 3-step journey
+ * - Switching from "Starting point" to "End point" and back
+ * - Switching to "End point" and exploring a 3-step journey, switching back
+ * - Selecting a different 2nd step in a 3-step journey
+ * - Deselecting 2nd step in a 3-step journey
+ * - Selecting a different 1st step in a 3-step journey
+ * - Deselecting 1st step in a 3-step journey
+ * - Changing period with a 3-step journey with results present in all steps
+ * - Changing period with a 3-step journey where there are no results for any of the steps
+ * - Changing period with a 3-step funnel where there are no results for the 3rd step
+ * - Exploring journey hitting the 20-step limit
+ */
+
+const getReport = (page: Page) => page.getByTestId('report-behaviours')
+const getExplorationTabButton = (report: Locator) =>
+  tabButton(report, 'Explore')
+
+test('load featured tunnel with only a single step', async ({ page, request }) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/page',
+        timestamp: { hoursAgo: 40 }
+      }
+    ]
+  })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  await expect(
+    report.getByTestId('exploration-direction-forward')
+  ).toBeVisible()
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+  const secondColumn = report.getByTestId('exploration-column-1')
+
+  await expect(firstColumn).toBeVisible()
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/page'])
+
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+  ).toHaveText(['1'])
+
+
+  await expect(secondColumn).toHaveText(/1 step after/)
+  await expect(secondColumn).toHaveText(/No further steps found/)
+})

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -6,7 +6,7 @@ const getReport = (page: Page) => page.getByTestId('report-behaviours')
 const getExplorationTabButton = (report: Locator) =>
   tabButton(report, 'Explore')
 
-test('load featured tunnel with only a single step', async ({
+test('load featured funnel with only a single step', async ({
   page,
   request
 }) => {
@@ -58,7 +58,7 @@ test('load featured tunnel with only a single step', async ({
 })
 
 // current version is often stuck loading if the timing is unlucky
-test('load featured tunnel and switch to a period with no events without waiting for load', async ({
+test('load featured funnel and switch to a period with no events without waiting for load', async ({
   page,
   request
 }) => {
@@ -94,7 +94,7 @@ test('load featured tunnel and switch to a period with no events without waiting
   await expect(report).toHaveText(/No data yet/)
 })
 
-test('load featured tunnel and switch to a period with no events', async ({
+test('load featured funnel and switch to a period with no events', async ({
   page,
   request
 }) => {
@@ -906,7 +906,7 @@ test('explore from end point', async ({ page, request }) => {
     firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
   ).toHaveText(firstStepSuggestions)
 
-  await test.step('switch to end point, bact to start point and to end point again', async () => {
+  await test.step('switch to end point, back to start point and to end point again', async () => {
     await report.getByTestId('exploration-direction-forward').click()
     await report.getByTestId('exploration-direction-backward').click()
 

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect, Page, Locator } from '@playwright/test'
 import { setupSite, populateStats, addGoal } from '../fixtures'
 import { tabButton } from '../test-utils'
 

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -9,8 +9,8 @@ import {
 import { tabButton } from '../test-utils'
 
 /*
- * - Loading featured funnel
- * - Loading featured funnel when there are no events fora given set of conditions and time range
+ * V - Loading featured funnel
+ * V - Loading featured funnel when there are no events for a given set of conditions and time range
  * - Rendering entries for:
  *   - pageview
  *   - custom event
@@ -52,7 +52,10 @@ const getReport = (page: Page) => page.getByTestId('report-behaviours')
 const getExplorationTabButton = (report: Locator) =>
   tabButton(report, 'Explore')
 
-test('load featured tunnel with only a single step', async ({ page, request }) => {
+test('load featured tunnel with only a single step', async ({
+  page,
+  request
+}) => {
   const report = getReport(page)
   const explorationTabButton = getExplorationTabButton(report)
   const { domain } = await setupSite({ page, request })
@@ -91,12 +94,197 @@ test('load featured tunnel with only a single step', async ({ page, request }) =
     firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
   ).toHaveText(['/page'])
 
-
   await expect(
     firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
   ).toHaveText(['1'])
 
-
   await expect(secondColumn).toHaveText(/1 step after/)
   await expect(secondColumn).toHaveText(/No further steps found/)
+})
+
+// current version is often stuck loading if the timing is unlucky
+test('load featured tunnel and switch to a period with no events without waiting for load', async ({
+  page,
+  request
+}) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/page',
+        timestamp: { hoursAgo: 40 }
+      }
+    ]
+  })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  // switch to 'Today'
+  await page.keyboard.press('d')
+
+  await expect(report).toHaveText(/No data yet/)
+})
+
+test('load featured tunnel and switch to a period with no events', async ({
+  page,
+  request
+}) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/page',
+        timestamp: { hoursAgo: 40 }
+      }
+    ]
+  })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+
+  await expect(firstColumn).toBeVisible()
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/page'])
+
+  // switch to 'Today'
+  await page.keyboard.press('d')
+
+  await expect(report).toHaveText(/No data yet/)
+})
+
+test('load a 3-step featured funnel', async ({ page, request }) => {
+  const report = getReport(page)
+  const explorationTabButton = getExplorationTabButton(report)
+  const { domain } = await setupSite({ page, request })
+
+  await populateStats({
+    request,
+    domain,
+    events: [
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 123,
+        name: 'pageview',
+        pathname: '/dashboard',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 124,
+        name: 'pageview',
+        pathname: '/login',
+        timestamp: { minutesAgo: 30 }
+      },
+      {
+        user_id: 125,
+        name: 'pageview',
+        pathname: '/home',
+        timestamp: { minutesAgo: 35 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/another',
+        timestamp: { minutesAgo: 40 }
+      },
+      {
+        user_id: 126,
+        name: 'pageview',
+        pathname: '/journey',
+        timestamp: { minutesAgo: 35 }
+      }
+    ]
+  })
+
+  await page.goto('/' + domain, { waitUntil: 'commit' })
+
+  await explorationTabButton.click()
+
+  await expect(report.getByTestId('exploration-title')).toHaveText(
+    'Explore user journeys'
+  )
+
+  await expect(
+    report.getByTestId('exploration-direction-forward')
+  ).toBeVisible()
+
+  const firstColumn = report.getByTestId('exploration-column-0')
+  const secondColumn = report.getByTestId('exploration-column-1')
+  const thirdColumn = report.getByTestId('exploration-column-2')
+
+  await expect(firstColumn).toBeVisible()
+  await expect(secondColumn).toBeVisible()
+  await expect(thirdColumn).toBeVisible()
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/home', '/login', '/another', '/dashboard', '/journey'])
+
+  await expect(
+    firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
+  ).toHaveText(['3', '2', '1', '1', '1'])
+
+  await expect(
+    secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['/login', 'no further action'])
+
+  await expect(
+    secondColumn.getByTestId('exploration-row').getByTestId('metric-value')
+  ).toHaveText(['2', '1'])
+
+  await expect(
+    thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
+  ).toHaveText(['no further action', '/dashboard'])
+
+  await expect(
+    thirdColumn.getByTestId('exploration-row').getByTestId('metric-value')
+  ).toHaveText(['1', '1'])
+
+  await expect(secondColumn).toHaveText(/1 step after/)
+  await expect(thirdColumn).toHaveText(/2 steps after/)
 })

--- a/e2e/tests/dashboard/top-stats.spec.ts
+++ b/e2e/tests/dashboard/top-stats.spec.ts
@@ -1,20 +1,8 @@
 import { test, expect } from '@playwright/test'
-import {
-  ZonedDateTime,
-  ZoneOffset,
-  ChronoUnit,
-  DateTimeFormatter
-} from '@js-joda/core'
+import { ChronoUnit, DateTimeFormatter } from '@js-joda/core'
 import { Locale } from '@js-joda/locale'
+import { currentTime, timeToISO } from '../test-utils'
 import { setupSite, populateStats, StatsEntry } from '../fixtures'
-
-function currentTime(): ZonedDateTime {
-  return ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
-}
-
-function timeToISO(ts: ZonedDateTime): string {
-  return ts.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-}
 
 test('site switcher allows switching between different sites', async ({
   page,

--- a/e2e/tests/test-utils.ts
+++ b/e2e/tests/test-utils.ts
@@ -1,5 +1,19 @@
 import type { Locator, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
+import {
+  ZonedDateTime,
+  ZoneOffset,
+  ChronoUnit,
+  DateTimeFormatter
+} from '@js-joda/core'
+
+export function currentTime(): ZonedDateTime {
+  return ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+}
+
+export function timeToISO(ts: ZonedDateTime): string {
+  return ts.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+}
 
 export async function expectLiveViewConnected(page: Page) {
   await expect

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -25,13 +25,15 @@ defmodule PlausibleWeb.Api.StatsController do
   @not_set "(not set)"
 
   on_ee do
-    plug PlausibleWeb.SuperAdminOnlyPlug
-         when action in [
-                :exploration_next,
-                :exploration_funnel,
-                :exploration_next_with_funnel,
-                :exploration_featured_funnel
-              ]
+    if Mix.env() != :e2e_test do
+      plug PlausibleWeb.SuperAdminOnlyPlug
+           when action in [
+                  :exploration_next,
+                  :exploration_funnel,
+                  :exploration_next_with_funnel,
+                  :exploration_featured_funnel
+                ]
+    end
   end
 
   plug(:date_validation_plug when action not in [:query])
@@ -140,8 +142,13 @@ defmodule PlausibleWeb.Api.StatsController do
     alias Plausible.Stats.Exploration
 
     @exploration_wildcard_disabled_flag :exploration_wildcard_disabled
-    @exploration_hourly_limit 600
-    @exploration_burst_limit 10
+    if Mix.env() == :e2e_test do
+      @exploration_hourly_limit 100_000
+      @exploration_burst_limit 100_000
+    else
+      @exploration_hourly_limit 600
+      @exploration_burst_limit 10
+    end
 
     defp check_exploration_rate_limit(site) do
       key = "exploration:#{site.id}"

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -59,9 +59,6 @@ defmodule PlausibleWeb.StatsController do
 
     consolidated_view? = Plausible.Sites.consolidated?(site)
 
-    exploration_available? =
-      on_ee(do: Plausible.Auth.super_admin?(current_user), else: false)
-
     {exploration_journey_end_event, exploration_max_journey_steps} =
       on_ee(
         do:
@@ -108,7 +105,7 @@ defmodule PlausibleWeb.StatsController do
           hide_footer?: if(ce?() || demo, do: false, else: site_role != :public),
           consolidated_view?: consolidated_view?,
           consolidated_view_available?: consolidated_view_available?,
-          exploration_available?: exploration_available?,
+          exploration_available?: exploration_available?(current_user),
           exploration_journey_end_event: exploration_journey_end_event,
           exploration_max_journey_steps: exploration_max_journey_steps,
           team_identifier: team_identifier,
@@ -482,9 +479,6 @@ defmodule PlausibleWeb.StatsController do
 
         flags = get_flags(current_user, shared_link.site)
 
-        exploration_available? =
-          on_ee(do: Plausible.Auth.super_admin?(current_user), else: false)
-
         {exploration_journey_end_event, exploration_max_journey_steps} =
           on_ee(
             do:
@@ -542,13 +536,23 @@ defmodule PlausibleWeb.StatsController do
           # no shared links for consolidated views
           consolidated_view?: false,
           consolidated_view_available?: false,
-          exploration_available?: exploration_available?,
+          exploration_available?: exploration_available?(current_user),
           exploration_journey_end_event: exploration_journey_end_event,
           exploration_max_journey_steps: exploration_max_journey_steps,
           team_identifier: team_identifier,
           limited_to_segment_id: limited_to_segment_id
         )
     end
+  end
+
+  if Mix.env() != :e2e_test do
+    on_ee do
+      defp exploration_available?(user), do: Plausible.Auth.super_admin?(user)
+    else
+      defp exploration_available?(_user), do: false
+    end
+  else
+    defp exploration_available?(_user), do: true
   end
 
   defp get_fallback_site_role(conn),


### PR DESCRIPTION
### Changes

This PR introduces an E2E test harness to exploration UI. It's not exhaustive but it provides at least some basis for the future refactorings of the FE logic.

### Tests
- [x] Automated tests have been added

