### PR TITLE
Fix graph conversion rate

### DIFF
--- a/assets/js/dashboard/stats/graph/fetch-main-graph.ts
+++ b/assets/js/dashboard/stats/graph/fetch-main-graph.ts
@@ -1,8 +1,7 @@
 import { Metric } from '../metrics'
-import { DashboardState } from '../../dashboard-state'
 import { DashboardPeriod } from '../../dashboard-time-periods'
-import { PlausibleSite, useSiteContext } from '../../site-context'
-import { createStatsQuery, ReportParams, StatsQuery } from '../../stats-query'
+import { useSiteContext } from '../../site-context'
+import { createStatsQuery, StatsQuery } from '../../stats-query'
 import { isRealTimeDashboard } from '../../util/filters'
 import { MetricValue } from '../../api'
 import * as api from '../../api'
@@ -21,12 +20,15 @@ export function useMainGraphQuery(
   const site = useSiteContext()
   const { dashboardState } = useDashboardStateContext()
 
+  const metricToQuery =
+    metric === 'conversion_rate' ? 'group_conversion_rate' : metric
+
   const mainGraphQueryKey: StatsReportQueryKey = [
     'main-graph',
     {
       dashboardState,
       reportParams: {
-        metrics: [metric!],
+        metrics: [metricToQuery!],
         dimensions: [`time:${interval}`],
         include: {
           time_labels: true,
@@ -60,35 +62,6 @@ function getMainGraphQuery(queryKey: StatsReportQueryKey): StatsQuery {
   }
 
   return statsQuery
-}
-
-export function fetchMainGraph(
-  site: PlausibleSite,
-  dashboardState: DashboardState,
-  metric: Metric,
-  interval: Interval
-): Promise<MainGraphResponse> {
-  const metricToQuery =
-    metric === 'conversion_rate' ? 'group_conversion_rate' : metric
-
-  const reportParams: ReportParams = {
-    metrics: [metricToQuery],
-    dimensions: [`time:${interval}`],
-    include: {
-      time_labels: true,
-      partial_time_labels: true,
-      empty_metrics: true,
-      present_index: true
-    }
-  }
-
-  const statsQuery = createStatsQuery(dashboardState, reportParams)
-
-  if (isRealTimeDashboard(dashboardState)) {
-    statsQuery.date_range = DashboardPeriod.realtime_30m
-  }
-
-  return api.stats(site, statsQuery)
 }
 
 export type ResultItem = {


### PR DESCRIPTION
### Changes

Fix regression introduced in https://github.com/plausible/analytics/pull/6351. The refactor missed the `conversion_rate` -> `group_conversion_rate` override. Graph should always request the latter.

Trying to get this in as a quick fix but working on tests as we speak.

### Tests
- [x] Upcoming PR

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
