### PR TITLE
Distinguish exploration step types with icons

### DIFF
--- a/assets/js/dashboard/components/icons.tsx
+++ b/assets/js/dashboard/components/icons.tsx
@@ -79,26 +79,56 @@ export const RefreshIcon = ({ className }: { className?: string }) => (
   </svg>
 )
 
-export const CursorIcon = ({
-  className,
-  title
-}: {
-  className?: string
-  title?: string
-}) => (
+export const CursorIcon = ({ className }: { className?: string }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
     fill="none"
     className={className}
   >
-    {title && <title>{title}</title>}
     <path
       stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth="1.5"
       d="m4.63 3.711 15.23 5.565c.641.235.623 1.148-.028 1.358l-6.97 2.23-2.232 6.971c-.208.65-1.122.67-1.357.028L3.71 4.631a.717.717 0 0 1 .92-.92"
+    />
+  </svg>
+)
+
+export const DocumentIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    className={className}
+  >
+    <g
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+    >
+      <path d="M20.216 8.333h-4.547a1.334 1.334 0 0 1-1.333-1.334V2.47" />
+      <path d="M3.668 18.999v-14a2.666 2.666 0 0 1 2.667-2.667h7.448c.353 0 .693.14.942.39l5.219 5.22c.25.25.39.589.39.942v10.115a2.666 2.666 0 0 1-2.666 2.666H6.335A2.666 2.666 0 0 1 3.668 19" />
+    </g>
+  </svg>
+)
+
+export const FolderIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    className={className}
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeMiterlimit="10"
+      strokeWidth="1.5"
+      d="M2 5v13a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7l-3-3H4a2 2 0 0 0-2 2"
     />
   </svg>
 )

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -17,9 +17,18 @@ import {
   numberShortFormatter,
   numberLongFormatter
 } from '../util/number-formatter'
