### PR TITLE
Add proper escaping to goal

### DIFF
--- a/lib/plausible_web/live/goal_settings/form.ex
+++ b/lib/plausible_web/live/goal_settings/form.ex
@@ -330,14 +330,14 @@ defmodule PlausibleWeb.Live.GoalSettings.Form do
         }
         """
       else
-        """
-        {
-          scrollThreshold: '#{assigns.goal.scroll_threshold}',
-          pagePath: '#{assigns.goal.page_path}',
-          displayName: '#{assigns.goal.display_name}',
-          updateDisplayName() {}
-        }
-        """
+        data =
+          Jason.encode!(%{
+            scrollThreshold: to_string(assigns.goal.scroll_threshold),
+            pagePath: assigns.goal.page_path,
+            displayName: assigns.goal.display_name
+          })
+
+        "{...#{data}, updateDisplayName() {}}"
       end
 
     assigns = assign(assigns, :js, js)


### PR DESCRIPTION
Open one of the latest Goals of type Scroll and compare behaviour:
https://staging.plausible.io/cenk.me/settings/goals
vs
https://pr-6386.review.plausible.io/cenk.me/settings/goals