### PR TITLE
Alter a couple E2E exploration test so that they don't fail on evening UTC

### DIFF
--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -19,7 +19,7 @@ test('load user journey', async ({ page, request }) => {
         user_id: 123,
         name: 'pageview',
         pathname: '/page',
-        timestamp: { hoursAgo: 40 }
+        timestamp: { daysAgo: 7 }
       }
     ]
   })
@@ -114,7 +114,7 @@ test('load user journey and switch to a period with no events', async ({
         user_id: 123,
         name: 'pageview',
         pathname: '/page',
-        timestamp: { hoursAgo: 40 }
+        timestamp: { daysAgo: 7 }
       }
     ]
   })


### PR DESCRIPTION
### Changes

While this change makes the tests not fail at least now, it's not ideal. It's also not really a fix but rather a cover up of a certain behavior of FE logic building the initial DashboardState object.

The default period of the query is determined when building dashboard state context in https://github.com/plausible/analytics/blob/e2e-exploration-failing-tests-time/assets/js/dashboard/dashboard-state-context.tsx#L71-L77.

If the current time falls into today _or_ yesterday, a `day` period is chosen: https://github.com/plausible/analytics/blob/e2e-exploration-failing-tests-time/assets/js/dashboard/dashboard-time-periods.ts#L637-L639

Even if the native stats start date falls on yesterday, the default day is always picked as today in https://github.com/plausible/analytics/blob/e2e-exploration-failing-tests-time/assets/js/dashboard/dashboard-state-context.tsx#L98

It means that for stats which a) started collecting yesterday b) don't have any events for today (yet), the dashboard will turn up initially empty. I suppose it's a reasonable compromise but also something that can trip us up when building synthethic test cases via methods like populate_stats.

For now this should do well enough, however, the tests relying on stats setups shifted minutes in the past might fail shortly after midnight UTC. For better robustness, we'd probably have to ensure that the most suitable period is always set manually as part of the test setup. We might circle back to that further robustness refinement later on.