-import { RefreshIcon, CursorIcon } from '../components/icons'
-import { ChevronUpDownIcon, ChevronRightIcon } from '@heroicons/react/20/solid'
-import { FlagIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import {
+  RefreshIcon,
+  CursorIcon,
+  FolderIcon,
+  DocumentIcon
+} from '../components/icons'
+import { ChevronUpDownIcon } from '@heroicons/react/20/solid'
+import {
+  FlagIcon,
+  MagnifyingGlassIcon,
+  NoSymbolIcon
+} from '@heroicons/react/24/outline'
 import { popover } from '../components/popover'
 
 const DIRECTION = { FORWARD: 'forward', BACKWARD: 'backward' }
@@ -386,15 +395,13 @@ function CandidateCard({
     ? 'text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-400'
     : 'text-gray-900 dark:text-gray-100'
 
-  const subpathColor = isDimmed
-    ? 'text-gray-400 dark:text-gray-500 group-hover:text-gray-500 dark:group-hover:text-gray-400'
-    : 'text-gray-500 dark:text-gray-400'
-
-  const barBg = isSelected
-    ? 'bg-indigo-150 group-hover:bg-indigo-150 dark:bg-indigo-500/50 dark:group-hover:bg-indigo-500/50'
-    : isDimmed
-      ? 'bg-indigo-50/80 dark:bg-indigo-500/10 group-hover:bg-indigo-100 dark:group-hover:bg-indigo-500/25'
-      : 'bg-indigo-50 group-hover:bg-indigo-100 dark:bg-indigo-500/20 dark:group-hover:bg-indigo-500/30'
+  const barBg = isJourneyEnd
+    ? 'bg-gray-100 dark:bg-gray-700/50'
+    : isSelected
+      ? 'bg-indigo-150 group-hover:bg-indigo-150 dark:bg-indigo-500/50 dark:group-hover:bg-indigo-500/50'
+      : isDimmed
+        ? 'bg-indigo-50/80 dark:bg-indigo-500/10 group-hover:bg-indigo-100 dark:group-hover:bg-indigo-500/25'
+        : 'bg-indigo-50 group-hover:bg-indigo-100 dark:bg-indigo-500/20 dark:group-hover:bg-indigo-500/30'
 
   const rowBg = isSelected
     ? 'bg-gray-100/60 dark:bg-gray-850'
@@ -403,6 +410,34 @@ function CandidateCard({
   const pointer = isJourneyEnd ? 'pointer-events-none' : ''
 
   const onSelectHandler = isJourneyEnd ? () => {} : onSelect
+
+  const iconClassName = `size-4 shrink-0 ${textColor}`
+  const iconTooltipInfo =
+    isCustomEvent || isGoal
+      ? isGoal
+        ? 'Goal'
+        : 'Custom event'
+      : step.includes_subpaths
+        ? `Pageview group: ${numberShortFormatter(step.subpaths_count)} pages with this prefix`
+        : 'Pageview'
+
+  const iconSvg = isJourneyEnd ? (
+    <NoSymbolIcon className={iconClassName} />
+  ) : isCustomEvent || isGoal ? (
+    <CursorIcon className={iconClassName} />
+  ) : step.includes_subpaths ? (
+    <FolderIcon className={iconClassName} />
+  ) : (
+    <DocumentIcon className={iconClassName} />
+  )
+
+  const iconElement = isJourneyEnd ? (
+    iconSvg
+  ) : (
+    <Tooltip info={iconTooltipInfo} containerRef={{ current: document.body }}>
+      {iconSvg}
+    </Tooltip>
+  )
 
   return (
     <li data-testid="exploration-row">
@@ -419,34 +454,12 @@ function CandidateCard({
 
         <div className="relative flex items-center justify-between gap-2 px-2 py-1.5">
           <span
-            className={`flex items-center gap-1.5 min-w-0 ${textColor}`}
+            className={`flex items-center gap-2 min-w-0 ${textColor}`}
+            title={step.label}
             data-testid="metric-label"
-            title={
-              step.includes_subpaths
-                ? `${step.label} > all (${step.subpaths_count})`
-                : step.label
-            }
           >
-            {(isCustomEvent || isGoal) && (
-              <CursorIcon
-                title={isGoal ? 'Goal' : 'Custom event'}
-                className={`size-4 shrink-0 ${textColor}`}
-              />
-            )}
+            {iconElement}
             <span className="truncate">{step.label}</span>
-            {step.includes_subpaths && (
-              <>
-                <ChevronRightIcon
-                  className={`mt-0.5 size-3 shrink-0 ${subpathColor}`}
-                />
-                <span className={`shrink-0 ${subpathColor}`}>
-                  all{' '}
-                  <span className="text-[0.85rem]">
-                    ({numberShortFormatter(step.subpaths_count)})
-                  </span>
-                </span>
-              </>
-            )}
           </span>
 
           <span className={`shrink-0 font-medium ${textColor}`}>
@@ -596,7 +609,7 @@ function ExplorationColumn({
       data-exploration-column={colIndex}
       className="border border-gray-200 dark:border-gray-750 rounded-lg overflow-hidden"
     >
-      <div className="h-[42px] py-2 pl-4 pr-1.5 flex items-center justify-between gap-x-2">
+      <div className="h-[44px] py-1.5 pl-4 pr-1.5 flex items-center justify-between gap-x-2">
         {onDirectionChange ? (
           <DirectionDropdown
             direction={direction}
@@ -615,7 +628,7 @@ function ExplorationColumn({
             defaultValue={filter}
             placeholder="Search"
             onChange={debouncedFilterChange}
-            className="peer max-w-48 w-full text-xs dark:text-gray-100 block border-gray-300 dark:border-gray-700 rounded-md dark:bg-gray-700 dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
+            className="peer max-w-48 w-full h-full py-0 text-xs dark:text-gray-100 block border-gray-300 dark:border-gray-700 rounded-md dark:bg-gray-700 dark:placeholder:text-gray-400 focus:outline-none focus:ring-3 focus:ring-indigo-500/20 dark:focus:ring-indigo-500/25 focus:border-indigo-500"
           />
         )}
 
@@ -1207,7 +1220,7 @@ export function FunnelExploration() {
             ref={containerRef}
             className="relative grid gap-6 overflow-x-auto -mx-5 px-5 -mb-3 pb-3 [scrollbar-width:thin] [scrollbar-color:theme(colors.gray.300)_transparent] dark:[scrollbar-color:theme(colors.gray.600)_transparent]"
             style={{
-              gridTemplateColumns: `repeat(${gridColumns}, minmax(18rem, 1fr))`
+              gridTemplateColumns: `repeat(${gridColumns}, minmax(19rem, 1fr))`
             }}
           >
             {Array.from({ length: numColumns }, (_, i) => {

--- a/assets/js/dashboard/extra/exploration.js
+++ b/assets/js/dashboard/extra/exploration.js
@@ -15,20 +15,12 @@ import { useSiteContext } from '../site-context'
 import { useDashboardStateContext } from '../dashboard-state-context'
 import {
   numberShortFormatter,
-  numberLongFormatter
+  numberLongFormatter,
+  percentageFormatter
 } from '../util/number-formatter'
-import {
-  RefreshIcon,
-  CursorIcon,
-  FolderIcon,
-  DocumentIcon
-} from '../components/icons'
+import { RefreshIcon, CursorIcon, FolderIcon } from '../components/icons'
 import { ChevronUpDownIcon } from '@heroicons/react/20/solid'
-import {
-  FlagIcon,
-  MagnifyingGlassIcon,
-  NoSymbolIcon
-} from '@heroicons/react/24/outline'
+import { FlagIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import { popover } from '../components/popover'
 
 const DIRECTION = { FORWARD: 'forward', BACKWARD: 'backward' }
@@ -418,22 +410,17 @@ function CandidateCard({
         ? 'Goal'
         : 'Custom event'
       : step.includes_subpaths
-        ? `Pageview group: ${numberShortFormatter(step.subpaths_count)} pages with this prefix`
+        ? `Grouped pages: ${numberShortFormatter(step.subpaths_count)} pages with this prefix`
         : 'Pageview'
 
-  const iconSvg = isJourneyEnd ? (
-    <NoSymbolIcon className={iconClassName} />
-  ) : isCustomEvent || isGoal ? (
-    <CursorIcon className={iconClassName} />
-  ) : step.includes_subpaths ? (
-    <FolderIcon className={iconClassName} />
-  ) : (
-    <DocumentIcon className={iconClassName} />
-  )
+  const iconSvg =
+    isCustomEvent || isGoal ? (
+      <CursorIcon className={iconClassName} />
+    ) : step.includes_subpaths ? (
+      <FolderIcon className={iconClassName} />
+    ) : null
 
-  const iconElement = isJourneyEnd ? (
-    iconSvg
-  ) : (
+  const iconElement = !iconSvg ? null : (
     <Tooltip info={iconTooltipInfo} containerRef={{ current: document.body }}>
       {iconSvg}
     </Tooltip>
@@ -1183,7 +1170,7 @@ export function FunnelExploration() {
             <div className="order-last sm:order-none w-full sm:w-auto flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
               <span>
                 <span className="font-medium sm:font-semibold text-gray-700 dark:text-gray-200">
-                  Conversion: {parseFloat(overallConversionRate).toFixed(1)}%{' '}
+                  CR: {percentageFormatter(parseFloat(overallConversionRate))}{' '}
                 </span>
                 <span className="text-gray-500 dark:text-gray-400">
                   ({numberShortFormatter(overallConversionVisitors)})

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -233,7 +233,7 @@ test('load a 3-step featured funnel', async ({ page, request }) => {
 
   await expect(
     secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
-  ).toHaveText(['/login', 'no further action'])
+  ).toHaveText(['/login', 'No further action'])
 
   await expect(
     secondColumn.getByRole('button', { name: '/login' })
@@ -245,7 +245,7 @@ test('load a 3-step featured funnel', async ({ page, request }) => {
 
   await expect(
     thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
-  ).toHaveText(['no further action', '/dashboard'])
+  ).toHaveText(['No further action', '/dashboard'])
 
   await expect(
     thirdColumn.getByRole('button', { name: '/dashboard' })
@@ -371,7 +371,7 @@ test('select entries in a 1-step journey', async ({ page, request }) => {
 
     await expect(
       secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
-    ).toHaveText(['no further action', '/dashboard'])
+    ).toHaveText(['No further action', '/dashboard'])
   })
 
   await test.step('select a different entry', async () => {
@@ -433,7 +433,7 @@ test('select entries in a 1-step journey', async ({ page, request }) => {
 
     await expect(
       secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
-    ).toHaveText(['/login', 'no further action'])
+    ).toHaveText(['/login', 'No further action'])
 
     await expect(
       firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
@@ -603,21 +603,21 @@ test('select entries in a 3-step journey', async ({ page, request }) => {
 
   await expect(
     secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
-  ).toHaveText(['/login', 'no further action', '/blog'])
+  ).toHaveText(['/login', 'No further action', '/blog'])
 
-  await test.step('filter for "no further action" in the second step', async () => {
+  await test.step('filter for "No further action" in the second step', async () => {
     await secondColumn.getByPlaceholder('Search').fill('no further')
 
     await expect(
       secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
-    ).toHaveText(['no further action'])
+    ).toHaveText(['No further action'])
   })
 
   await secondColumn.getByPlaceholder('Search').fill('')
 
   await expect(
     secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
-  ).toHaveText(['/login', 'no further action', '/blog'])
+  ).toHaveText(['/login', 'No further action', '/blog'])
 
   await test.step('select an entry in the 2nd step', async () => {
     await secondColumn.getByRole('button', { name: '/login' }).click()
@@ -652,7 +652,7 @@ test('select entries in a 3-step journey', async ({ page, request }) => {
 
     await expect(
       secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
-    ).toHaveText(['/login', 'no further action', '/blog'])
+    ).toHaveText(['/login', 'No further action', '/blog'])
   })
 
   await test.step('select a different entry in the 1st step', async () => {
@@ -1096,7 +1096,7 @@ test('change filters during a 3-step journey', async ({ page, request }) => {
 
   await expect(
     thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
-  ).toHaveText(['no further action', '/dashboard'])
+  ).toHaveText(['No further action', '/dashboard'])
 
   await expect(
     thirdColumn.getByTestId('exploration-row').getByTestId('metric-value')
@@ -1217,7 +1217,7 @@ test('change filters during a 3-step journey', async ({ page, request }) => {
 
     await expect(
       thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')
-    ).toHaveText(['no further action', '/dashboard'])
+    ).toHaveText(['No further action', '/dashboard'])
 
     await expect(
       thirdColumn.getByTestId('exploration-row').getByTestId('metric-value')
@@ -1339,12 +1339,23 @@ test('render various types of entries', async ({ page, request }) => {
   await expect(
     firstColumn.getByTestId('exploration-row').getByTestId('metric-label')
   ).toHaveText([
-    /\/blog.*all \(2\)/,
-    /Custom event.*checkout/,
-    /Goal.*Create a site/,
+    '/blog',
+    'checkout',
+    'Create a site',
     '/blog/first-post',
     '/blog/second-post',
     '/home',
-    /Goal.*Visit \/login/
+    'Visit /login'
   ])
+
+  await firstColumn.getByTestId('exploration-row').nth(0).locator('svg').hover()
+  await expect(page.getByRole('tooltip')).toHaveText(
+    /Grouped pages: 2 pages with this prefix/
+  )
+
+  await firstColumn.getByTestId('exploration-row').nth(2).locator('svg').hover()
+  await expect(page.getByRole('tooltip')).toHaveText(/Goal/)
+
+  await firstColumn.getByTestId('exploration-row').nth(6).locator('svg').hover()
+  await expect(page.getByRole('tooltip')).toHaveText(/Goal/)
 })

--- a/extra/lib/plausible/stats/journey/step.ex
+++ b/extra/lib/plausible/stats/journey/step.ex
@@ -13,7 +13,7 @@ defmodule Plausible.Stats.Exploration.Journey.Step do
             is_goal: false
 
   @journey_end_event "__journey_end__"
-  @journey_end_label "no further action"
+  @journey_end_label "No further action"
 
   @spec journey_end_event() :: String.t()
   def journey_end_event, do: @journey_end_event

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -632,7 +632,7 @@ defmodule Plausible.Stats.ExplorationTest do
         assert {:ok, [next_step]} =
                  Exploration.next_steps(site, query, journey, search_term: "no further")
 
-        assert next_step.step.label == "no further action"
+        assert next_step.step.label == "No further action"
         assert next_step.visitors == 1
       end
 


### PR DESCRIPTION
### Changes

- Add an icon for pageview groups, pageviews, and 'No further action', each with a tooltip
- Capitalize 'No further action' label
- Change 'No further action' background to gray
- Fix search input spacing
- Change grid column width to 19rem

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
