### PR TITLE
Fix isEventFilter condition (fix exit rate causing 400 in exit pages details with prop filter)

### DIFF
--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -201,7 +201,13 @@ const VISIT_PREFIX = 'visit:'
 
 export function hasEventFilters(dashboardState) {
   return dashboardState.resolvedFilters.some(
-    ([_operation, filterKey, _clauses]) => EVENT_FILTER_KEYS.has(filterKey)
+    ([_operation, filterKey, _clauses]) => isEventFilterKey(filterKey)
+  )
+}
+
+function isEventFilterKey(filterKey) {
+  return (
+    EVENT_FILTER_KEYS.has(filterKey) || filterKey.startsWith(EVENT_PROPS_PREFIX)
   )
 }
 
@@ -209,10 +215,7 @@ function remapFilterKey(filterKey) {
   if (NO_PREFIX_KEYS.has(filterKey)) {
     return filterKey
   }
-  if (
-    EVENT_FILTER_KEYS.has(filterKey) ||
-    filterKey.startsWith(EVENT_PROPS_PREFIX)
-  ) {
+  if (isEventFilterKey(filterKey)) {
     return `${EVENT_PREFIX}${filterKey}`
   }
   return `${VISIT_PREFIX}${filterKey}`


### PR DESCRIPTION
### Changes

The attempted fix in https://github.com/plausible/analytics/pull/6395 missed accounting for `props:` prefix as an event filter. This fixes it.