### PR TITLE
Make "No fruther action" clickable

### DIFF
--- a/assets/js/dashboard/extra/exploration/exploration-column.tsx
+++ b/assets/js/dashboard/extra/exploration/exploration-column.tsx
@@ -108,7 +108,6 @@ function CandidateCard({
   onSelect: (step: JourneyStep | null) => void
 }): ReactNode {
   const { explorationJourneyEndEvent: journeyEndEvent } = useSiteContext()
-  const isJourneyEnd = step.name === journeyEndEvent
   const isCustomEvent =
     step.name !== 'pageview' && step.name !== journeyEndEvent
   const isGoal = step.is_goal
@@ -124,21 +123,15 @@ function CandidateCard({
     ? 'text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-400'
     : 'text-gray-900 dark:text-gray-100'
 
-  const barBg = isJourneyEnd
-    ? 'bg-gray-100 dark:bg-gray-700/50'
-    : isSelected
-      ? 'bg-indigo-150 group-hover:bg-indigo-150 dark:bg-indigo-500/50 dark:group-hover:bg-indigo-500/50'
-      : isDimmed
-        ? 'bg-indigo-50/80 dark:bg-indigo-500/10 group-hover:bg-indigo-100 dark:group-hover:bg-indigo-500/25'
-        : 'bg-indigo-50 group-hover:bg-indigo-100 dark:bg-indigo-500/20 dark:group-hover:bg-indigo-500/30'
+  const barBg = isSelected
+    ? 'bg-indigo-150 group-hover:bg-indigo-150 dark:bg-indigo-500/50 dark:group-hover:bg-indigo-500/50'
+    : isDimmed
+      ? 'bg-indigo-50/80 dark:bg-indigo-500/10 group-hover:bg-indigo-100 dark:group-hover:bg-indigo-500/25'
+      : 'bg-indigo-50 group-hover:bg-indigo-100 dark:bg-indigo-500/20 dark:group-hover:bg-indigo-500/30'
 
   const rowBg = isSelected
     ? 'bg-gray-100/60 dark:bg-gray-850'
     : 'hover:bg-gray-100/60 dark:hover:bg-gray-850'
-
-  const pointer = isJourneyEnd ? 'pointer-events-none' : ''
-
-  const onSelectHandler = isJourneyEnd ? () => {} : onSelect
 
   const iconClassName = `size-4 shrink-0 ${textColor}`
   const iconTooltipInfo =
@@ -167,8 +160,8 @@ function CandidateCard({
     <li data-testid="exploration-row">
       <button
         data-exploration-step={isSelected ? colIndex : undefined}
-        className={`group relative w-full text-left text-sm rounded-sm overflow-hidden focus:outline-none ${rowBg} ${pointer}`}
-        onClick={() => onSelectHandler(isSelected ? null : step)}
+        className={`group relative w-full text-left text-sm rounded-sm overflow-hidden focus:outline-none ${rowBg}`}
+        onClick={() => onSelect(isSelected ? null : step)}
       >
         <div
           className={`absolute top-0 left-0 h-full rounded-sm transition-[width] ease-in-out ${barBg}`}

--- a/extra/lib/plausible/stats/exploration.ex
+++ b/extra/lib/plausible/stats/exploration.ex
@@ -536,6 +536,12 @@ defmodule Plausible.Stats.Exploration do
             fragment("match(?, ?)", field(s, ^:"pathname#{count}"), ^pattern)
         )
 
+      step.name == Journey.Step.journey_end_event() ->
+        dynamic(
+          [s],
+          field(s, ^:"name#{count}") == ""
+        )
+
       true ->
         dynamic(
           [s],

--- a/test/plausible/stats/exploration_test.exs
+++ b/test/plausible/stats/exploration_test.exs
@@ -158,6 +158,72 @@ defmodule Plausible.Stats.ExplorationTest do
         assert step4.step.label == "Create site"
       end
 
+      test "handles journey end event step" do
+        site = new_site()
+        now = DateTime.utc_now()
+
+        populate_stats(site, [
+          build(:pageview,
+            user_id: 123,
+            pathname: "/home",
+            timestamp: DateTime.shift(now, minute: -50)
+          ),
+          build(:pageview,
+            user_id: 123,
+            pathname: "/login",
+            timestamp: DateTime.shift(now, minute: -40)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/home",
+            timestamp: DateTime.shift(now, minute: -30)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/login",
+            timestamp: DateTime.shift(now, minute: -20)
+          ),
+          build(:pageview,
+            user_id: 124,
+            pathname: "/dashboard",
+            timestamp: DateTime.shift(now, minute: -10)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/home",
+            timestamp: DateTime.shift(now, minute: -50)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/login",
+            timestamp: DateTime.shift(now, minute: -40)
+          ),
+          build(:pageview,
+            user_id: 125,
+            pathname: "/dashboard",
+            timestamp: DateTime.shift(now, minute: -30)
+          )
+        ])
+
+        query = QueryBuilder.build!(site, input_date_range: :all)
+
+        journey = [
+          %Exploration.Journey.Step{name: "pageview", pathname: "/home"},
+          %Exploration.Journey.Step{name: "pageview", pathname: "/login"},
+          %Exploration.Journey.Step{name: Exploration.Journey.Step.journey_end_event()}
+        ]
+
+        assert {:ok, [_step1, _step2, step3]} = Exploration.journey_funnel(query, journey)
+
+        assert step3.step.label == Exploration.Journey.Step.journey_end_label()
+        assert step3.step.name == Exploration.Journey.Step.journey_end_event()
+        assert step3.visitors == 1
+        assert step3.dropoff == 2
+        assert step3.dropoff_percentage == "66.67"
+        assert step3.conversion_rate == "33.33"
+        assert step3.conversion_rate_step == "33.33"
+      end
+
       test "respects filters in the query", %{site: site} do
         query =
           QueryBuilder.build!(site,


### PR DESCRIPTION
### Changes

"No further action" entries can be now clicked like any other suggestion. Conversion stats are calculated and displayed for them as well.

### Tests
- [x] Automated tests have been added

<img width="1115" height="574" alt="image" src="https://github.com/user-attachments/assets/404666df-30f1-4649-aa9e-f2f5fc966bf9" />

