### PR TITLE
Exploration/billing integration

### DIFF
--- a/assets/js/dashboard/components/feature-preview-mocks.tsx
+++ b/assets/js/dashboard/components/feature-preview-mocks.tsx
@@ -74,7 +74,7 @@ export function ExplorationPreviewMock() {
         <div
           key={colIdx}
           className={classNames(
-            'flex-1 flex-col rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden',
+            'flex-1 flex-col rounded-lg border border-gray-400 dark:border-gray-500 overflow-hidden',
             colIdx === 2 ? 'hidden lg:flex' : 'flex'
           )}
         >

--- a/assets/js/dashboard/components/feature-preview-mocks.tsx
+++ b/assets/js/dashboard/components/feature-preview-mocks.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import classNames from 'classnames'
+
+/*
+ * Non-interactive previews of the Funnels / Properties / Exploration reports,
+ * rendered behind the CTA when the feature isn't available on the current
+ * plan. They give users an at-a-glance idea of what the report looks like
+ * without needing to navigate elsewhere. Always heavily blurred in their
+ * parent container, so the goal is to be suggestive rather than pixel-perfect.
+ */
+
+export function PropertiesPreviewMock() {
+  const rows = [98, 82, 68, 60, 45, 21, 12, 8, 5, 2]
+
+  return (
+    <div className="size-full flex flex-col gap-1.5 pt-9">
+      {rows.map((width, i) => (
+        <div
+          key={i}
+          className="h-7.5 bg-red-200/70 dark:bg-gray-500/30 rounded-sm"
+          style={{ width: `${width}%` }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function FunnelsPreviewMock() {
+  const steps = [{ visitors: 100 }, { visitors: 55 }, { visitors: 24 }]
+
+  return (
+    <div className="size-full flex flex-col pt-5">
+      <div className="h-4 w-32 bg-gray-400/60 dark:bg-gray-600 rounded-md mb-8" />
+
+      <div className="flex-1 flex items-end justify-between lg:justify-around gap-6">
+        {steps.map((step, i) => (
+          <div
+            key={i}
+            className="relative h-full flex-1 max-w-[160px] flex flex-col justify-end rounded-md overflow-hidden"
+          >
+            <div
+              className="w-full bg-indigo-100 dark:bg-gray-700"
+              style={{ height: `${100 - step.visitors}%` }}
+            />
+            <div
+              className="w-full bg-indigo-500"
+              style={{ height: `${step.visitors}%` }}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-around gap-6 pt-4 pb-2">
+        {steps.map((_, i) => (
+          <div key={i} className="flex-1 max-w-[160px] flex justify-center">
+            <div className="h-3 w-3/5 bg-gray-400/70 dark:bg-gray-600 rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function ExplorationPreviewMock() {
+  const columns = [
+    [98, 96, 54, 42, 27, 18, 15, 10, 5],
+    [88, 70, 68, 30, 18, 16, 10, 9, 5],
+    [82, 78, 48, 35, 25, 14, 12, 10, 5]
+  ]
+
+  return (
+    <div className="size-full flex gap-3 pt-3">
+      {columns.map((rows, colIdx) => (
+        <div
+          key={colIdx}
+          className={classNames(
+            'flex-1 flex-col rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden',
+            colIdx === 2 ? 'hidden lg:flex' : 'flex'
+          )}
+        >
+          <div className="h-12 shrink-0 flex items-center px-3">
+            <div className="h-2.5 w-20 bg-gray-400/70 dark:bg-gray-500/80 rounded" />
+          </div>
+          <div className="flex flex-col gap-1.5 px-2 pb-2">
+            {rows.map((width, i) => (
+              <div
+                key={i}
+                className={
+                  i === 0 && colIdx === 0
+                    ? 'h-7.5 bg-indigo-300/80 dark:bg-indigo-500/70 rounded-sm'
+                    : 'h-7.5 bg-indigo-200/70 dark:bg-indigo-500/30 rounded-sm'
+                }
+                style={{ width: `${width}%` }}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/assets/js/dashboard/components/feature-setup-notice.tsx
+++ b/assets/js/dashboard/components/feature-setup-notice.tsx
@@ -1,20 +1,37 @@
 import React from 'react'
+import classNames from 'classnames'
 import { MODES } from '../stats/behaviours/modes-context'
 import * as api from '../api'
 import { useSiteContext } from '../site-context'
+import { Pill } from './pill'
+import { DiamondIcon } from './icons'
+import { buttonClassName } from './button'
+
+function BusinessPill() {
+  return (
+    <Pill color="yellow">
+      <DiamondIcon className="size-3.5 [&_path]:stroke-2" />
+      Business
+    </Pill>
+  )
+}
 
 export function FeatureSetupNotice({
   feature,
   title,
   info,
   callToAction,
-  onHideAction
+  secondaryCallToAction,
+  onHideAction,
+  previewMock
 }: {
   feature: keyof typeof MODES
   title: React.ReactNode
   info: React.ReactNode
   callToAction: { link: string; action: string }
-  onHideAction: () => void
+  secondaryCallToAction?: { link: string; action: string }
+  onHideAction: (() => void) | null
+  previewMock?: React.ReactNode
 }) {
   const site = useSiteContext()
   const sectionTitle = MODES[feature].title
@@ -30,7 +47,7 @@ export function FeatureSetupNotice({
           method: 'PUT',
           body: { feature: feature }
         })
-        .then(() => onHideAction())
+        .then(() => onHideAction?.())
         .catch((error) => {
           if (!(error instanceof api.ApiError)) {
             throw error
@@ -43,23 +60,12 @@ export function FeatureSetupNotice({
     return (
       <a
         href={callToAction.link}
-        className="flex items-center gap-x-1.5 ml-2 sm:ml-4 button px-2 sm:px-4"
+        className={buttonClassName({
+          theme: 'primary',
+          className: 'ml-2 sm:ml-4'
+        })}
       >
-        <p className="text-xs sm:text-sm font-medium">{callToAction.action}</p>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="size-4"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"
-          />
-        </svg>
+        {callToAction.action} &rarr;
       </a>
     )
   }
@@ -68,24 +74,65 @@ export function FeatureSetupNotice({
     return (
       <button
         onClick={requestHideSection}
-        className="inline-block px-2 sm:px-4 py-2 font-medium leading-5 rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:text-white hover:shadow-sm transition-all duration-150"
+        className={buttonClassName({ theme: 'secondary' })}
       >
         Hide this report
       </button>
     )
   }
 
+  function renderSecondaryCallToAction() {
+    if (!secondaryCallToAction) {
+      return null
+    }
+    return (
+      <a
+        href={secondaryCallToAction.link}
+        className={buttonClassName({
+          theme: 'secondary'
+        })}
+      >
+        {secondaryCallToAction.action}
+      </a>
+    )
+  }
+
   return (
-    <div className="size-full flex items-center justify-center">
-      <div className="py-3 max-w-2xl">
+    <div
+      className={classNames(
+        'relative size-full flex items-center justify-center',
+        previewMock && 'md:h-[400px]'
+      )}
+    >
+      {previewMock && (
+        <div
+          aria-hidden="true"
+          className="hidden md:block pointer-events-none absolute inset-0 blur-sm opacity-50"
+        >
+          {previewMock}
+        </div>
+      )}
+      <div
+        className={classNames(
+          'relative py-3 max-w-2xl',
+          previewMock &&
+            'max-w-[600px] md:p-8 md:bg-white md:dark:bg-gray-800 md:border md:border-gray-100 md:dark:border-gray-750 md:rounded-lg md:shadow-xl'
+        )}
+      >
+        {previewMock && (
+          <div className="flex justify-center mb-3">
+            <BusinessPill />
+          </div>
+        )}
         <div className="text-center mt-2 text-gray-800 dark:text-gray-200 font-medium text-pretty">
           {title}
         </div>
-        <div className="text-center mt-4 font-small text-sm text-gray-500 dark:text-gray-200 text-pretty">
+        <div className="text-center mt-4 font-small text-sm text-gray-500 dark:text-gray-300 text-pretty">
           {info}
         </div>
-        <div className="text-xs sm:text-sm flex my-6 justify-center">
+        <div className="text-xs sm:text-sm flex mt-6 mb-1 justify-center">
           {typeof onHideAction === 'function' && renderHideButton()}
+          {renderSecondaryCallToAction()}
           {renderCallToAction()}
         </div>
       </div>

--- a/assets/js/dashboard/components/feature-setup-notice.tsx
+++ b/assets/js/dashboard/components/feature-setup-notice.tsx
@@ -85,7 +85,7 @@ export function FeatureSetupNotice({
           {info}
         </div>
         <div className="text-xs sm:text-sm flex my-6 justify-center">
-          {renderHideButton()}
+          {typeof onHideAction === 'function' && renderHideButton()}
           {renderCallToAction()}
         </div>
       </div>

--- a/assets/js/dashboard/components/feature-setup-notice.tsx
+++ b/assets/js/dashboard/components/feature-setup-notice.tsx
@@ -116,7 +116,7 @@ export function FeatureSetupNotice({
         className={classNames(
           'relative py-3 max-w-2xl',
           previewMock &&
-            'max-w-[600px] md:p-8 md:bg-white md:dark:bg-gray-800 md:border md:border-gray-100 md:dark:border-gray-750 md:rounded-lg md:shadow-xl'
+            'max-w-lg md:p-8 md:bg-white md:dark:bg-gray-800 md:border md:border-gray-100 md:dark:border-gray-750 md:rounded-lg md:shadow-xl'
         )}
       >
         {previewMock && (

--- a/assets/js/dashboard/components/icons.tsx
+++ b/assets/js/dashboard/components/icons.tsx
@@ -133,6 +133,23 @@ export const FolderIcon = ({ className }: { className?: string }) => (
   </svg>
 )
 
+export const DiamondIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    className={className}
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      d="M2.734 9h18.531M3.023 8.164l3.205-3.408c.255-.27.61-.424.984-.424h9.57c.374 0 .73.153.985.424l3.205 3.408c.44.468.48 1.18.093 1.693l-7.99 10.608a1.352 1.352 0 0 1-2.155 0L2.93 9.857a1.31 1.31 0 0 1 .093-1.693"
+    />
+  </svg>
+)
+
 export const Spinner = ({ className }: { className?: string }) => (
   <svg
     className={className}

--- a/assets/js/dashboard/components/pill.tsx
+++ b/assets/js/dashboard/components/pill.tsx
@@ -1,16 +1,26 @@
 import React, { ReactNode } from 'react'
 import classNames from 'classnames'
 
+export type PillColor = 'green' | 'yellow'
+
+const colorClasses: Record<PillColor, string> = {
+  green: 'bg-green-50 dark:bg-green-900/60 text-green-700 dark:text-green-300',
+  yellow:
+    'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-600 dark:text-yellow-400'
+}
+
 export type PillProps = {
   className?: string
+  color?: PillColor
   children: ReactNode
 }
 
-export function Pill({ className, children }: PillProps) {
+export function Pill({ className, color = 'green', children }: PillProps) {
   return (
     <div
       className={classNames(
-        'flex items-center shrink-0 h-fit rounded-md bg-green-50 dark:bg-green-900/60 text-green-700 dark:text-green-300 text-xs font-medium px-2.5 py-1',
+        'flex items-center gap-x-1 shrink-0 h-fit rounded-md text-xs font-medium px-2.5 py-1',
+        colorClasses[color],
         className
       )}
     >

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -32,7 +32,7 @@ import { getSpecialGoal, isPageViewGoal, isSpecialGoal } from '../../util/goals'
 
 /*global BUILD_EXTRA*/
 /*global require*/
-function maybeRequire() {
+function maybeRequireFunnels() {
   if (BUILD_EXTRA) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require('../../extra/funnel')
@@ -46,12 +46,12 @@ function maybeRequireExploration() {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require('../../extra/exploration')
   } else {
-    return { FunnelExploration: null }
+    return { default: null }
   }
 }
 
-const Funnel = maybeRequire().default
-const { FunnelExploration } = maybeRequireExploration()
+const Funnel = maybeRequireFunnels().default
+const FunnelExploration = maybeRequireExploration().default
 
 function singleGoalFilterApplied(dashboardState) {
   const goalFilter = getGoalFilter(dashboardState)
@@ -304,7 +304,24 @@ function Behaviours({ importedDataInView, setMode, mode }) {
     if (FunnelExploration === null) {
       return featureUnavailable()
     }
-    return <FunnelExploration />
+
+    if (site.explorationAvailable) {
+      return <FunnelExploration />
+    }
+
+    const callToAction = { action: 'Upgrade', link: '/billing/choose-plan' }
+
+    return (
+      <FeatureSetupNotice
+        feature={Mode.EXPLORATION}
+        title={'Discover how visitors navigate your site'}
+        info={
+          'See where visitors continue, convert or leave with detailed path exploration'
+        }
+        callToAction={callToAction}
+        onHideAction={null}
+      />
+    )
   }
 
   function renderFunnels() {
@@ -383,8 +400,14 @@ function Behaviours({ importedDataInView, setMode, mode }) {
 
   function featureUnavailable() {
     return (
-      <div className="flex-1 flex items-center justify-center font-medium text-gray-500 dark:text-gray-400">
-        This feature is unavailable
+      <div className="flex-1 flex flex-col items-center justify-center font-medium text-gray-500 dark:text-gray-400">
+        <span>This report is available in Plausible Cloud</span>
+        <a
+          className="flex items-center gap-x-1.5 mt-4 button px-2 sm:px-4"
+          href="https://plausible.io"
+        >
+          Learn more
+        </a>
       </div>
     )
   }
@@ -537,7 +560,7 @@ function Behaviours({ importedDataInView, setMode, mode }) {
                   Funnels
                 </TabButton>
               ))}
-            {!site.isConsolidatedView && site.explorationAvailable && (
+            {!site.isConsolidatedView && isEnabled(Mode.EXPLORATION) && (
               <TabButton
                 active={mode === Mode.EXPLORATION}
                 onClick={setTabFactory(Mode.EXPLORATION)}

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -319,9 +319,9 @@ function Behaviours({ importedDataInView, setMode, mode }) {
     return (
       <FeatureSetupNotice
         feature={Mode.EXPLORATION}
-        title={'Discover how visitors navigate your site'}
+        title={'Explore user journeys'}
         info={
-          'User journeys allow you to see how visitors navigate your site, where they convert and where they drop off.'
+          'See how visitors move between pages and events to understand browsing behavior.'
         }
         callToAction={callToAction}
         secondaryCallToAction={{ action: 'Learn more', link: '#' }}
@@ -351,9 +351,9 @@ function Behaviours({ importedDataInView, setMode, mode }) {
       return (
         <FeatureSetupNotice
           feature={Mode.FUNNELS}
-          title={'Follow the visitor journey from entry to conversion'}
+          title={'Analyze conversion funnels'}
           info={
-            'Funnels allow you to analyze the user flow through your website, uncover possible issues, optimize your site and increase the conversion rate.'
+            'Measure conversion rates between each step and identify where visitors drop off.'
           }
           callToAction={callToAction}
           onHideAction={() => disableMode(Mode.FUNNELS)}
@@ -387,9 +387,9 @@ function Behaviours({ importedDataInView, setMode, mode }) {
       return (
         <FeatureSetupNotice
           feature={Mode.PROPS}
-          title={'Send custom data to create your own metrics'}
+          title={'Attach your own data to the stats'}
           info={
-            "You can attach custom properties when sending a pageview or event. This allows you to create custom metrics and analyze stats we don't track automatically."
+            "Create custom metrics and analyze data specific to your business."
           }
           callToAction={callToAction}
           onHideAction={() => disableMode(Mode.PROPS)}

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -324,7 +324,10 @@ function Behaviours({ importedDataInView, setMode, mode }) {
           'See how visitors move between pages and events to understand browsing behavior.'
         }
         callToAction={callToAction}
-        secondaryCallToAction={{ action: 'Learn more', link: '#' }}
+        secondaryCallToAction={{
+          action: 'Learn more',
+          link: 'https://plausible.io/docs/user-journeys'
+        }}
         onHideAction={null}
         previewMock={<ExplorationPreviewMock />}
       />
@@ -389,7 +392,7 @@ function Behaviours({ importedDataInView, setMode, mode }) {
           feature={Mode.PROPS}
           title={'Attach your own data to the stats'}
           info={
-            "Create custom metrics and analyze data specific to your business."
+            'Create custom metrics and analyze data specific to your business.'
           }
           callToAction={callToAction}
           onHideAction={() => disableMode(Mode.PROPS)}

--- a/assets/js/dashboard/stats/behaviours/index.js
+++ b/assets/js/dashboard/stats/behaviours/index.js
@@ -4,6 +4,11 @@ import ImportedQueryUnsupportedWarning from '../imported-query-unsupported-warni
 import Properties from './props'
 import { FeatureSetupNotice } from '../../components/feature-setup-notice'
 import {
+  ExplorationPreviewMock,
+  FunnelsPreviewMock,
+  PropertiesPreviewMock
+} from '../../components/feature-preview-mocks'
+import {
   hasConversionGoalFilter,
   getGoalFilter,
   FILTER_OPERATIONS
@@ -316,10 +321,12 @@ function Behaviours({ importedDataInView, setMode, mode }) {
         feature={Mode.EXPLORATION}
         title={'Discover how visitors navigate your site'}
         info={
-          'See where visitors continue, convert or leave with detailed path exploration'
+          'User journeys allow you to see how visitors navigate your site, where they convert and where they drop off.'
         }
         callToAction={callToAction}
+        secondaryCallToAction={{ action: 'Learn more', link: '#' }}
         onHideAction={null}
+        previewMock={<ExplorationPreviewMock />}
       />
     )
   }
@@ -350,6 +357,9 @@ function Behaviours({ importedDataInView, setMode, mode }) {
           }
           callToAction={callToAction}
           onHideAction={() => disableMode(Mode.FUNNELS)}
+          previewMock={
+            !site.funnelsAvailable ? <FunnelsPreviewMock /> : undefined
+          }
         />
       )
     } else {
@@ -383,6 +393,9 @@ function Behaviours({ importedDataInView, setMode, mode }) {
           }
           callToAction={callToAction}
           onHideAction={() => disableMode(Mode.PROPS)}
+          previewMock={
+            !site.propsAvailable ? <PropertiesPreviewMock /> : undefined
+          }
         />
       )
     } else {

--- a/assets/js/dashboard/stats/behaviours/modes-context.tsx
+++ b/assets/js/dashboard/stats/behaviours/modes-context.tsx
@@ -27,7 +27,7 @@ export const MODES = {
   },
   [Mode.EXPLORATION]: {
     title: 'Exploration',
-    isAvailableKey: null, // always available
+    isAvailableKey: `${Mode.FUNNELS}Available`,
     optedOutKey: null
   }
 } as const

--- a/lib/plausible/billing/feature.ex
+++ b/lib/plausible/billing/feature.ex
@@ -14,6 +14,9 @@ defmodule Plausible.Billing.Feature do
 
     * `:display_name` - human-readable display name of the feature
 
+    * `:toggle_display_name` - human-readable display name used in dashboard
+    toggle notifications. Defaults to `:display_name` if not set.
+
     * `:toggle_field` - the field in the %Plausible.Site{} schema that toggles
     the feature. If `nil` or not set, toggle/2 silently returns `:ok`
 
@@ -109,6 +112,10 @@ defmodule Plausible.Billing.Feature do
       @impl true
       def display_name, do: Keyword.get(unquote(opts), :display_name)
 
+      def toggle_display_name do
+        Keyword.get(unquote(opts), :toggle_display_name, display_name())
+      end
+
       @impl true
       def toggle_field, do: Keyword.get(unquote(opts), :toggle_field)
 
@@ -162,7 +169,8 @@ defmodule Plausible.Billing.Feature.Funnels do
   @moduledoc false
   use Plausible.Billing.Feature,
     name: :funnels,
-    display_name: "Funnels",
+    display_name: "Funnels and user journeys",
+    toggle_display_name: "Funnels",
     toggle_field: :funnels_enabled
 end
 

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -674,8 +674,7 @@ defmodule Plausible.Teams.Billing do
   end
 
   def allowed_features_for(team) do
-    team =
-      Teams.with_subscription(team)
+    team = Teams.with_subscription(team)
 
     features =
       case Plans.get_subscription_plan(team.subscription) do

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -674,7 +674,8 @@ defmodule Plausible.Teams.Billing do
   end
 
   def allowed_features_for(team) do
-    team = Teams.with_subscription(team)
+    team =
+      Teams.with_subscription(team)
 
     features =
       case Plans.get_subscription_plan(team.subscription) do

--- a/lib/plausible_web/components/site/toggle_live.ex
+++ b/lib/plausible_web/components/site/toggle_live.ex
@@ -73,9 +73,9 @@ defmodule PlausibleWeb.Components.Site.Feature.ToggleLive do
 
         message =
           if new_setting do
-            "#{feature_mod.display_name()} are now visible again on your dashboard"
+            "#{feature_mod.toggle_display_name()} are now visible again on your dashboard"
           else
-            "#{feature_mod.display_name()} are now hidden from your dashboard"
+            "#{feature_mod.toggle_display_name()} are now hidden from your dashboard"
           end
 
         send(self(), {:feature_toggled, message, updated_site})

--- a/lib/plausible_web/controllers/api/stats_controller.ex
+++ b/lib/plausible_web/controllers/api/stats_controller.ex
@@ -140,7 +140,6 @@ defmodule PlausibleWeb.Api.StatsController do
   on_ee do
     alias Plausible.Stats.Exploration
 
-    @exploration_wildcard_disabled_flag :exploration_wildcard_disabled
     if Mix.env() == :e2e_test do
       @exploration_hourly_limit 100_000
       @exploration_burst_limit 100_000
@@ -170,13 +169,10 @@ defmodule PlausibleWeb.Api.StatsController do
            {:ok, journey} <- parse_journey(steps),
            {:ok, direction} <- parse_exploration_direction(params["direction"]),
            query = Query.from(site, params, debug_metadata: debug_metadata(conn)),
-           include_wildcard? =
-             not FunWithFlags.enabled?(@exploration_wildcard_disabled_flag, for: site),
            {:ok, next_steps} <-
              Exploration.next_steps(site, query, journey,
                search_term: search_term,
-               direction: direction,
-               include_wildcard?: include_wildcard?
+               direction: direction
              ) do
         json(conn, next_steps)
       else
@@ -221,13 +217,10 @@ defmodule PlausibleWeb.Api.StatsController do
            {:ok, journey} <- parse_journey(steps),
            {:ok, direction} <- parse_exploration_direction(params["direction"]),
            query = Query.from(site, params, debug_metadata: debug_metadata(conn)),
-           include_wildcard? =
-             not FunWithFlags.enabled?(@exploration_wildcard_disabled_flag, for: site),
            {:ok, next_steps} <-
              Exploration.next_steps(site, query, journey,
                search_term: search_term,
                direction: direction,
-               include_wildcard?: include_wildcard?,
                max_candidates: @exploration_max_candidates
              ),
            funnel <- maybe_include_funnel(include_funnel?, query, journey, direction) do

--- a/lib/plausible_web/controllers/stats_controller.ex
+++ b/lib/plausible_web/controllers/stats_controller.ex
@@ -105,7 +105,6 @@ defmodule PlausibleWeb.StatsController do
           hide_footer?: if(ce?() || demo, do: false, else: site_role != :public),
           consolidated_view?: consolidated_view?,
           consolidated_view_available?: consolidated_view_available?,
-          exploration_available?: exploration_available?(current_user),
           exploration_journey_end_event: exploration_journey_end_event,
           exploration_max_journey_steps: exploration_max_journey_steps,
           team_identifier: team_identifier,
@@ -536,23 +535,12 @@ defmodule PlausibleWeb.StatsController do
           # no shared links for consolidated views
           consolidated_view?: false,
           consolidated_view_available?: false,
-          exploration_available?: exploration_available?(current_user),
           exploration_journey_end_event: exploration_journey_end_event,
           exploration_max_journey_steps: exploration_max_journey_steps,
           team_identifier: team_identifier,
           limited_to_segment_id: limited_to_segment_id
         )
     end
-  end
-
-  if Mix.env() != :e2e_test do
-    on_ee do
-      defp exploration_available?(user), do: Plausible.Auth.super_admin?(user)
-    else
-      defp exploration_available?(_user), do: false
-    end
-  else
-    defp exploration_available?(_user), do: true
   end
 
   defp get_fallback_site_role(conn),

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -47,7 +47,9 @@
     data-segments={Jason.encode!(@segments)}
     data-is-consolidated-view={Jason.encode!(@consolidated_view?)}
     data-consolidated-view-available={Jason.encode!(@consolidated_view_available?)}
-    data-exploration-available={Jason.encode!(@exploration_available?)}
+    data-exploration-available={
+      to_string(Plausible.Billing.Feature.Funnels.check_availability(@site.team) == :ok)
+    }
     data-exploration-journey-end-event={@exploration_journey_end_event}
     data-exploration-max-journey-steps={@exploration_max_journey_steps}
     data-team-identifier={@team_identifier}

--- a/test/plausible/billing/plan_benefits_test.exs
+++ b/test/plausible/billing/plan_benefits_test.exs
@@ -80,7 +80,7 @@ defmodule Plausible.Billing.PlanBenefitsTest do
                "Stats API (600 requests per hour)",
                "Looker Studio Connector",
                "Ecommerce revenue attribution",
-               "Funnels",
+               "Funnels and user journeys",
                "Consolidated View"
              ]
     end
@@ -97,7 +97,7 @@ defmodule Plausible.Billing.PlanBenefitsTest do
                "5 years of data retention",
                "Custom Properties",
                "Ecommerce revenue attribution",
-               "Funnels",
+               "Funnels and user journeys",
                "Stats API (600 requests per hour)",
                "Looker Studio Connector",
                "Shared Segments",
@@ -121,7 +121,7 @@ defmodule Plausible.Billing.PlanBenefitsTest do
                ) == [
                  "Everything in Growth",
                  "Ecommerce revenue attribution",
-                 "Funnels",
+                 "Funnels and user journeys",
                  "Shared Segments",
                  "Consolidated View"
                ]

--- a/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/funnels_test.exs
@@ -237,7 +237,7 @@ defmodule PlausibleWeb.Api.StatsController.FunnelsTest do
 
         assert %{
                  "error" =>
-                   "Funnels is part of the Plausible Business plan. To get access to this feature, please upgrade your account."
+                   "Funnels and user journeys is part of the Plausible Business plan. To get access to this feature, please upgrade your account."
                } == resp
       end
     end

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -22,7 +22,7 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-props-available") == "true"
       assert text_of_attr(resp, @react_container, "data-site-segments-available") == "true"
       assert text_of_attr(resp, @react_container, "data-funnels-available") == "true"
-      assert text_of_attr(resp, @react_container, "data-exploration-available") == "false"
+      assert text_of_attr(resp, @react_container, "data-exploration-available") == "true"
       assert text_of_attr(resp, @react_container, "data-has-props") == "false"
       assert text_of_attr(resp, @react_container, "data-logged-in") == "false"
       assert text_of_attr(resp, @react_container, "data-current-user-role") == "public"
@@ -150,17 +150,39 @@ defmodule PlausibleWeb.StatsControllerTest do
       assert text_of_attr(resp, @react_container, "data-logged-in") == "true"
     end
 
-    test "non-superadmin can't see exploration funnel UI", %{conn: conn, site: site} do
-      populate_stats(site, [build(:pageview)])
-      conn = get(conn, "/" <> site.domain)
-      resp = html_response(conn, 200)
-      assert text_of_attr(resp, @react_container, "data-exploration-available") == "false"
-    end
-
     on_ee do
-      test "superadmin can see exploration funnel UI", %{conn: conn, site: site, user: user} do
-        patch_env(:super_admin_user_ids, [user.id])
+      test "can't see exploration funnel UI if funnels feature unavailable", %{
+        conn: conn,
+        site: site,
+        user: user
+      } do
+        subscribe_to_growth_plan(user)
         populate_stats(site, [build(:pageview)])
+        conn = get(conn, "/" <> site.domain)
+        resp = html_response(conn, 200)
+        assert text_of_attr(resp, @react_container, "data-exploration-available") == "false"
+      end
+
+      test "can see exploration funnel UI on trial", %{conn: conn, site: site} do
+        populate_stats(site, [build(:pageview)])
+        conn = get(conn, "/" <> site.domain)
+        resp = html_response(conn, 200)
+        assert text_of_attr(resp, @react_container, "data-exploration-available") == "true"
+      end
+
+      test "can see exploration funnel UI past trial with funnels feature enabled", %{
+        conn: conn,
+        site: site,
+        user: user
+      } do
+        populate_stats(site, [build(:pageview)])
+
+        site.team
+        |> Plausible.Teams.Team.end_trial()
+        |> Plausible.Repo.update!()
+
+        subscribe_to_enterprise_plan(user, features: [Plausible.Billing.Feature.Funnels])
+
         conn = get(conn, "/" <> site.domain)
         resp = html_response(conn, 200)
         assert text_of_attr(resp, @react_container, "data-exploration-available") == "true"


### PR DESCRIPTION
### Changes

This PR renames "Funnels" billing feature to "Funnels and user journeys".
The exploration panel is no longer available for super-admins on all sites, but only on sites where the related subscription enables the Funnels feature. 
Deploying this is essentially go-live at this point.

~~Awaiting CTA tweaks from @sanne-san, then I'll rebase clean.~~