### PR TITLE
Duplicate legacy, and add new sources/browsers/os-s/conversions tests

### DIFF
--- a/test/plausible_web/controllers/api/stats_controller/browsers_legacy_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_legacy_test.exs
@@ -1,0 +1,588 @@
+defmodule PlausibleWeb.Api.StatsController.BrowsersLegacyTest do
+  @moduledoc """
+  [DEPRECATED] Still used for CSV export but to be removed.
+  """
+  use PlausibleWeb.ConnCase
+
+  describe "GET /api/stats/:domain/browsers" do
+    setup [:create_user, :log_in, :create_site, :create_site_import]
+
+    test "returns top browsers by unique visitors", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, browser: "Chrome"),
+        build(:pageview, browser: "Chrome"),
+        build(:pageview, browser: "Firefox")
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Chrome", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "Firefox", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "returns top browsers with :is filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          browser: "Chrome"
+        ),
+        build(:pageview,
+          user_id: 123,
+          browser: "Chrome",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          browser: "Firefox",
+          "meta.key": ["author"],
+          "meta.value": ["other"]
+        ),
+        build(:pageview,
+          browser: "Safari"
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:props:author", ["John Doe"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Chrome", "visitors" => 1, "percentage" => 100}
+             ]
+    end
+
+    test "returns top browsers with :is_not filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          browser: "Chrome",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          user_id: 123,
+          browser: "Chrome",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          browser: "Firefox",
+          "meta.key": ["author"],
+          "meta.value": ["other"]
+        ),
+        build(:pageview,
+          browser: "Safari"
+        )
+      ])
+
+      filters = Jason.encode!([[:is_not, "event:props:author", ["John Doe"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Firefox", "visitors" => 1, "percentage" => 50},
+               %{"name" => "Safari", "visitors" => 1, "percentage" => 50}
+             ]
+    end
+
+    test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:pageview, user_id: 1, browser: "Chrome"),
+        build(:pageview, user_id: 2, browser: "Chrome"),
+        build(:event, user_id: 1, name: "Signup")
+      ])
+
+      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Chrome",
+                 "total_visitors" => 2,
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0
+               }
+             ]
+    end
+
+    test "returns top browsers including imported data", %{
+      conn: conn,
+      site: site,
+      site_import: site_import
+    } do
+      populate_stats(site, site_import.id, [
+        build(:pageview, browser: "Chrome"),
+        build(:imported_browsers, browser: "Chrome"),
+        build(:imported_browsers, browser: "Firefox"),
+        build(:imported_visitors, visitors: 2)
+      ])
+
+      conn1 = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
+
+      assert json_response(conn1, 200)["results"] == [
+               %{"name" => "Chrome", "visitors" => 1, "percentage" => 100}
+             ]
+
+      conn2 = get(conn, "/api/stats/#{site.domain}/browsers?period=day&with_imported=true")
+
+      assert json_response(conn2, 200)["results"] == [
+               %{"name" => "Chrome", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "Firefox", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "skips breakdown when visitors=0 (possibly due to 'Enable Users Metric' in GA)", %{
+      conn: conn,
+      site: site,
+      site_import: site_import
+    } do
+      populate_stats(site, site_import.id, [
+        build(:imported_browsers, browser: "Chrome", visitors: 0, visits: 14),
+        build(:imported_browsers, browser: "Firefox", visitors: 0, visits: 14),
+        build(:imported_browsers,
+          browser: "''",
+          visitors: 0,
+          visits: 14,
+          visit_duration: 0,
+          bounces: 14
+        )
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&with_imported=true")
+
+      assert json_response(conn, 200)["results"] == []
+    end
+
+    test "returns (not set) when appropriate", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          browser: ""
+        )
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 100.0}
+             ]
+    end
+
+    test "select empty imported_browsers as (not set), merging with the native (not set)", %{
+      conn: conn,
+      site: site,
+      site_import: site_import
+    } do
+      populate_stats(site, site_import.id, [
+        build(:pageview, user_id: 123),
+        build(:imported_browsers, visitors: 1),
+        build(:imported_visitors, visitors: 1)
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&with_imported=true")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "(not set)", "visitors" => 2, "percentage" => 100.0}
+             ]
+    end
+
+    test "returns comparisons", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, browser: "Safari", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+        build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+        build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00])
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/browsers?period=7d&date=2021-01-14&comparison=previous_period"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Chrome",
+                 "visitors" => 2,
+                 "percentage" => 66.67,
+                 "comparison" => %{
+                   "visitors" => 0,
+                   "percentage" => 0.0,
+                   "change" => %{"percentage" => 100, "visitors" => 100}
+                 }
+               },
+               %{
+                 "name" => "Firefox",
+                 "visitors" => 1,
+                 "percentage" => 33.33,
+                 "comparison" => %{
+                   "visitors" => 1,
+                   "percentage" => 50.0,
+                   "change" => %{"percentage" => -33, "visitors" => 0}
+                 }
+               }
+             ]
+
+      assert json_response(conn, 200)["meta"] == %{
+               "date_range_label" => "7 Jan - 13 Jan 2021",
+               "comparison_date_range_label" => "31 Dec 2020 - 6 Jan 2021"
+             }
+    end
+
+    test "returns comparisons with limit", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-01 00:00:00]),
+        build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+        build(:pageview, browser: "Chrome", timestamp: ~N[2021-01-07 00:00:00]),
+        build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00])
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/browsers?period=7d&date=2021-01-13&comparison=previous_period&limit=1"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Chrome",
+                 "visitors" => 2,
+                 "percentage" => 66.67,
+                 "comparison" => %{
+                   "visitors" => 1,
+                   "percentage" => 25.0,
+                   "change" => %{"percentage" => 167, "visitors" => 100}
+                 }
+               }
+             ]
+
+      assert json_response(conn, 200)["meta"] == %{
+               "date_range_label" => "6 Jan - 12 Jan 2021",
+               "comparison_date_range_label" => "30 Dec 2020 - 5 Jan 2021"
+             }
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for browsers breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, user_id: 1, browser: "Firefox"),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 2, browser: "Firefox"),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 3, browser: "Firefox"),
+        build(:pageview, user_id: 4, browser: "Safari"),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 5, browser: "Safari"),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/browsers#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$600.00",
+                   "short" => "$600.0",
+                   "value" => 600.0
+                 },
+                 "conversion_rate" => 100.0,
+                 "name" => "(not set)",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$600.00",
+                   "short" => "$600.0",
+                   "value" => 600.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "name" => "Firefox",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "name" => "Safari",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/browser-versions" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns correct conversion_rate when browser_version clashes across browsers", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event, browser: "Chrome", browser_version: "110", name: "Signup"),
+        build(:event, browser: "Chrome", browser_version: "110", name: "Signup"),
+        build(:pageview, browser: "Chrome", browser_version: "110"),
+        build(:pageview, browser: "Chrome", browser_version: "121"),
+        build(:pageview, browser: "Chrome", browser_version: "121"),
+        build(:event, browser: "Firefox", browser_version: "121", name: "Signup"),
+        build(:pageview, browser: "Firefox", browser_version: "110"),
+        build(:pageview, browser: "Firefox", browser_version: "110"),
+        build(:pageview, browser: "Firefox", browser_version: "110"),
+        build(:pageview, browser: "Firefox", browser_version: "110")
+      ])
+
+      insert(:goal, site: site, event_name: "Signup")
+      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+
+      json_response =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/browser-versions?period=day&filters=#{filters}"
+        )
+        |> json_response(200)
+        |> Map.get("results")
+
+      assert %{
+               "name" => "Chrome 110",
+               "browser" => "Chrome",
+               "conversion_rate" => 66.67,
+               "version" => "110",
+               "total_visitors" => 3,
+               "visitors" => 2
+             } == List.first(json_response)
+
+      assert %{
+               "name" => "Firefox 121",
+               "browser" => "Firefox",
+               "conversion_rate" => 100.0,
+               "version" => "121",
+               "total_visitors" => 1,
+               "visitors" => 1
+             } == List.last(json_response)
+    end
+
+    test "returns top browser versions by unique visitors", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, browser: "Chrome", browser_version: "78.0"),
+        build(:pageview, browser: "Chrome", browser_version: "78.0"),
+        build(:pageview, browser: "Chrome", browser_version: "77.0"),
+        build(:pageview, browser: "Firefox", browser_version: "88.0")
+      ])
+
+      filters = Jason.encode!([[:is, "visit:browser", ["Chrome"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/browser-versions?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Chrome 78.0",
+                 "version" => "78.0",
+                 "visitors" => 2,
+                 "percentage" => 66.67,
+                 "browser" => "Chrome"
+               },
+               %{
+                 "name" => "Chrome 77.0",
+                 "version" => "77.0",
+                 "visitors" => 1,
+                 "percentage" => 33.33,
+                 "browser" => "Chrome"
+               }
+             ]
+    end
+
+    test "returns only version under the name key (+ additional metrics) when 'detailed' is true in params",
+         %{
+           conn: conn,
+           site: site
+         } do
+      populate_stats(site, [build(:pageview, browser: "Chrome", browser_version: "78.0")])
+
+      filters = Jason.encode!([[:is, "visit:browser", ["Chrome"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/browser-versions?filters=#{filters}&detailed=true&period=day"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "78.0",
+                 "browser" => "Chrome",
+                 "visitors" => 1,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    test "returns results for (not set)", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, browser: "", browser_version: "")
+      ])
+
+      filters = Jason.encode!([[:is, "visit:browser", ["(not set)"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/browser-versions?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "(not set)",
+                 "visitors" => 1,
+                 "percentage" => 100,
+                 "browser" => "(not set)",
+                 "version" => "(not set)"
+               }
+             ]
+    end
+
+    test "with imported data", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          browser: "Chrome",
+          browser_version: "121",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          browser: "Chrome",
+          browser_version: "110",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:imported_browsers,
+          date: ~D[2021-01-01],
+          browser: "Chrome",
+          browser_version: "121",
+          visitors: 5
+        ),
+        build(:imported_browsers,
+          date: ~D[2021-01-01],
+          browser: "Firefox",
+          browser_version: "121",
+          visitors: 3
+        ),
+        build(:imported_browsers, date: ~D[2021-01-01], visitors: 10),
+        build(:imported_visitors, date: ~D[2021-01-01], visitors: 18)
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/browser-versions?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "browser" => "(not set)",
+                 "version" => "(not set)",
+                 "name" => "(not set)",
+                 "visitors" => 10,
+                 "percentage" => 50.0
+               },
+               %{
+                 "browser" => "Chrome",
+                 "version" => "121",
+                 "name" => "Chrome 121",
+                 "visitors" => 6,
+                 "percentage" => 30.0
+               },
+               %{
+                 "browser" => "Firefox",
+                 "version" => "121",
+                 "name" => "Firefox 121",
+                 "visitors" => 3,
+                 "percentage" => 15.0
+               },
+               %{
+                 "browser" => "Chrome",
+                 "version" => "110",
+                 "name" => "Chrome 110",
+                 "visitors" => 1,
+                 "percentage" => 5.0
+               }
+             ]
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/browsers_test.exs
@@ -1,6 +1,22 @@
 defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
   use PlausibleWeb.ConnCase
 
+  defp query_browsers(conn, site, opts) do
+    params = %{
+      "dimensions" => Keyword.get(opts, :dimensions, ["visit:browser"]),
+      "date_range" => Keyword.get(opts, :date_range, "all"),
+      "filters" => Keyword.get(opts, :filters, []),
+      "metrics" => Keyword.get(opts, :metrics, ["visitors", "percentage"]),
+      "include" => Keyword.get(opts, :include, nil),
+      "pagination" => Keyword.get(opts, :pagination, nil),
+      "order_by" => Keyword.get(opts, :order_by, nil)
+    }
+
+    conn
+    |> post("/api/stats/#{site.domain}/query", params)
+    |> json_response(200)
+  end
+
   describe "GET /api/stats/:domain/browsers" do
     setup [:create_user, :log_in, :create_site, :create_site_import]
 
@@ -11,11 +27,11 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:pageview, browser: "Firefox")
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
+      response = query_browsers(conn, site, date_range: "day")
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Chrome", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "Firefox", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["Chrome"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["Firefox"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -44,11 +60,14 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "event:props:author", ["John Doe"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&filters=#{filters}")
+      response =
+        query_browsers(conn, site,
+          date_range: "day",
+          filters: [["is", "event:props:author", ["John Doe"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Chrome", "visitors" => 1, "percentage" => 100}
+      assert response["results"] == [
+               %{"dimensions" => ["Chrome"], "metrics" => [1, 100.0]}
              ]
     end
 
@@ -79,12 +98,16 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         )
       ])
 
-      filters = Jason.encode!([[:is_not, "event:props:author", ["John Doe"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&filters=#{filters}")
+      response =
+        query_browsers(conn, site,
+          date_range: "day",
+          filters: [["is_not", "event:props:author", ["John Doe"]]],
+          order_by: [["visit:browser", "asc"]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Firefox", "visitors" => 1, "percentage" => 50},
-               %{"name" => "Safari", "visitors" => 1, "percentage" => 50}
+      assert response["results"] == [
+               %{"dimensions" => ["Firefox"], "metrics" => [1, 50.0]},
+               %{"dimensions" => ["Safari"], "metrics" => [1, 50.0]}
              ]
     end
 
@@ -97,17 +120,15 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:event, user_id: 1, name: "Signup")
       ])
 
-      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+      response =
+        query_browsers(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Signup"]]],
+          metrics: ["visitors", "total_visitors", "group_conversion_rate"]
+        )
 
-      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Chrome",
-                 "total_visitors" => 2,
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Chrome"], "metrics" => [1, 2, 50.0]}
              ]
     end
 
@@ -123,17 +144,18 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:imported_visitors, visitors: 2)
       ])
 
-      conn1 = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
+      response1 = query_browsers(conn, site, date_range: "day")
 
-      assert json_response(conn1, 200)["results"] == [
-               %{"name" => "Chrome", "visitors" => 1, "percentage" => 100}
+      assert response1["results"] == [
+               %{"dimensions" => ["Chrome"], "metrics" => [1, 100.0]}
              ]
 
-      conn2 = get(conn, "/api/stats/#{site.domain}/browsers?period=day&with_imported=true")
+      response2 =
+        query_browsers(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn2, 200)["results"] == [
-               %{"name" => "Chrome", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "Firefox", "visitors" => 1, "percentage" => 33.33}
+      assert response2["results"] == [
+               %{"dimensions" => ["Chrome"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["Firefox"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -154,9 +176,10 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         )
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&with_imported=true")
+      response =
+        query_browsers(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn, 200)["results"] == []
+      assert response["results"] == []
     end
 
     test "returns (not set) when appropriate", %{conn: conn, site: site} do
@@ -167,10 +190,10 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         )
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day")
+      response = query_browsers(conn, site, date_range: "day")
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "(not set)", "visitors" => 1, "percentage" => 100.0}
+      assert response["results"] == [
+               %{"dimensions" => ["(not set)"], "metrics" => [1, 100.0]}
              ]
     end
 
@@ -185,10 +208,11 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:imported_visitors, visitors: 1)
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/browsers?period=day&with_imported=true")
+      response =
+        query_browsers(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "(not set)", "visitors" => 2, "percentage" => 100.0}
+      assert response["results"] == [
+               %{"dimensions" => ["(not set)"], "metrics" => [2, 100.0]}
              ]
     end
 
@@ -201,39 +225,42 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00])
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/browsers?period=7d&date=2021-01-14&comparison=previous_period"
+      response =
+        query_browsers(conn, site,
+          date_range: ["2021-01-07", "2021-01-13"],
+          include: %{"compare" => "previous_period"}
         )
 
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "name" => "Chrome",
-                 "visitors" => 2,
-                 "percentage" => 66.67,
+                 "dimensions" => ["Chrome"],
+                 "metrics" => [2, 66.67],
                  "comparison" => %{
-                   "visitors" => 0,
-                   "percentage" => 0.0,
-                   "change" => %{"percentage" => 100, "visitors" => 100}
+                   "dimensions" => ["Chrome"],
+                   "metrics" => [0, 0.0],
+                   "change" => [100, 100]
                  }
                },
                %{
-                 "name" => "Firefox",
-                 "visitors" => 1,
-                 "percentage" => 33.33,
+                 "dimensions" => ["Firefox"],
+                 "metrics" => [1, 33.33],
                  "comparison" => %{
-                   "visitors" => 1,
-                   "percentage" => 50.0,
-                   "change" => %{"percentage" => -33, "visitors" => 0}
+                   "dimensions" => ["Firefox"],
+                   "metrics" => [1, 50.0],
+                   "change" => [0, -33]
                  }
                }
              ]
 
-      assert json_response(conn, 200)["meta"] == %{
-               "date_range_label" => "7 Jan - 13 Jan 2021",
-               "comparison_date_range_label" => "31 Dec 2020 - 6 Jan 2021"
-             }
+      assert response["query"]["date_range"] == [
+               "2021-01-07T00:00:00Z",
+               "2021-01-13T23:59:59Z"
+             ]
+
+      assert response["query"]["comparison_date_range"] == [
+               "2020-12-31T00:00:00Z",
+               "2021-01-06T23:59:59Z"
+             ]
     end
 
     test "returns comparisons with limit", %{conn: conn, site: site} do
@@ -247,29 +274,34 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:pageview, browser: "Firefox", timestamp: ~N[2021-01-07 00:00:00])
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/browsers?period=7d&date=2021-01-13&comparison=previous_period&limit=1"
+      response =
+        query_browsers(conn, site,
+          date_range: ["2021-01-06", "2021-01-12"],
+          include: %{"compare" => "previous_period"},
+          pagination: %{"limit" => 1}
         )
 
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "name" => "Chrome",
-                 "visitors" => 2,
-                 "percentage" => 66.67,
+                 "dimensions" => ["Chrome"],
+                 "metrics" => [2, 66.67],
                  "comparison" => %{
-                   "visitors" => 1,
-                   "percentage" => 25.0,
-                   "change" => %{"percentage" => 167, "visitors" => 100}
+                   "dimensions" => ["Chrome"],
+                   "metrics" => [1, 25.0],
+                   "change" => [100, 167]
                  }
                }
              ]
 
-      assert json_response(conn, 200)["meta"] == %{
-               "date_range_label" => "6 Jan - 12 Jan 2021",
-               "comparison_date_range_label" => "30 Dec 2020 - 5 Jan 2021"
-             }
+      assert response["query"]["date_range"] == [
+               "2021-01-06T00:00:00Z",
+               "2021-01-12T23:59:59Z"
+             ]
+
+      assert response["query"]["comparison_date_range"] == [
+               "2020-12-30T00:00:00Z",
+               "2021-01-05T23:59:59Z"
+             ]
     end
 
     @tag :ee_only
@@ -315,67 +347,80 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_browsers(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Payment"]]],
+          metrics: [
+            "visitors",
+            "total_visitors",
+            "group_conversion_rate",
+            "average_revenue",
+            "total_revenue"
+          ],
+          order_by: [["visitors", "desc"], ["visit:browser", "asc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/browsers#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$600.00",
-                   "short" => "$600.0",
-                   "value" => 600.0
-                 },
-                 "conversion_rate" => 100.0,
-                 "name" => "(not set)",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$600.00",
-                   "short" => "$600.0",
-                   "value" => 600.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 2
+                 "dimensions" => ["(not set)"],
+                 "metrics" => [
+                   2,
+                   2,
+                   100.0,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$600.00",
+                     "short" => "$600.0",
+                     "value" => 600.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$600.00",
+                     "short" => "$600.0",
+                     "value" => 600.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "name" => "Firefox",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3,
-                 "visitors" => 2
+                 "dimensions" => ["Firefox"],
+                 "metrics" => [
+                   2,
+                   3,
+                   66.67,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "name" => "Safari",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 1
+                 "dimensions" => ["Safari"],
+                 "metrics" => [
+                   1,
+                   2,
+                   50.0,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -402,33 +447,24 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
       ])
 
       insert(:goal, site: site, event_name: "Signup")
-      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
 
-      json_response =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/browser-versions?period=day&filters=#{filters}"
+      response =
+        query_browsers(conn, site,
+          date_range: "day",
+          dimensions: ["visit:browser", "visit:browser_version"],
+          filters: [["is", "event:goal", ["Signup"]]],
+          metrics: ["visitors", "total_visitors", "group_conversion_rate"]
         )
-        |> json_response(200)
-        |> Map.get("results")
 
-      assert %{
-               "name" => "Chrome 110",
-               "browser" => "Chrome",
-               "conversion_rate" => 66.67,
-               "version" => "110",
-               "total_visitors" => 3,
-               "visitors" => 2
-             } == List.first(json_response)
+      assert List.first(response["results"]) == %{
+               "dimensions" => ["Chrome", "110"],
+               "metrics" => [2, 3, 66.67]
+             }
 
-      assert %{
-               "name" => "Firefox 121",
-               "browser" => "Firefox",
-               "conversion_rate" => 100.0,
-               "version" => "121",
-               "total_visitors" => 1,
-               "visitors" => 1
-             } == List.last(json_response)
+      assert List.last(response["results"]) == %{
+               "dimensions" => ["Firefox", "121"],
+               "metrics" => [1, 1, 100.0]
+             }
     end
 
     test "returns top browser versions by unique visitors", %{conn: conn, site: site} do
@@ -439,56 +475,32 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:pageview, browser: "Firefox", browser_version: "88.0")
       ])
 
-      filters = Jason.encode!([[:is, "visit:browser", ["Chrome"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/browser-versions?period=day&filters=#{filters}"
+      response =
+        query_browsers(conn, site,
+          date_range: "day",
+          dimensions: ["visit:browser", "visit:browser_version"],
+          filters: [["is", "visit:browser", ["Chrome"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Chrome 78.0",
-                 "version" => "78.0",
-                 "visitors" => 2,
-                 "percentage" => 66.67,
-                 "browser" => "Chrome"
-               },
-               %{
-                 "name" => "Chrome 77.0",
-                 "version" => "77.0",
-                 "visitors" => 1,
-                 "percentage" => 33.33,
-                 "browser" => "Chrome"
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Chrome", "78.0"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["Chrome", "77.0"], "metrics" => [1, 33.33]}
              ]
     end
 
-    test "returns only version under the name key (+ additional metrics) when 'detailed' is true in params",
-         %{
-           conn: conn,
-           site: site
-         } do
+    test "returns browser and version with additional metrics", %{conn: conn, site: site} do
       populate_stats(site, [build(:pageview, browser: "Chrome", browser_version: "78.0")])
 
-      filters = Jason.encode!([[:is, "visit:browser", ["Chrome"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/browser-versions?filters=#{filters}&detailed=true&period=day"
+      response =
+        query_browsers(conn, site,
+          date_range: "day",
+          dimensions: ["visit:browser", "visit:browser_version"],
+          filters: [["is", "visit:browser", ["Chrome"]]],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "78.0",
-                 "browser" => "Chrome",
-                 "visitors" => 1,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 100.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Chrome", "78.0"], "metrics" => [1, 100, 0, 100.0]}
              ]
     end
 
@@ -497,22 +509,15 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:pageview, browser: "", browser_version: "")
       ])
 
-      filters = Jason.encode!([[:is, "visit:browser", ["(not set)"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/browser-versions?period=day&filters=#{filters}"
+      response =
+        query_browsers(conn, site,
+          date_range: "day",
+          dimensions: ["visit:browser", "visit:browser_version"],
+          filters: [["is", "visit:browser", ["(not set)"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "(not set)",
-                 "visitors" => 1,
-                 "percentage" => 100,
-                 "browser" => "(not set)",
-                 "version" => "(not set)"
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["(not set)", "(not set)"], "metrics" => [1, 100.0]}
              ]
     end
 
@@ -544,41 +549,18 @@ defmodule PlausibleWeb.Api.StatsController.BrowsersTest do
         build(:imported_visitors, date: ~D[2021-01-01], visitors: 18)
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/browser-versions?period=day&date=2021-01-01&with_imported=true"
+      response =
+        query_browsers(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          dimensions: ["visit:browser", "visit:browser_version"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "browser" => "(not set)",
-                 "version" => "(not set)",
-                 "name" => "(not set)",
-                 "visitors" => 10,
-                 "percentage" => 50.0
-               },
-               %{
-                 "browser" => "Chrome",
-                 "version" => "121",
-                 "name" => "Chrome 121",
-                 "visitors" => 6,
-                 "percentage" => 30.0
-               },
-               %{
-                 "browser" => "Firefox",
-                 "version" => "121",
-                 "name" => "Firefox 121",
-                 "visitors" => 3,
-                 "percentage" => 15.0
-               },
-               %{
-                 "browser" => "Chrome",
-                 "version" => "110",
-                 "name" => "Chrome 110",
-                 "visitors" => 1,
-                 "percentage" => 5.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["(not set)", "(not set)"], "metrics" => [10, 50.0]},
+               %{"dimensions" => ["Chrome", "121"], "metrics" => [6, 30.0]},
+               %{"dimensions" => ["Firefox", "121"], "metrics" => [3, 15.0]},
+               %{"dimensions" => ["Chrome", "110"], "metrics" => [1, 5.0]}
              ]
     end
   end

--- a/test/plausible_web/controllers/api/stats_controller/conversions_legacy_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_legacy_test.exs
@@ -1,0 +1,1462 @@
+defmodule PlausibleWeb.Api.StatsController.ConversionsLegacyTest do
+  @moduledoc """
+  [DEPRECATED] Still used for CSV export but to be removed.
+  """
+  use PlausibleWeb.ConnCase
+
+  @user_id Enum.random(1000..9999)
+
+  describe "GET /api/stats/:domain/conversions" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "returns mixed pageview and custom event goal conversions ordered by count", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/register"),
+        build(:pageview, pathname: "/register"),
+        build(:event, name: "Signup", "meta.key": ["variant"], "meta.value": ["A"]),
+        build(:event,
+          user_id: @user_id,
+          name: "Signup",
+          "meta.key": ["variant"],
+          "meta.value": ["A"]
+        ),
+        build(:event,
+          user_id: @user_id,
+          name: "Signup",
+          "meta.key": ["variant"],
+          "meta.value": ["B"]
+        ),
+        build(:event, name: "Signup")
+      ])
+
+      insert(:goal, %{site: site, page_path: "/register"})
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Signup",
+                 "visitors" => 3,
+                 "events" => 4,
+                 "conversion_rate" => 42.86
+               },
+               %{
+                 "name" => "Visit /register",
+                 "visitors" => 2,
+                 "events" => 2,
+                 "conversion_rate" => 28.57
+               }
+             ]
+    end
+
+    test "returns page scroll goals ordered by count", %{conn: conn, site: site} do
+      populate_stats(site, [
+        # user 1: /blog -> /another -> blog/posts/1
+        build(:pageview, user_id: 1, pathname: "/blog", timestamp: ~N[2020-01-01 00:00:00]),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/blog",
+          timestamp: ~N[2020-01-01 00:01:00],
+          scroll_depth: 20
+        ),
+        build(:pageview, user_id: 1, pathname: "/another", timestamp: ~N[2020-01-01 00:01:00]),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/another",
+          timestamp: ~N[2020-01-01 00:02:00],
+          scroll_depth: 100
+        ),
+        build(:pageview,
+          user_id: 1,
+          pathname: "/blog/posts/1",
+          timestamp: ~N[2020-01-01 00:02:00]
+        ),
+        build(:engagement,
+          user_id: 1,
+          pathname: "/blog/posts/1",
+          timestamp: ~N[2020-01-01 00:03:00],
+          scroll_depth: 55
+        ),
+        # user 2: /blog -> /blog/posts/1 -> /blog/posts/2
+        build(:pageview, user_id: 2, pathname: "/blog", timestamp: ~N[2020-01-01 00:00:00]),
+        build(:engagement,
+          user_id: 2,
+          pathname: "/blog",
+          timestamp: ~N[2020-01-01 00:01:00],
+          scroll_depth: 60
+        ),
+        build(:pageview,
+          user_id: 2,
+          pathname: "/blog/posts/1",
+          timestamp: ~N[2020-01-01 00:02:00]
+        ),
+        build(:engagement,
+          user_id: 2,
+          pathname: "/blog/posts/1",
+          timestamp: ~N[2020-01-01 00:03:00],
+          scroll_depth: 100
+        ),
+        build(:pageview,
+          user_id: 2,
+          pathname: "/blog/posts/2",
+          timestamp: ~N[2020-01-01 00:02:00]
+        ),
+        build(:engagement,
+          user_id: 2,
+          pathname: "/blog/posts/2",
+          timestamp: ~N[2020-01-01 00:03:00],
+          scroll_depth: 100
+        )
+      ])
+
+      insert(:goal, %{
+        site: site,
+        page_path: "/blog/**",
+        scroll_threshold: 50,
+        display_name: "Scroll 50 /blog/**"
+      })
+
+      insert(:goal, %{
+        site: site,
+        page_path: "/blog/posts/1",
+        scroll_threshold: 75,
+        display_name: "Scroll 75 /blog/posts/1"
+      })
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&date=2020-01-01")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Scroll 50 /blog/**",
+                 "visitors" => 2,
+                 "events" => nil,
+                 "conversion_rate" => 100.0
+               },
+               %{
+                 "name" => "Scroll 75 /blog/posts/1",
+                 "visitors" => 1,
+                 "events" => nil,
+                 "conversion_rate" => 50.0
+               }
+             ]
+    end
+
+    test "returns conversions when a direct :is filter on event prop", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["100", "true"]
+        ),
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["500", "true"]
+        ),
+        build(:event,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["100", "false"]
+        ),
+        build(:event,
+          name: "Payment",
+          "meta.key": ["amount"],
+          "meta.value": ["200"]
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment"})
+
+      filters = Jason.encode!([[:is, "event:props:logged_in", ["true"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Payment",
+                 "visitors" => 1,
+                 "events" => 2,
+                 "conversion_rate" => 33.33
+               }
+             ]
+    end
+
+    test "returns conversions when a direct :is_not filter on event prop", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["100", "true"]
+        ),
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["500", "true"]
+        ),
+        build(:event,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["100", "false"]
+        ),
+        build(:event, name: "Payment")
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment"})
+
+      filters = Jason.encode!([[:is_not, "event:props:logged_in", ["true"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Payment",
+                 "visitors" => 2,
+                 "events" => 2,
+                 "conversion_rate" => 66.67
+               }
+             ]
+    end
+
+    test "returns conversions when a direct :is (none) filter on event prop", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event,
+          user_id: @user_id,
+          name: "Payment"
+        ),
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          "meta.key": ["amount"],
+          "meta.value": ["500"]
+        ),
+        build(:event,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["100", "false"]
+        ),
+        build(:event, name: "Payment")
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment"})
+
+      filters = Jason.encode!([[:is, "event:props:logged_in", ["(none)"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Payment",
+                 "visitors" => 2,
+                 "events" => 3,
+                 "conversion_rate" => 66.67
+               }
+             ]
+    end
+
+    test "returns conversions when a direct :is_not (none) filter on event prop", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["500", "false"]
+        ),
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["500", "true"]
+        ),
+        build(:event,
+          name: "Payment",
+          "meta.key": ["amount", "logged_in"],
+          "meta.value": ["100", "false"]
+        ),
+        build(:event, name: "Payment")
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment"})
+
+      filters = Jason.encode!([[:is_not, "event:props:logged_in", ["(none)"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Payment",
+                 "visitors" => 2,
+                 "events" => 3,
+                 "conversion_rate" => 66.67
+               }
+             ]
+    end
+
+    @tag capture_log: true
+    test "garbage filters don't crash the call", %{conn: conn, site: site} do
+      filters =
+        "{\"source\":\"Direct / None\",\"screen\":\"Desktop\",\"browser\":\"Chrome\",\"os\":\"Mac\",\"os_version\":\"10.15\",\"country\":\"DE\",\"city\":\"2950159\"}%' AND 2*3*8=6*8 AND 'L9sv'!='L9sv%"
+
+      resp =
+        conn
+        |> get("/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+        |> json_response(200)
+        |> Map.get("results")
+
+      assert resp == []
+    end
+
+    test "filtering by session attribute and multiple goals", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          browser: "Firefox"
+        ),
+        build(:event,
+          user_id: @user_id,
+          name: "Payment",
+          browser: "Firefox"
+        ),
+        build(:event,
+          name: "Payment",
+          browser: "Chrome"
+        ),
+        build(:event, name: "Payment"),
+        build(:pageview, browser: "Firefox", pathname: "/"),
+        build(:pageview, browser: "Firefox", pathname: "/register")
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment"})
+      insert(:goal, %{site: site, page_path: "/register"})
+
+      filters = Jason.encode!([[:is, "visit:browser", ["Firefox"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Payment",
+                 "visitors" => 1,
+                 "events" => 2,
+                 "conversion_rate" => 33.33
+               },
+               %{
+                 "name" => "Visit /register",
+                 "visitors" => 1,
+                 "events" => 1,
+                 "conversion_rate" => 33.33
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "returns formatted average and total values for a conversion with revenue value", %{
+      conn: conn,
+      site: site
+    } do
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(site, site_import.id, [
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("200100300.123"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("300100400.123"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("0"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event, name: "Payment", revenue_reporting_amount: nil),
+        build(:event, name: "Payment", revenue_reporting_amount: nil)
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :EUR})
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&with_imported=true")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Payment",
+                 "visitors" => 5,
+                 "events" => 5,
+                 "conversion_rate" => 100.0,
+                 "average_revenue" => %{
+                   "short" => "€166.7M",
+                   "long" => "€166,733,566.75",
+                   "value" => 166_733_566.748,
+                   "currency" => "EUR"
+                 },
+                 "total_revenue" => %{
+                   "short" => "€500.2M",
+                   "long" => "€500,200,700.25",
+                   "value" => 500_200_700.246,
+                   "currency" => "EUR"
+                 }
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "returns revenue goals as custom events if the plan doesn't cover the feature", %{
+      conn: conn,
+      site: site,
+      user: user
+    } do
+      user
+      |> team_of()
+      |> Plausible.Teams.Team.end_trial()
+      |> Plausible.Repo.update!()
+
+      populate_stats(site, [
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("200100300.123"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("300100400.123"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event,
+          name: "Payment",
+          revenue_reporting_amount: Decimal.new("0"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:event, name: "Payment", revenue_reporting_amount: nil),
+        build(:event, name: "Payment", revenue_reporting_amount: nil)
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :EUR})
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Payment",
+                 "visitors" => 5,
+                 "events" => 5,
+                 "conversion_rate" => 100.0
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "excludes goals with custom props when Props feature is unavailable", %{
+      conn: conn,
+      site: site,
+      user: user
+    } do
+      user
+      |> team_of()
+      |> Plausible.Teams.Team.end_trial()
+      |> Plausible.Repo.update!()
+
+      populate_stats(site, [
+        build(:event, name: "Signup"),
+        build(:event, name: "Signup"),
+        build(:event, name: "Signup")
+      ])
+
+      {:ok, _goal_with_props} =
+        Plausible.Goals.create(site, %{
+          "event_name" => "Purchase",
+          "custom_props" => %{"product" => "Shirt"}
+        })
+
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Signup",
+                 "visitors" => 3,
+                 "events" => 3,
+                 "conversion_rate" => 100.0
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "includes goals with custom props when Props feature is available", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"]),
+        build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"])
+      ])
+
+      {:ok, _goal_with_props} =
+        Plausible.Goals.create(site, %{
+          "event_name" => "Purchase",
+          "custom_props" => %{"product" => "Shirt"}
+        })
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+
+      results = json_response(conn, 200)["results"]
+
+      assert length(results) == 1
+      assert hd(results)["name"] == "Purchase"
+      assert hd(results)["visitors"] == 2
+    end
+
+    @tag :ee_only
+    test "returns correct conversion stats for goals with and without custom properties", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"]),
+        build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Jacket"])
+      ])
+
+      {:ok, _} =
+        Plausible.Goals.create(
+          site,
+          %{
+            "event_name" => "Purchase",
+            "display_name" => "Purchase - Shirt",
+            "custom_props" => %{"product" => "Shirt"}
+          }
+        )
+
+      {:ok, _} =
+        Plausible.Goals.create(
+          site,
+          %{
+            "event_name" => "Purchase",
+            "display_name" => "Purchase - Jacket",
+            "custom_props" => %{"product" => "Jacket"}
+          }
+        )
+
+      {:ok, _} =
+        Plausible.Goals.create(
+          site,
+          %{
+            "event_name" => "Purchase",
+            "display_name" => "Purchase - All"
+          }
+        )
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+      response = json_response(conn, 200)
+      results = response["results"]
+
+      assert [
+               %{
+                 "conversion_rate" => 100.0,
+                 "events" => 2,
+                 "name" => "Purchase - All",
+                 "visitors" => 2
+               },
+               %{
+                 "conversion_rate" => 50.0,
+                 "events" => 1,
+                 "name" => "Purchase - Shirt",
+                 "visitors" => 1
+               },
+               %{
+                 "conversion_rate" => 50.0,
+                 "events" => 1,
+                 "name" => "Purchase - Jacket",
+                 "visitors" => 1
+               }
+             ] =
+               results
+    end
+
+    @tag :ee_only
+    test "handles mixed goals with and without custom props (2)", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event, name: "Signup"),
+        build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"])
+      ])
+
+      {:ok, _goal_with_props} =
+        Plausible.Goals.create(
+          site,
+          %{
+            "event_name" => "Purchase",
+            "custom_props" => %{"product" => "Shirt"}
+          }
+        )
+
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+      response = json_response(conn, 200)
+      results = response["results"]
+
+      assert [
+               %{"conversion_rate" => 50.0, "events" => 1, "name" => "Purchase", "visitors" => 1},
+               %{"conversion_rate" => 50.0, "events" => 1, "name" => "Signup", "visitors" => 1}
+             ] =
+               results
+    end
+
+    @tag :ee_only
+    test "returns revenue metrics as nil for non-revenue goals", %{
+      conn: conn,
+      site: site
+    } do
+      [
+        build(:event,
+          name: "Payment",
+          pathname: "/checkout",
+          revenue_reporting_amount: Decimal.new("10.00"),
+          revenue_reporting_currency: "EUR"
+        )
+      ]
+      |> Enum.concat(build_list(2, :event, name: "Signup"))
+      |> Enum.concat(build_list(3, :pageview, pathname: "/checkout"))
+      |> then(fn events -> populate_stats(site, events) end)
+
+      insert(:goal, %{site: site, event_name: "Signup"})
+      insert(:goal, %{site: site, page_path: "/checkout"})
+      insert(:goal, %{site: site, event_name: "Payment", currency: :EUR})
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+      response = json_response(conn, 200)["results"]
+
+      assert [
+               %{
+                 "average_revenue" => %{
+                   "long" => "€10.00",
+                   "short" => "€10.0",
+                   "value" => 10.0,
+                   "currency" => "EUR"
+                 },
+                 "conversion_rate" => 16.67,
+                 "name" => "Payment",
+                 "events" => 1,
+                 "total_revenue" => %{
+                   "long" => "€10.00",
+                   "short" => "€10.0",
+                   "value" => 10.0,
+                   "currency" => "EUR"
+                 },
+                 "visitors" => 1
+               },
+               %{
+                 "average_revenue" => nil,
+                 "conversion_rate" => 33.33,
+                 "name" => "Signup",
+                 "events" => 2,
+                 "total_revenue" => nil,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => nil,
+                 "conversion_rate" => 50.0,
+                 "name" => "Visit /checkout",
+                 "events" => 3,
+                 "total_revenue" => nil,
+                 "visitors" => 3
+               }
+             ] == Enum.sort_by(response, & &1["name"])
+    end
+
+    test "does not return revenue metrics if no revenue goals are returned", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:event, name: "Signup")
+      ])
+
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Signup",
+                 "visitors" => 1,
+                 "events" => 1,
+                 "conversion_rate" => 100.0
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/conversions - with goal filter" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "does not consider custom event pathname as a pageview goal completion", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/register"),
+        build(:event, pathname: "/register", name: "Signup")
+      ])
+
+      insert(:goal, %{site: site, page_path: "/register"})
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      get_with_filter = fn filters ->
+        path = "/api/stats/#{site.domain}/conversions"
+        query = "?period=day&filters=#{Jason.encode!(filters)}"
+
+        get(conn, path <> query)
+        |> json_response(200)
+        |> Map.get("results")
+      end
+
+      expected = [
+        %{
+          "name" => "Signup",
+          "visitors" => 1,
+          "events" => 1,
+          "conversion_rate" => 33.33
+        }
+      ]
+
+      # {:is, {:event, event}} filter type
+      assert get_with_filter.([[:is, "event:goal", ["Signup"]]]) == expected
+
+      # {:member, clauses} filter type
+      assert get_with_filter.([[:is, "event:goal", ["Signup", "Whatever"]]]) == expected
+
+      # {:matches_member, clauses} filter type
+      assert get_with_filter.([[:is, "event:goal", ["Signup", "Visit /whatever*"]]]) == expected
+    end
+
+    test "does not return custom events with the filtered pageview goal pathname", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/register"),
+        build(:event, pathname: "/register", name: "Signup")
+      ])
+
+      insert(:goal, %{site: site, page_path: "/register"})
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Visit /register"]]])
+
+      results =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+        )
+        |> json_response(200)
+        |> Map.get("results")
+
+      assert results == [
+               %{
+                 "name" => "Visit /register",
+                 "visitors" => 1,
+                 "events" => 1,
+                 "conversion_rate" => 33.33
+               }
+             ]
+    end
+
+    test "can filter by multiple mixed goals", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/another"),
+        build(:pageview, pathname: "/register"),
+        build(:event, name: "Signup"),
+        build(:event, name: "Signup")
+      ])
+
+      insert(:goal, %{site: site, page_path: "/register"})
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Signup", "Visit /register"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Signup",
+                 "visitors" => 2,
+                 "events" => 2,
+                 "conversion_rate" => 33.33
+               },
+               %{
+                 "name" => "Visit /register",
+                 "visitors" => 1,
+                 "events" => 1,
+                 "conversion_rate" => 16.67
+               }
+             ]
+    end
+
+    test "can combine wildcard and no wildcard in matches_member", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, pathname: "/blog/post-1"),
+        build(:pageview, pathname: "/blog/post-2"),
+        build(:pageview, pathname: "/billing/upgrade")
+      ])
+
+      insert(:goal, %{site: site, page_path: "/blog/**"})
+      insert(:goal, %{site: site, page_path: "/billing/upgrade"})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Visit /blog/**", "Visit /billing/upgrade"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Visit /blog/**",
+                 "visitors" => 2,
+                 "events" => 2,
+                 "conversion_rate" => 66.67
+               },
+               %{
+                 "name" => "Visit /billing/upgrade",
+                 "visitors" => 1,
+                 "events" => 1,
+                 "conversion_rate" => 33.33
+               }
+             ]
+    end
+
+    test "can filter by matches_member filter type on goals", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/another"),
+        build(:pageview, pathname: "/blog/post-1"),
+        build(:pageview, pathname: "/blog/post-2"),
+        build(:event, name: "CTA"),
+        build(:event, name: "Signup")
+      ])
+
+      insert(:goal, %{site: site, page_path: "/blog**"})
+      insert(:goal, %{site: site, event_name: "CTA"})
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Signup", "Visit /blog**"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Visit /blog**",
+                 "visitors" => 2,
+                 "events" => 2,
+                 "conversion_rate" => 33.33
+               },
+               %{
+                 "name" => "Signup",
+                 "visitors" => 1,
+                 "events" => 1,
+                 "conversion_rate" => 16.67
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/conversions - with goal and prop=(none) filter" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "returns only the conversion that is filtered for", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, pathname: "/", user_id: 1),
+        build(:pageview, pathname: "/", user_id: 2),
+        build(:event, name: "Signup", user_id: 1, "meta.key": ["variant"], "meta.value": ["A"]),
+        build(:event, name: "Signup", user_id: 2)
+      ])
+
+      insert(:goal, %{site: site, event_name: "Signup"})
+
+      filters =
+        Jason.encode!([
+          [:is, "event:goal", ["Signup"]],
+          [:is, "event:props:variant", ["(none)"]]
+        ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Signup",
+                 "visitors" => 1,
+                 "events" => 1,
+                 "conversion_rate" => 50
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/conversions - with glob goals" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "returns correct and sorted glob goal counts", %{conn: conn, site: site} do
+      insert(:goal, %{site: site, page_path: "/register"})
+      insert(:goal, %{site: site, page_path: "/reg*"})
+      insert(:goal, %{site: site, page_path: "/*/register"})
+      insert(:goal, %{site: site, page_path: "/billing*/success"})
+      insert(:goal, %{site: site, page_path: "/signup"})
+      insert(:goal, %{site: site, page_path: "/signup/*"})
+      insert(:goal, %{site: site, page_path: "/*"})
+
+      populate_stats(site, [
+        build(:pageview,
+          pathname: "/hum",
+          timestamp: ~N[2019-07-01 23:00:00]
+        ),
+        build(:pageview,
+          pathname: "/register",
+          timestamp: ~N[2019-07-01 23:00:00]
+        ),
+        build(:pageview,
+          pathname: "/reg",
+          timestamp: ~N[2019-07-01 23:00:00]
+        ),
+        build(:pageview,
+          pathname: "/billing/success",
+          timestamp: ~N[2019-07-01 23:00:00]
+        ),
+        build(:pageview,
+          pathname: "/billing/upgrade/success",
+          timestamp: ~N[2019-07-01 23:00:00]
+        ),
+        build(:pageview,
+          pathname: "/signup/new",
+          timestamp: ~N[2019-07-01 23:00:00]
+        ),
+        build(:pageview,
+          pathname: "/signup/new/2",
+          timestamp: ~N[2019-07-01 23:00:00]
+        ),
+        build(:pageview,
+          pathname: "/signup/new/3",
+          timestamp: ~N[2019-07-01 23:00:00]
+        )
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/conversions?period=day&date=2019-07-01"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "conversion_rate" => 100.0,
+                 "visitors" => 8,
+                 "name" => "Visit /*",
+                 "events" => 8
+               },
+               %{
+                 "conversion_rate" => 37.5,
+                 "visitors" => 3,
+                 "name" => "Visit /signup/*",
+                 "events" => 3
+               },
+               %{
+                 "conversion_rate" => 25.0,
+                 "visitors" => 2,
+                 "name" => "Visit /billing*/success",
+                 "events" => 2
+               },
+               %{
+                 "conversion_rate" => 25.0,
+                 "visitors" => 2,
+                 "name" => "Visit /reg*",
+                 "events" => 2
+               },
+               %{
+                 "conversion_rate" => 12.5,
+                 "visitors" => 1,
+                 "name" => "Visit /register",
+                 "events" => 1
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/conversions - with imported data" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "returns custom event goals and pageview goals", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Purchase")
+      insert(:goal, site: site, page_path: "/test")
+
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(site, site_import.id, [
+        build(:pageview,
+          timestamp: ~N[2021-01-01 00:00:01],
+          pathname: "/test"
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:imported_custom_events,
+          name: "Purchase",
+          visitors: 3,
+          events: 5,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/test",
+          visitors: 2,
+          pageviews: 2,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
+      ])
+
+      url_query_params = "?period=day&date=2021-01-01&with_imported=true"
+      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+
+      assert [
+               %{
+                 "name" => "Purchase",
+                 "visitors" => 5,
+                 "events" => 7,
+                 "conversion_rate" => 62.5
+               },
+               %{
+                 "name" => "Visit /test",
+                 "visitors" => 3,
+                 "events" => 3,
+                 "conversion_rate" => 37.5
+               }
+             ] = json_response(conn, 200)["results"]
+    end
+
+    test "returns only custom event goals with a custom event goal filter", %{
+      conn: conn,
+      site: site
+    } do
+      insert(:goal, site: site, event_name: "Purchase")
+      insert(:goal, site: site, event_name: "Activation")
+      insert(:goal, site: site, page_path: "/test")
+
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(site, site_import.id, [
+        build(:pageview,
+          timestamp: ~N[2021-01-01 00:00:01],
+          pathname: "/test"
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:imported_custom_events,
+          name: "Purchase",
+          visitors: 3,
+          events: 5,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/test",
+          visitors: 2,
+          pageviews: 2,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
+      ])
+
+      filters = Jason.encode!([[:is, "event:goal", ["Purchase"]]])
+      url_query_params = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
+      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+
+      assert [
+               %{
+                 "name" => "Purchase",
+                 "visitors" => 5,
+                 "events" => 7,
+                 "conversion_rate" => 62.5
+               }
+             ] = json_response(conn, 200)["results"]
+    end
+
+    test "returns custom event goals with more than one option in goal filter", %{
+      conn: conn,
+      site: site
+    } do
+      insert(:goal, site: site, event_name: "Purchase")
+      insert(:goal, site: site, event_name: "Activation")
+      insert(:goal, site: site, page_path: "/test")
+
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(site, site_import.id, [
+        build(:pageview,
+          timestamp: ~N[2021-01-01 00:00:01],
+          pathname: "/test"
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:event,
+          name: "Activation",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:imported_custom_events,
+          name: "Purchase",
+          visitors: 3,
+          events: 5,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_custom_events,
+          name: "Activation",
+          visitors: 2,
+          events: 4,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/test",
+          visitors: 2,
+          pageviews: 2,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
+      ])
+
+      filters = Jason.encode!([[:is, "event:goal", ["Purchase", "Activation"]]])
+      url_query_params = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
+      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+
+      assert [
+               %{
+                 "name" => "Purchase",
+                 "visitors" => 5,
+                 "events" => 7,
+                 "conversion_rate" => 55.56
+               },
+               %{
+                 "name" => "Activation",
+                 "visitors" => 3,
+                 "events" => 5,
+                 "conversion_rate" => 33.33
+               }
+             ] = json_response(conn, 200)["results"]
+    end
+
+    test "returns only pageview goals with a pageview goal filter", %{
+      conn: conn,
+      site: site
+    } do
+      insert(:goal, site: site, event_name: "Purchase")
+      insert(:goal, site: site, event_name: "Activation")
+      insert(:goal, site: site, page_path: "/test")
+
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(site, site_import.id, [
+        build(:pageview,
+          timestamp: ~N[2021-01-01 00:00:01],
+          pathname: "/test"
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:imported_custom_events,
+          name: "Purchase",
+          visitors: 3,
+          events: 5,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/test",
+          visitors: 2,
+          pageviews: 2,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
+      ])
+
+      filters = Jason.encode!([[:is, "event:goal", ["Visit /test"]]])
+      url_query_params = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
+      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+
+      assert [
+               %{
+                 "name" => "Visit /test",
+                 "visitors" => 3,
+                 "events" => 3,
+                 "conversion_rate" => 37.5
+               }
+             ] = json_response(conn, 200)["results"]
+    end
+
+    test "returns pageview goals with more than one option in pageview goal filter", %{
+      conn: conn,
+      site: site
+    } do
+      insert(:goal, site: site, event_name: "Purchase")
+      insert(:goal, site: site, event_name: "Activation")
+      insert(:goal, site: site, page_path: "/test")
+      insert(:goal, site: site, page_path: "/blog")
+
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(site, site_import.id, [
+        build(:pageview,
+          timestamp: ~N[2021-01-01 00:00:01],
+          pathname: "/test"
+        ),
+        build(:pageview,
+          timestamp: ~N[2021-01-01 00:00:01],
+          pathname: "/blog"
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:event,
+          name: "Purchase",
+          timestamp: ~N[2021-01-01 00:00:03]
+        ),
+        build(:imported_custom_events,
+          name: "Purchase",
+          visitors: 3,
+          events: 5,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/test",
+          visitors: 2,
+          pageviews: 2,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/blog",
+          visitors: 1,
+          pageviews: 1,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
+      ])
+
+      filters = Jason.encode!([[:is, "event:goal", ["Visit /test", "Visit /blog"]]])
+      url_query_params = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
+      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+
+      assert [
+               %{
+                 "name" => "Visit /test",
+                 "visitors" => 3,
+                 "events" => 3,
+                 "conversion_rate" => 33.33
+               },
+               %{
+                 "name" => "Visit /blog",
+                 "visitors" => 2,
+                 "events" => 2,
+                 "conversion_rate" => 22.22
+               }
+             ] = json_response(conn, 200)["results"]
+    end
+
+    test "returns pageview goals with a page filter", %{
+      conn: conn,
+      site: site
+    } do
+      insert(:goal, site: site, page_path: "/blog/two")
+      insert(:goal, site: site, page_path: "/blog/thr**")
+      insert(:goal, site: site, page_path: "/blog/*")
+
+      site_import = insert(:site_import, site: site)
+
+      populate_stats(site, site_import.id, [
+        build(:imported_pages, page: "/", visitors: 1, pageviews: 1, date: ~D[2021-01-01]),
+        build(:imported_pages,
+          page: "/blog/one",
+          visitors: 2,
+          pageviews: 2,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/blog/two",
+          visitors: 3,
+          pageviews: 3,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_pages,
+          page: "/blog/three",
+          visitors: 4,
+          pageviews: 4,
+          date: ~D[2021-01-01]
+        ),
+        build(:imported_visitors, visitors: 10, date: ~D[2021-01-01])
+      ])
+
+      filters = Jason.encode!([[:is, "event:page", ["/blog/one", "/blog/two"]]])
+      q = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
+      conn = get(conn, "/api/stats/#{site.domain}/conversions#{q}")
+
+      assert [
+               %{
+                 "name" => "Visit /blog/*",
+                 "visitors" => 5,
+                 "events" => 5,
+                 "conversion_rate" => 100.0
+               },
+               %{
+                 "name" => "Visit /blog/two",
+                 "visitors" => 3,
+                 "events" => 3,
+                 "conversion_rate" => 60.0
+               }
+             ] = json_response(conn, 200)["results"]
+    end
+
+    test "calculates conversion_rate for goals with glob pattern with imported data", %{
+      conn: conn,
+      site: site
+    } do
+      site_import =
+        insert(:site_import,
+          start_date: ~D[2005-01-01],
+          end_date: Date.utc_today(),
+          source: :universal_analytics
+        )
+
+      populate_stats(site, site_import.id, [
+        build(:pageview, pathname: "/"),
+        build(:pageview, pathname: "/another"),
+        build(:pageview, pathname: "/blog/post-1"),
+        build(:pageview, pathname: "/blog/post-2"),
+        build(:imported_pages, page: "/blog/post-1"),
+        build(:imported_visitors)
+      ])
+
+      insert(:goal, %{site: site, page_path: "/blog**"})
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/conversions?period=day"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Visit /blog**",
+                 "visitors" => 2,
+                 "events" => 2,
+                 "conversion_rate" => 50
+               }
+             ]
+    end
+
+    test "filtering with goal contains filter", %{
+      conn: conn,
+      site: site
+    } do
+      site_import =
+        insert(:site_import,
+          site: site,
+          start_date: ~D[2005-01-01],
+          end_date: Date.utc_today(),
+          source: :universal_analytics
+        )
+
+      insert(:goal, site: site, event_name: "Onboarding: Step 1")
+      insert(:goal, site: site, event_name: "Onboarding: Step 2")
+      insert(:goal, site: site, event_name: "Unrelated")
+
+      populate_stats(site, site_import.id, [
+        build(:event, name: "Onboarding: Step 1"),
+        build(:event, name: "Onboarding: Step 1"),
+        build(:event, name: "Onboarding: Step 2"),
+        build(:event, name: "Unrelated"),
+        build(:imported_custom_events, name: "Onboarding: Step 1", visitors: 2, events: 2),
+        build(:imported_custom_events, name: "Onboarding: Step 2"),
+        build(:imported_custom_events, name: "Unrelated"),
+        build(:imported_visitors, visitors: 4)
+      ])
+
+      filters = Jason.encode!([[:contains, "event:goal", ["Onboarding"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}&with_imported=true"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Onboarding: Step 1",
+                 "visitors" => 4,
+                 "events" => 4,
+                 "conversion_rate" => 50
+               },
+               %{
+                 "name" => "Onboarding: Step 2",
+                 "visitors" => 2,
+                 "events" => 2,
+                 "conversion_rate" => 25
+               }
+             ]
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -3,6 +3,21 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
   @user_id Enum.random(1000..9999)
 
+  defp query_conversions(conn, site, opts) do
+    params = %{
+      "dimensions" => Keyword.get(opts, :dimensions, ["event:goal"]),
+      "date_range" => Keyword.get(opts, :date_range, "all"),
+      "filters" => Keyword.get(opts, :filters, []),
+      "metrics" => Keyword.get(opts, :metrics, ["visitors", "events", "conversion_rate"]),
+      "include" => Keyword.get(opts, :include, nil),
+      "order_by" => Keyword.get(opts, :order_by, nil)
+    }
+
+    conn
+    |> post("/api/stats/#{site.domain}/query", params)
+    |> json_response(200)
+  end
+
   describe "GET /api/stats/:domain/conversions" do
     setup [:create_user, :log_in, :create_site]
 
@@ -34,21 +49,11 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       insert(:goal, %{site: site, page_path: "/register"})
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+      response = query_conversions(conn, site, date_range: "day")
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Signup",
-                 "visitors" => 3,
-                 "events" => 4,
-                 "conversion_rate" => 42.86
-               },
-               %{
-                 "name" => "Visit /register",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 28.57
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Signup"], "metrics" => [3, 4, 42.86]},
+               %{"dimensions" => ["Visit /register"], "metrics" => [2, 2, 28.57]}
              ]
     end
 
@@ -126,21 +131,11 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         display_name: "Scroll 75 /blog/posts/1"
       })
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&date=2020-01-01")
+      response = query_conversions(conn, site, date_range: ["2020-01-01", "2020-01-01"])
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Scroll 50 /blog/**",
-                 "visitors" => 2,
-                 "events" => nil,
-                 "conversion_rate" => 100.0
-               },
-               %{
-                 "name" => "Scroll 75 /blog/posts/1",
-                 "visitors" => 1,
-                 "events" => nil,
-                 "conversion_rate" => 50.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Scroll 50 /blog/**"], "metrics" => [2, nil, 100.0]},
+               %{"dimensions" => ["Scroll 75 /blog/posts/1"], "metrics" => [1, nil, 50.0]}
              ]
     end
 
@@ -172,16 +167,14 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Payment"})
 
-      filters = Jason.encode!([[:is, "event:props:logged_in", ["true"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is", "event:props:logged_in", ["true"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Payment",
-                 "visitors" => 1,
-                 "events" => 2,
-                 "conversion_rate" => 33.33
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Payment"], "metrics" => [1, 2, 33.33]}
              ]
     end
 
@@ -212,16 +205,14 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Payment"})
 
-      filters = Jason.encode!([[:is_not, "event:props:logged_in", ["true"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is_not", "event:props:logged_in", ["true"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Payment",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 66.67
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Payment"], "metrics" => [2, 2, 66.67]}
              ]
     end
 
@@ -250,16 +241,14 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Payment"})
 
-      filters = Jason.encode!([[:is, "event:props:logged_in", ["(none)"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is", "event:props:logged_in", ["(none)"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Payment",
-                 "visitors" => 2,
-                 "events" => 3,
-                 "conversion_rate" => 66.67
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Payment"], "metrics" => [2, 3, 66.67]}
              ]
     end
 
@@ -290,31 +279,32 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Payment"})
 
-      filters = Jason.encode!([[:is_not, "event:props:logged_in", ["(none)"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is_not", "event:props:logged_in", ["(none)"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Payment",
-                 "visitors" => 2,
-                 "events" => 3,
-                 "conversion_rate" => 66.67
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Payment"], "metrics" => [2, 3, 66.67]}
              ]
     end
 
-    @tag capture_log: true
-    test "garbage filters don't crash the call", %{conn: conn, site: site} do
-      filters =
-        "{\"source\":\"Direct / None\",\"screen\":\"Desktop\",\"browser\":\"Chrome\",\"os\":\"Mac\",\"os_version\":\"10.15\",\"country\":\"DE\",\"city\":\"2950159\"}%' AND 2*3*8=6*8 AND 'L9sv'!='L9sv%"
+    test "garbage filters result in a 400 response", %{conn: conn, site: site} do
+      params = %{
+        "date_range" => "all",
+        "metrics" => ["visitors", "events", "conversion_rate"],
+        "filters" => [
+          ["is", "visit:city AND 2*3*8=6*8 AND 'L9sv'!='L9sv%", ["a"]]
+        ]
+      }
 
-      resp =
+      response =
         conn
-        |> get("/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
-        |> json_response(200)
-        |> Map.get("results")
+        |> post("/api/stats/#{site.domain}/query", params)
+        |> json_response(400)
 
-      assert resp == []
+      assert response["error"] =~ "filter"
     end
 
     test "filtering by session attribute and multiple goals", %{
@@ -344,22 +334,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       insert(:goal, %{site: site, event_name: "Payment"})
       insert(:goal, %{site: site, page_path: "/register"})
 
-      filters = Jason.encode!([[:is, "visit:browser", ["Firefox"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}")
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is", "visit:browser", ["Firefox"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Payment",
-                 "visitors" => 1,
-                 "events" => 2,
-                 "conversion_rate" => 33.33
-               },
-               %{
-                 "name" => "Visit /register",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 33.33
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Payment"], "metrics" => [1, 2, 33.33]},
+               %{"dimensions" => ["Visit /register"], "metrics" => [1, 1, 33.33]}
              ]
     end
 
@@ -392,26 +375,33 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :EUR})
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day&with_imported=true")
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          metrics: ["visitors", "events", "conversion_rate", "average_revenue", "total_revenue"],
+          include: %{"imports" => true}
+        )
 
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "name" => "Payment",
-                 "visitors" => 5,
-                 "events" => 5,
-                 "conversion_rate" => 100.0,
-                 "average_revenue" => %{
-                   "short" => "€166.7M",
-                   "long" => "€166,733,566.75",
-                   "value" => 166_733_566.748,
-                   "currency" => "EUR"
-                 },
-                 "total_revenue" => %{
-                   "short" => "€500.2M",
-                   "long" => "€500,200,700.25",
-                   "value" => 500_200_700.246,
-                   "currency" => "EUR"
-                 }
+                 "dimensions" => ["Payment"],
+                 "metrics" => [
+                   5,
+                   5,
+                   100.0,
+                   %{
+                     "short" => "€166.7M",
+                     "long" => "€166,733,566.75",
+                     "value" => 166_733_566.748,
+                     "currency" => "EUR"
+                   },
+                   %{
+                     "short" => "€500.2M",
+                     "long" => "€500,200,700.25",
+                     "value" => 500_200_700.246,
+                     "currency" => "EUR"
+                   }
+                 ]
                }
              ]
     end
@@ -449,15 +439,16 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :EUR})
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          metrics: ["visitors", "events", "conversion_rate", "average_revenue", "total_revenue"]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Payment",
-                 "visitors" => 5,
-                 "events" => 5,
-                 "conversion_rate" => 100.0
-               }
+      assert response["query"]["metrics"] == ["visitors", "events", "conversion_rate"]
+
+      assert response["results"] == [
+               %{"dimensions" => ["Payment"], "metrics" => [5, 5, 100.0]}
              ]
     end
 
@@ -475,7 +466,8 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       populate_stats(site, [
         build(:event, name: "Signup"),
         build(:event, name: "Signup"),
-        build(:event, name: "Signup")
+        build(:event, name: "Signup"),
+        build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"])
       ])
 
       {:ok, _goal_with_props} =
@@ -486,15 +478,10 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+      response = query_conversions(conn, site, date_range: "day")
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Signup",
-                 "visitors" => 3,
-                 "events" => 3,
-                 "conversion_rate" => 100.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Signup"], "metrics" => [3, 3, 75.0]}
              ]
     end
 
@@ -514,21 +501,19 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
           "custom_props" => %{"product" => "Shirt"}
         })
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+      response = query_conversions(conn, site, date_range: "day")
 
-      results = json_response(conn, 200)["results"]
-
-      assert length(results) == 1
-      assert hd(results)["name"] == "Purchase"
-      assert hd(results)["visitors"] == 2
+      assert response["results"] == [
+               %{"dimensions" => ["Purchase"], "metrics" => [2, 2, 100.0]}
+             ]
     end
 
-    @tag :ee_only
     test "returns correct conversion stats for goals with and without custom properties", %{
       conn: conn,
       site: site
     } do
       populate_stats(site, [
+        build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"]),
         build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"]),
         build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Jacket"])
       ])
@@ -562,31 +547,13 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
           }
         )
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
-      response = json_response(conn, 200)
-      results = response["results"]
+      response = query_conversions(conn, site, date_range: "day")
 
-      assert [
-               %{
-                 "conversion_rate" => 100.0,
-                 "events" => 2,
-                 "name" => "Purchase - All",
-                 "visitors" => 2
-               },
-               %{
-                 "conversion_rate" => 50.0,
-                 "events" => 1,
-                 "name" => "Purchase - Shirt",
-                 "visitors" => 1
-               },
-               %{
-                 "conversion_rate" => 50.0,
-                 "events" => 1,
-                 "name" => "Purchase - Jacket",
-                 "visitors" => 1
-               }
-             ] =
-               results
+      assert response["results"] == [
+               %{"dimensions" => ["Purchase - All"], "metrics" => [3, 3, 100.0]},
+               %{"dimensions" => ["Purchase - Shirt"], "metrics" => [2, 2, 66.67]},
+               %{"dimensions" => ["Purchase - Jacket"], "metrics" => [1, 1, 33.33]}
+             ]
     end
 
     @tag :ee_only
@@ -596,6 +563,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
     } do
       populate_stats(site, [
         build(:event, name: "Signup"),
+        build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"]),
         build(:event, name: "Purchase", "meta.key": ["product"], "meta.value": ["Shirt"])
       ])
 
@@ -610,15 +578,12 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
-      response = json_response(conn, 200)
-      results = response["results"]
+      response = query_conversions(conn, site, date_range: "day")
 
       assert [
-               %{"conversion_rate" => 50.0, "events" => 1, "name" => "Purchase", "visitors" => 1},
-               %{"conversion_rate" => 50.0, "events" => 1, "name" => "Signup", "visitors" => 1}
-             ] =
-               results
+               %{"dimensions" => ["Purchase"], "metrics" => [2, 2, 66.67]},
+               %{"dimensions" => ["Signup"], "metrics" => [1, 1, 33.33]}
+             ] = response["results"]
     end
 
     @tag :ee_only
@@ -642,45 +607,37 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       insert(:goal, %{site: site, page_path: "/checkout"})
       insert(:goal, %{site: site, event_name: "Payment", currency: :EUR})
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
-      response = json_response(conn, 200)["results"]
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          metrics: ["visitors", "events", "conversion_rate", "average_revenue", "total_revenue"],
+          order_by: [["visitors", "asc"]]
+        )
 
-      assert [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "long" => "€10.00",
-                   "short" => "€10.0",
-                   "value" => 10.0,
-                   "currency" => "EUR"
-                 },
-                 "conversion_rate" => 16.67,
-                 "name" => "Payment",
-                 "events" => 1,
-                 "total_revenue" => %{
-                   "long" => "€10.00",
-                   "short" => "€10.0",
-                   "value" => 10.0,
-                   "currency" => "EUR"
-                 },
-                 "visitors" => 1
+                 "dimensions" => ["Payment"],
+                 "metrics" => [
+                   1,
+                   1,
+                   16.67,
+                   %{
+                     "long" => "€10.00",
+                     "short" => "€10.0",
+                     "value" => 10.0,
+                     "currency" => "EUR"
+                   },
+                   %{
+                     "long" => "€10.00",
+                     "short" => "€10.0",
+                     "value" => 10.0,
+                     "currency" => "EUR"
+                   }
+                 ]
                },
-               %{
-                 "average_revenue" => nil,
-                 "conversion_rate" => 33.33,
-                 "name" => "Signup",
-                 "events" => 2,
-                 "total_revenue" => nil,
-                 "visitors" => 2
-               },
-               %{
-                 "average_revenue" => nil,
-                 "conversion_rate" => 50.0,
-                 "name" => "Visit /checkout",
-                 "events" => 3,
-                 "total_revenue" => nil,
-                 "visitors" => 3
-               }
-             ] == Enum.sort_by(response, & &1["name"])
+               %{"dimensions" => ["Signup"], "metrics" => [2, 2, 33.33, nil, nil]},
+               %{"dimensions" => ["Visit /checkout"], "metrics" => [3, 3, 50.0, nil, nil]}
+             ]
     end
 
     test "does not return revenue metrics if no revenue goals are returned", %{
@@ -693,15 +650,22 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      conn = get(conn, "/api/stats/#{site.domain}/conversions?period=day")
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          metrics: [
+            "visitors",
+            "events",
+            "conversion_rate",
+            "average_revenue",
+            "total_revenue"
+          ]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Signup",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 100.0
-               }
+      assert response["query"]["metrics"] == ["visitors", "events", "conversion_rate"]
+
+      assert response["results"] == [
+               %{"dimensions" => ["Signup"], "metrics" => [1, 1, 100.0]}
              ]
     end
   end
@@ -722,32 +686,23 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       insert(:goal, %{site: site, page_path: "/register"})
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      get_with_filter = fn filters ->
-        path = "/api/stats/#{site.domain}/conversions"
-        query = "?period=day&filters=#{Jason.encode!(filters)}"
-
-        get(conn, path <> query)
-        |> json_response(200)
+      get_with_filters = fn filters ->
+        query_conversions(conn, site, date_range: "day", filters: filters)
         |> Map.get("results")
       end
 
       expected = [
-        %{
-          "name" => "Signup",
-          "visitors" => 1,
-          "events" => 1,
-          "conversion_rate" => 33.33
-        }
+        %{"dimensions" => ["Signup"], "metrics" => [1, 1, 33.33]}
       ]
 
       # {:is, {:event, event}} filter type
-      assert get_with_filter.([[:is, "event:goal", ["Signup"]]]) == expected
+      assert get_with_filters.([["is", "event:goal", ["Signup"]]]) == expected
 
       # {:member, clauses} filter type
-      assert get_with_filter.([[:is, "event:goal", ["Signup", "Whatever"]]]) == expected
+      assert get_with_filters.([["is", "event:goal", ["Signup", "Whatever"]]]) == expected
 
       # {:matches_member, clauses} filter type
-      assert get_with_filter.([[:is, "event:goal", ["Signup", "Visit /whatever*"]]]) == expected
+      assert get_with_filters.([["is", "event:goal", ["Signup", "Visit /whatever*"]]]) == expected
     end
 
     test "does not return custom events with the filtered pageview goal pathname", %{
@@ -763,23 +718,14 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       insert(:goal, %{site: site, page_path: "/register"})
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Visit /register"]]])
-
-      results =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Visit /register"]]]
         )
-        |> json_response(200)
-        |> Map.get("results")
 
-      assert results == [
-               %{
-                 "name" => "Visit /register",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 33.33
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Visit /register"], "metrics" => [1, 1, 33.33]}
              ]
     end
 
@@ -796,27 +742,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       insert(:goal, %{site: site, page_path: "/register"})
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Signup", "Visit /register"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Signup", "Visit /register"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Signup",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 33.33
-               },
-               %{
-                 "name" => "Visit /register",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 16.67
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Signup"], "metrics" => [2, 2, 33.33]},
+               %{"dimensions" => ["Visit /register"], "metrics" => [1, 1, 16.67]}
              ]
     end
 
@@ -830,27 +764,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       insert(:goal, %{site: site, page_path: "/blog/**"})
       insert(:goal, %{site: site, page_path: "/billing/upgrade"})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Visit /blog/**", "Visit /billing/upgrade"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Visit /blog/**", "Visit /billing/upgrade"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Visit /blog/**",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 66.67
-               },
-               %{
-                 "name" => "Visit /billing/upgrade",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 33.33
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Visit /blog/**"], "metrics" => [2, 2, 66.67]},
+               %{"dimensions" => ["Visit /billing/upgrade"], "metrics" => [1, 1, 33.33]}
              ]
     end
 
@@ -868,27 +790,15 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
       insert(:goal, %{site: site, event_name: "CTA"})
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Signup", "Visit /blog**"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Signup", "Visit /blog**"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Visit /blog**",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 33.33
-               },
-               %{
-                 "name" => "Signup",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 16.67
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Visit /blog**"], "metrics" => [2, 2, 33.33]},
+               %{"dimensions" => ["Signup"], "metrics" => [1, 1, 16.67]}
              ]
     end
   end
@@ -906,25 +816,17 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, event_name: "Signup"})
 
-      filters =
-        Jason.encode!([
-          [:is, "event:goal", ["Signup"]],
-          [:is, "event:props:variant", ["(none)"]]
-        ])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}"
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [
+            ["is", "event:goal", ["Signup"]],
+            ["is", "event:props:variant", ["(none)"]]
+          ]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Signup",
-                 "visitors" => 1,
-                 "events" => 1,
-                 "conversion_rate" => 50
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Signup"], "metrics" => [1, 1, 50.0]}
              ]
     end
   end
@@ -951,8 +853,14 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
           timestamp: ~N[2019-07-01 23:00:00]
         ),
         build(:pageview,
+          user_id: @user_id,
           pathname: "/reg",
           timestamp: ~N[2019-07-01 23:00:00]
+        ),
+        build(:pageview,
+          user_id: @user_id,
+          pathname: "/reg123",
+          timestamp: ~N[2019-07-01 23:10:00]
         ),
         build(:pageview,
           pathname: "/billing/success",
@@ -976,43 +884,18 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         )
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&date=2019-07-01"
+      response =
+        query_conversions(conn, site,
+          date_range: ["2019-07-01", "2019-07-01"],
+          order_by: [["visitors", "desc"], ["events", "asc"]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "conversion_rate" => 100.0,
-                 "visitors" => 8,
-                 "name" => "Visit /*",
-                 "events" => 8
-               },
-               %{
-                 "conversion_rate" => 37.5,
-                 "visitors" => 3,
-                 "name" => "Visit /signup/*",
-                 "events" => 3
-               },
-               %{
-                 "conversion_rate" => 25.0,
-                 "visitors" => 2,
-                 "name" => "Visit /billing*/success",
-                 "events" => 2
-               },
-               %{
-                 "conversion_rate" => 25.0,
-                 "visitors" => 2,
-                 "name" => "Visit /reg*",
-                 "events" => 2
-               },
-               %{
-                 "conversion_rate" => 12.5,
-                 "visitors" => 1,
-                 "name" => "Visit /register",
-                 "events" => 1
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Visit /*"], "metrics" => [8, 9, 100.0]},
+               %{"dimensions" => ["Visit /signup/*"], "metrics" => [3, 3, 37.5]},
+               %{"dimensions" => ["Visit /billing*/success"], "metrics" => [2, 2, 25.0]},
+               %{"dimensions" => ["Visit /reg*"], "metrics" => [2, 3, 25.0]},
+               %{"dimensions" => ["Visit /register"], "metrics" => [1, 1, 12.5]}
              ]
     end
   end
@@ -1054,23 +937,16 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
       ])
 
-      url_query_params = "?period=day&date=2021-01-01&with_imported=true"
-      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+      response =
+        query_conversions(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          include: %{"imports" => true}
+        )
 
       assert [
-               %{
-                 "name" => "Purchase",
-                 "visitors" => 5,
-                 "events" => 7,
-                 "conversion_rate" => 62.5
-               },
-               %{
-                 "name" => "Visit /test",
-                 "visitors" => 3,
-                 "events" => 3,
-                 "conversion_rate" => 37.5
-               }
-             ] = json_response(conn, 200)["results"]
+               %{"dimensions" => ["Purchase"], "metrics" => [5, 7, 62.5]},
+               %{"dimensions" => ["Visit /test"], "metrics" => [3, 3, 37.5]}
+             ] = response["results"]
     end
 
     test "returns only custom event goals with a custom event goal filter", %{
@@ -1111,18 +987,16 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
       ])
 
-      filters = Jason.encode!([[:is, "event:goal", ["Purchase"]]])
-      url_query_params = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
-      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+      response =
+        query_conversions(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is", "event:goal", ["Purchase"]]],
+          include: %{"imports" => true}
+        )
 
       assert [
-               %{
-                 "name" => "Purchase",
-                 "visitors" => 5,
-                 "events" => 7,
-                 "conversion_rate" => 62.5
-               }
-             ] = json_response(conn, 200)["results"]
+               %{"dimensions" => ["Purchase"], "metrics" => [5, 7, 62.5]}
+             ] = response["results"]
     end
 
     test "returns custom event goals with more than one option in goal filter", %{
@@ -1173,24 +1047,17 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
       ])
 
-      filters = Jason.encode!([[:is, "event:goal", ["Purchase", "Activation"]]])
-      url_query_params = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
-      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+      response =
+        query_conversions(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is", "event:goal", ["Purchase", "Activation"]]],
+          include: %{"imports" => true}
+        )
 
       assert [
-               %{
-                 "name" => "Purchase",
-                 "visitors" => 5,
-                 "events" => 7,
-                 "conversion_rate" => 55.56
-               },
-               %{
-                 "name" => "Activation",
-                 "visitors" => 3,
-                 "events" => 5,
-                 "conversion_rate" => 33.33
-               }
-             ] = json_response(conn, 200)["results"]
+               %{"dimensions" => ["Purchase"], "metrics" => [5, 7, 55.56]},
+               %{"dimensions" => ["Activation"], "metrics" => [3, 5, 33.33]}
+             ] = response["results"]
     end
 
     test "returns only pageview goals with a pageview goal filter", %{
@@ -1231,18 +1098,16 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
       ])
 
-      filters = Jason.encode!([[:is, "event:goal", ["Visit /test"]]])
-      url_query_params = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
-      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+      response =
+        query_conversions(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is", "event:goal", ["Visit /test"]]],
+          include: %{"imports" => true}
+        )
 
       assert [
-               %{
-                 "name" => "Visit /test",
-                 "visitors" => 3,
-                 "events" => 3,
-                 "conversion_rate" => 37.5
-               }
-             ] = json_response(conn, 200)["results"]
+               %{"dimensions" => ["Visit /test"], "metrics" => [3, 3, 37.5]}
+             ] = response["results"]
     end
 
     test "returns pageview goals with more than one option in pageview goal filter", %{
@@ -1294,24 +1159,17 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         build(:imported_visitors, visitors: 5, date: ~D[2021-01-01])
       ])
 
-      filters = Jason.encode!([[:is, "event:goal", ["Visit /test", "Visit /blog"]]])
-      url_query_params = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
-      conn = get(conn, "/api/stats/#{site.domain}/conversions#{url_query_params}")
+      response =
+        query_conversions(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is", "event:goal", ["Visit /test", "Visit /blog"]]],
+          include: %{"imports" => true}
+        )
 
       assert [
-               %{
-                 "name" => "Visit /test",
-                 "visitors" => 3,
-                 "events" => 3,
-                 "conversion_rate" => 33.33
-               },
-               %{
-                 "name" => "Visit /blog",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 22.22
-               }
-             ] = json_response(conn, 200)["results"]
+               %{"dimensions" => ["Visit /test"], "metrics" => [3, 3, 33.33]},
+               %{"dimensions" => ["Visit /blog"], "metrics" => [2, 2, 22.22]}
+             ] = response["results"]
     end
 
     test "returns pageview goals with a page filter", %{
@@ -1347,24 +1205,17 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         build(:imported_visitors, visitors: 10, date: ~D[2021-01-01])
       ])
 
-      filters = Jason.encode!([[:is, "event:page", ["/blog/one", "/blog/two"]]])
-      q = "?filters=#{filters}&period=day&date=2021-01-01&with_imported=true"
-      conn = get(conn, "/api/stats/#{site.domain}/conversions#{q}")
+      response =
+        query_conversions(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is", "event:page", ["/blog/one", "/blog/two"]]],
+          include: %{"imports" => true}
+        )
 
       assert [
-               %{
-                 "name" => "Visit /blog/*",
-                 "visitors" => 5,
-                 "events" => 5,
-                 "conversion_rate" => 100.0
-               },
-               %{
-                 "name" => "Visit /blog/two",
-                 "visitors" => 3,
-                 "events" => 3,
-                 "conversion_rate" => 60.0
-               }
-             ] = json_response(conn, 200)["results"]
+               %{"dimensions" => ["Visit /blog/*"], "metrics" => [5, 5, 100.0]},
+               %{"dimensions" => ["Visit /blog/two"], "metrics" => [3, 3, 60.0]}
+             ] = response["results"]
     end
 
     test "calculates conversion_rate for goals with glob pattern with imported data", %{
@@ -1373,6 +1224,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
     } do
       site_import =
         insert(:site_import,
+          site: site,
           start_date: ~D[2005-01-01],
           end_date: Date.utc_today(),
           source: :universal_analytics
@@ -1389,19 +1241,12 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
 
       insert(:goal, %{site: site, page_path: "/blog**"})
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day"
-        )
+      response = query_conversions(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Visit /blog**",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 50
-               }
+      assert response["meta"]["imports_included"]
+
+      assert response["results"] == [
+               %{"dimensions" => ["Visit /blog**"], "metrics" => [3, 3, 60.0]}
              ]
     end
 
@@ -1432,27 +1277,16 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
         build(:imported_visitors, visitors: 4)
       ])
 
-      filters = Jason.encode!([[:contains, "event:goal", ["Onboarding"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/conversions?period=day&filters=#{filters}&with_imported=true"
+      response =
+        query_conversions(conn, site,
+          date_range: "day",
+          filters: [["contains", "event:goal", ["Onboarding"]]],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Onboarding: Step 1",
-                 "visitors" => 4,
-                 "events" => 4,
-                 "conversion_rate" => 50
-               },
-               %{
-                 "name" => "Onboarding: Step 2",
-                 "visitors" => 2,
-                 "events" => 2,
-                 "conversion_rate" => 25
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Onboarding: Step 1"], "metrics" => [4, 4, 50.0]},
+               %{"dimensions" => ["Onboarding: Step 2"], "metrics" => [2, 2, 25.0]}
              ]
     end
   end

--- a/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/conversions_test.exs
@@ -640,6 +640,7 @@ defmodule PlausibleWeb.Api.StatsController.ConversionsTest do
              ]
     end
 
+    @tag :ee_only
     test "does not return revenue metrics if no revenue goals are returned", %{
       conn: conn,
       site: site

--- a/test/plausible_web/controllers/api/stats_controller/operating_systems_legacy_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/operating_systems_legacy_test.exs
@@ -1,0 +1,472 @@
+defmodule PlausibleWeb.Api.StatsController.OperatingSystemsLegacyTest do
+  @moduledoc """
+  [DEPRECATED] Still used for CSV export but to be removed.
+  """
+  use PlausibleWeb.ConnCase
+
+  describe "GET /api/stats/:domain/operating-systems" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns operating systems by unique visitors", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Android")
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Mac", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "Android", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "returns (not set) when appropriate", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          operating_system: ""
+        ),
+        build(:pageview,
+          operating_system: "Linux"
+        )
+      ])
+
+      conn1 = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
+
+      assert json_response(conn1, 200)["results"] == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 50},
+               %{"name" => "Linux", "visitors" => 1, "percentage" => 50}
+             ]
+
+      filters = Jason.encode!([[:is, "visit:os", ["(not set)"]]])
+
+      conn2 =
+        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
+
+      assert json_response(conn2, 200)["results"] == [
+               %{"name" => "(not set)", "visitors" => 1, "percentage" => 100}
+             ]
+    end
+
+    test "select empty imported_operating_systems as (not set), merging with the native (not set)",
+         %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, user_id: 123),
+        build(:imported_operating_systems, visitors: 1),
+        build(:imported_visitors, visitors: 1)
+      ])
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&with_imported=true")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "(not set)", "visitors" => 2, "percentage" => 100.0}
+             ]
+    end
+
+    test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:pageview, user_id: 1, operating_system: "Mac"),
+        build(:pageview, user_id: 2, operating_system: "Mac"),
+        build(:event, user_id: 1, name: "Signup")
+      ])
+
+      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Mac",
+                 "total_visitors" => 2,
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0
+               }
+             ]
+    end
+
+    test "returns operating systems with :is filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          operating_system: "Mac"
+        ),
+        build(:pageview,
+          user_id: 123,
+          operating_system: "Mac",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          operating_system: "Windows",
+          "meta.key": ["author"],
+          "meta.value": ["other"]
+        ),
+        build(:pageview,
+          operating_system: "Android"
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:props:author", ["John Doe"]]])
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Mac", "visitors" => 1, "percentage" => 100}
+             ]
+    end
+
+    test "returns screen sizes with :is_not filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          operating_system: "Windows",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          user_id: 123,
+          operating_system: "Windows",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          operating_system: "Mac",
+          "meta.key": ["author"],
+          "meta.value": ["other"]
+        ),
+        build(:pageview,
+          operating_system: "Android"
+        )
+      ])
+
+      filters = Jason.encode!([["is_not", "event:props:author", ["John Doe"]]])
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Android", "visitors" => 1, "percentage" => 50},
+               %{"name" => "Mac", "visitors" => 1, "percentage" => 50}
+             ]
+    end
+
+    test "returns operating systems by unique visitors with imported data", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Mac"),
+        build(:pageview, operating_system: "Android"),
+        build(:imported_operating_systems, operating_system: "Mac"),
+        build(:imported_operating_systems, operating_system: "Android"),
+        build(:imported_visitors, visitors: 2)
+      ])
+
+      conn1 = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
+
+      assert json_response(conn1, 200)["results"] == [
+               %{"name" => "Mac", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "Android", "visitors" => 1, "percentage" => 33.33}
+             ]
+
+      conn2 =
+        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&with_imported=true")
+
+      assert json_response(conn2, 200)["results"] == [
+               %{"name" => "Mac", "visitors" => 3, "percentage" => 60},
+               %{"name" => "Android", "visitors" => 2, "percentage" => 40}
+             ]
+    end
+
+    test "imported data is ignored when filtering for goal", %{conn: conn, site: site} do
+      insert(:goal, site: site, event_name: "Signup")
+
+      populate_stats(site, [
+        build(:pageview, user_id: 1, operating_system: "Mac"),
+        build(:pageview, user_id: 2, operating_system: "Mac"),
+        build(:imported_operating_systems, operating_system: "Mac"),
+        build(:event, user_id: 1, name: "Signup")
+      ])
+
+      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+
+      conn =
+        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Mac",
+                 "total_visitors" => 2,
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for operating systems breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, user_id: 1, operating_system: "Mac"),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 2, operating_system: "Mac"),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 3, operating_system: "Mac"),
+        build(:pageview, user_id: 4, operating_system: "Android"),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 5, operating_system: "Android"),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/operating-systems#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$600.00",
+                   "short" => "$600.0",
+                   "value" => 600.0
+                 },
+                 "conversion_rate" => 100.0,
+                 "name" => "(not set)",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$600.00",
+                   "short" => "$600.0",
+                   "value" => 600.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "name" => "Mac",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "name" => "Android",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/operating-system-versions" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns top OS versions by unique visitors", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          operating_system: "Mac",
+          operating_system_version: "10.15"
+        ),
+        build(:pageview,
+          operating_system: "Mac",
+          operating_system_version: "10.16"
+        ),
+        build(:pageview,
+          operating_system: "Mac",
+          operating_system_version: "10.16"
+        ),
+        build(:pageview,
+          operating_system: "Android",
+          operating_system_version: "4"
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "visit:os", ["Mac"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/operating-system-versions?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Mac 10.16",
+                 "visitors" => 2,
+                 "percentage" => 66.67,
+                 "os" => "Mac",
+                 "version" => "10.16"
+               },
+               %{
+                 "name" => "Mac 10.15",
+                 "visitors" => 1,
+                 "percentage" => 33.33,
+                 "os" => "Mac",
+                 "version" => "10.15"
+               }
+             ]
+    end
+
+    test "returns only version under the name key (+ additional metrics) when 'detailed' is true in params",
+         %{
+           conn: conn,
+           site: site
+         } do
+      populate_stats(site, [
+        build(:pageview, operating_system: "Mac", operating_system_version: "14")
+      ])
+
+      filters = Jason.encode!([[:is, "visit:os", ["Mac"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/operating-system-versions?filters=#{filters}&detailed=true&period=day"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "14",
+                 "os" => "Mac",
+                 "visitors" => 1,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    test "with imported data", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          operating_system: "Mac",
+          operating_system_version: "11",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          operating_system: "Mac",
+          operating_system_version: "12",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:imported_operating_systems,
+          date: ~D[2021-01-01],
+          operating_system: "Mac",
+          operating_system_version: "11",
+          visitors: 5
+        ),
+        build(:imported_operating_systems,
+          date: ~D[2021-01-01],
+          operating_system: "Windows",
+          operating_system_version: "11",
+          visitors: 3
+        ),
+        build(:imported_operating_systems, date: ~D[2021-01-01], visitors: 10),
+        build(:imported_visitors, date: ~D[2021-01-01], visitors: 18)
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/operating-system-versions?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "os" => "(not set)",
+                 "name" => "(not set)",
+                 "version" => "(not set)",
+                 "visitors" => 10,
+                 "percentage" => 50.0
+               },
+               %{
+                 "os" => "Mac",
+                 "name" => "Mac 11",
+                 "version" => "11",
+                 "visitors" => 6,
+                 "percentage" => 30.0
+               },
+               %{
+                 "os" => "Windows",
+                 "name" => "Windows 11",
+                 "version" => "11",
+                 "visitors" => 3,
+                 "percentage" => 15.0
+               },
+               %{
+                 "os" => "Mac",
+                 "name" => "Mac 12",
+                 "version" => "12",
+                 "visitors" => 1,
+                 "percentage" => 5.0
+               }
+             ]
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
@@ -1,6 +1,22 @@
 defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
   use PlausibleWeb.ConnCase
 
+  defp query_os(conn, site, opts) do
+    params = %{
+      "dimensions" => Keyword.get(opts, :dimensions, ["visit:os"]),
+      "date_range" => Keyword.get(opts, :date_range, "all"),
+      "filters" => Keyword.get(opts, :filters, []),
+      "metrics" => Keyword.get(opts, :metrics, ["visitors", "percentage"]),
+      "include" => Keyword.get(opts, :include, nil),
+      "pagination" => Keyword.get(opts, :pagination, nil),
+      "order_by" => Keyword.get(opts, :order_by, nil)
+    }
+
+    conn
+    |> post("/api/stats/#{site.domain}/query", params)
+    |> json_response(200)
+  end
+
   describe "GET /api/stats/:domain/operating-systems" do
     setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
 
@@ -11,38 +27,35 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         build(:pageview, operating_system: "Android")
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
+      response = query_os(conn, site, date_range: "day")
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Mac", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "Android", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["Mac"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["Android"], "metrics" => [1, 33.33]}
              ]
     end
 
     test "returns (not set) when appropriate", %{conn: conn, site: site} do
       populate_stats(site, [
-        build(:pageview,
-          operating_system: ""
-        ),
-        build(:pageview,
-          operating_system: "Linux"
-        )
+        build(:pageview, operating_system: ""),
+        build(:pageview, operating_system: "Linux")
       ])
 
-      conn1 = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
+      response1 = query_os(conn, site, date_range: "day", order_by: [["visit:os", "asc"]])
 
-      assert json_response(conn1, 200)["results"] == [
-               %{"name" => "(not set)", "visitors" => 1, "percentage" => 50},
-               %{"name" => "Linux", "visitors" => 1, "percentage" => 50}
+      assert response1["results"] == [
+               %{"dimensions" => ["(not set)"], "metrics" => [1, 50.0]},
+               %{"dimensions" => ["Linux"], "metrics" => [1, 50.0]}
              ]
 
-      filters = Jason.encode!([[:is, "visit:os", ["(not set)"]]])
+      response2 =
+        query_os(conn, site,
+          date_range: "day",
+          filters: [["is", "visit:os", ["(not set)"]]]
+        )
 
-      conn2 =
-        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
-
-      assert json_response(conn2, 200)["results"] == [
-               %{"name" => "(not set)", "visitors" => 1, "percentage" => 100}
+      assert response2["results"] == [
+               %{"dimensions" => ["(not set)"], "metrics" => [1, 100.0]}
              ]
     end
 
@@ -54,11 +67,10 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         build(:imported_visitors, visitors: 1)
       ])
 
-      conn =
-        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&with_imported=true")
+      response = query_os(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "(not set)", "visitors" => 2, "percentage" => 100.0}
+      assert response["results"] == [
+               %{"dimensions" => ["(not set)"], "metrics" => [2, 100.0]}
              ]
     end
 
@@ -71,18 +83,15 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         build(:event, user_id: 1, name: "Signup")
       ])
 
-      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+      response =
+        query_os(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Signup"]]],
+          metrics: ["visitors", "total_visitors", "group_conversion_rate"]
+        )
 
-      conn =
-        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Mac",
-                 "total_visitors" => 2,
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Mac"], "metrics" => [1, 2, 50.0]}
              ]
     end
 
@@ -111,13 +120,14 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "event:props:author", ["John Doe"]]])
+      response =
+        query_os(conn, site,
+          date_range: "day",
+          filters: [["is", "event:props:author", ["John Doe"]]]
+        )
 
-      conn =
-        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Mac", "visitors" => 1, "percentage" => 100}
+      assert response["results"] == [
+               %{"dimensions" => ["Mac"], "metrics" => [1, 100.0]}
              ]
     end
 
@@ -148,14 +158,16 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         )
       ])
 
-      filters = Jason.encode!([["is_not", "event:props:author", ["John Doe"]]])
+      response =
+        query_os(conn, site,
+          date_range: "day",
+          filters: [["is_not", "event:props:author", ["John Doe"]]],
+          order_by: [["visit:os", "asc"]]
+        )
 
-      conn =
-        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Android", "visitors" => 1, "percentage" => 50},
-               %{"name" => "Mac", "visitors" => 1, "percentage" => 50}
+      assert response["results"] == [
+               %{"dimensions" => ["Android"], "metrics" => [1, 50.0]},
+               %{"dimensions" => ["Mac"], "metrics" => [1, 50.0]}
              ]
     end
 
@@ -172,19 +184,18 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         build(:imported_visitors, visitors: 2)
       ])
 
-      conn1 = get(conn, "/api/stats/#{site.domain}/operating-systems?period=day")
+      response1 = query_os(conn, site, date_range: "day")
 
-      assert json_response(conn1, 200)["results"] == [
-               %{"name" => "Mac", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "Android", "visitors" => 1, "percentage" => 33.33}
+      assert response1["results"] == [
+               %{"dimensions" => ["Mac"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["Android"], "metrics" => [1, 33.33]}
              ]
 
-      conn2 =
-        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&with_imported=true")
+      response2 = query_os(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn2, 200)["results"] == [
-               %{"name" => "Mac", "visitors" => 3, "percentage" => 60},
-               %{"name" => "Android", "visitors" => 2, "percentage" => 40}
+      assert response2["results"] == [
+               %{"dimensions" => ["Mac"], "metrics" => [3, 60.0]},
+               %{"dimensions" => ["Android"], "metrics" => [2, 40.0]}
              ]
     end
 
@@ -198,22 +209,18 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         build(:event, user_id: 1, name: "Signup")
       ])
 
-      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+      response =
+        query_os(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Signup"]]],
+          metrics: ["visitors", "total_visitors", "group_conversion_rate"]
+        )
 
-      conn =
-        get(conn, "/api/stats/#{site.domain}/operating-systems?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Mac",
-                 "total_visitors" => 2,
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Mac"], "metrics" => [1, 2, 50.0]}
              ]
     end
 
-    @tag :ee_only
     test "return revenue metrics for operating systems breakdown", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 1, operating_system: "Mac"),
@@ -256,67 +263,80 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_os(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Payment"]]],
+          metrics: [
+            "visitors",
+            "total_visitors",
+            "group_conversion_rate",
+            "average_revenue",
+            "total_revenue"
+          ],
+          order_by: [["visitors", "desc"], ["visit:os", "asc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/operating-systems#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$600.00",
-                   "short" => "$600.0",
-                   "value" => 600.0
-                 },
-                 "conversion_rate" => 100.0,
-                 "name" => "(not set)",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$600.00",
-                   "short" => "$600.0",
-                   "value" => 600.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 2
+                 "dimensions" => ["(not set)"],
+                 "metrics" => [
+                   2,
+                   2,
+                   100.0,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$600.00",
+                     "short" => "$600.0",
+                     "value" => 600.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$600.00",
+                     "short" => "$600.0",
+                     "value" => 600.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "name" => "Mac",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3,
-                 "visitors" => 2
+                 "dimensions" => ["Mac"],
+                 "metrics" => [
+                   2,
+                   3,
+                   66.67,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "name" => "Android",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 1
+                 "dimensions" => ["Android"],
+                 "metrics" => [
+                   1,
+                   2,
+                   50.0,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -345,58 +365,34 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "visit:os", ["Mac"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/operating-system-versions?period=day&filters=#{filters}"
+      response =
+        query_os(conn, site,
+          date_range: "day",
+          dimensions: ["visit:os", "visit:os_version"],
+          filters: [["is", "visit:os", ["Mac"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Mac 10.16",
-                 "visitors" => 2,
-                 "percentage" => 66.67,
-                 "os" => "Mac",
-                 "version" => "10.16"
-               },
-               %{
-                 "name" => "Mac 10.15",
-                 "visitors" => 1,
-                 "percentage" => 33.33,
-                 "os" => "Mac",
-                 "version" => "10.15"
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Mac", "10.16"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["Mac", "10.15"], "metrics" => [1, 33.33]}
              ]
     end
 
-    test "returns only version under the name key (+ additional metrics) when 'detailed' is true in params",
-         %{
-           conn: conn,
-           site: site
-         } do
+    test "returns OS and version with additional metrics", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, operating_system: "Mac", operating_system_version: "14")
       ])
 
-      filters = Jason.encode!([[:is, "visit:os", ["Mac"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/operating-system-versions?filters=#{filters}&detailed=true&period=day"
+      response =
+        query_os(conn, site,
+          date_range: "day",
+          dimensions: ["visit:os", "visit:os_version"],
+          filters: [["is", "visit:os", ["Mac"]]],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "14",
-                 "os" => "Mac",
-                 "visitors" => 1,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 100.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Mac", "14"], "metrics" => [1, 100, 0, 100.0]}
              ]
     end
 
@@ -428,41 +424,18 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
         build(:imported_visitors, date: ~D[2021-01-01], visitors: 18)
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/operating-system-versions?period=day&date=2021-01-01&with_imported=true"
+      response =
+        query_os(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          dimensions: ["visit:os", "visit:os_version"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "os" => "(not set)",
-                 "name" => "(not set)",
-                 "version" => "(not set)",
-                 "visitors" => 10,
-                 "percentage" => 50.0
-               },
-               %{
-                 "os" => "Mac",
-                 "name" => "Mac 11",
-                 "version" => "11",
-                 "visitors" => 6,
-                 "percentage" => 30.0
-               },
-               %{
-                 "os" => "Windows",
-                 "name" => "Windows 11",
-                 "version" => "11",
-                 "visitors" => 3,
-                 "percentage" => 15.0
-               },
-               %{
-                 "os" => "Mac",
-                 "name" => "Mac 12",
-                 "version" => "12",
-                 "visitors" => 1,
-                 "percentage" => 5.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["(not set)", "(not set)"], "metrics" => [10, 50.0]},
+               %{"dimensions" => ["Mac", "11"], "metrics" => [6, 30.0]},
+               %{"dimensions" => ["Windows", "11"], "metrics" => [3, 15.0]},
+               %{"dimensions" => ["Mac", "12"], "metrics" => [1, 5.0]}
              ]
     end
   end

--- a/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/operating_systems_test.exs
@@ -221,6 +221,7 @@ defmodule PlausibleWeb.Api.StatsController.OperatingSystemsTest do
              ]
     end
 
+    @tag :ee_only
     test "return revenue metrics for operating systems breakdown", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 1, operating_system: "Mac"),

--- a/test/plausible_web/controllers/api/stats_controller/pages_legacy_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/pages_legacy_test.exs
@@ -1,10 +1,6 @@
 defmodule PlausibleWeb.Api.StatsController.PagesLegacyTest do
   @moduledoc """
-  [DEPRECATED] Tests for the pages, entry_pages, and exit_pages
-  actions in StatsController which are no longer used by the
-  dashboard pages reports. Still used by Dashboard CSV export
-  though, which is why we're keeping it around until the CSV
-  export is migrated to v2 API.
+  [DEPRECATED] Still used for CSV export but to be removed.
   """
   use PlausibleWeb.ConnCase
 

--- a/test/plausible_web/controllers/api/stats_controller/sources_legacy_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_legacy_test.exs
@@ -1,0 +1,2929 @@
+defmodule PlausibleWeb.Api.StatsController.SourcesLegacyTest do
+  @moduledoc """
+  [DEPRECATED] Still used for CSV export but to be removed.
+  """
+  use PlausibleWeb.ConnCase
+
+  @user_id Enum.random(1000..9999)
+
+  describe "GET /api/stats/:domain/sources" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns top sources by unique user ids", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
+        ),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
+        ),
+        build(:pageview)
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/sources?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 3, "percentage" => 50.0},
+               %{"name" => "DuckDuckGo", "visitors" => 2, "percentage" => 33.33},
+               %{"name" => "Direct / None", "visitors" => 1, "percentage" => 16.67}
+             ]
+    end
+
+    test "returns top sources with :is filter on custom pageview props", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:props:author", ["John Doe"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+
+      assert json_response(conn, 200)["meta"] == %{
+               "date_range_label" => "1 Jan 2021"
+             }
+    end
+
+    test "returns top sources with :is_not filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["other"],
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          "meta.key": ["author"],
+          "meta.value": ["other"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      filters = Jason.encode!([[:is_not, "event:props:author", ["John Doe"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "returns top sources with :is (none) filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"],
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          "meta.key": ["author"],
+          "meta.value": ["other"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:props:author", ["(none)"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Facebook", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "returns top sources with :is_not (none) filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          "meta.key": ["logged_in"],
+          "meta.value": ["true"],
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          "meta.key": ["author"],
+          "meta.value": ["other"],
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          "meta.key": ["author"],
+          "meta.value": ["other"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          "meta.key": ["author"],
+          "meta.value": ["another"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      filters = Jason.encode!([[:is_not, "event:props:author", ["(none)"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "returns top sources with imported data", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, referrer_source: "Google", referrer: "google.com"),
+        build(:pageview, referrer_source: "Google", referrer: "google.com"),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_visitors),
+        build(:imported_visitors),
+        build(:imported_visitors),
+        build(:imported_sources,
+          source: "Google",
+          visitors: 2
+        ),
+        build(:imported_sources,
+          source: "DuckDuckGo",
+          visitors: 1
+        )
+      ])
+
+      conn1 = get(conn, "/api/stats/#{site.domain}/sources?period=day")
+
+      assert json_response(conn1, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+
+      conn2 = get(conn, "/api/stats/#{site.domain}/sources?period=day&with_imported=true")
+
+      assert json_response(conn2, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 4, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 2, "percentage" => 33.33}
+             ]
+    end
+
+    test "calculates bounce rate and visit duration for sources", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&detailed=true"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "DuckDuckGo",
+                 "visitors" => 1,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 50.0
+               },
+               %{
+                 "name" => "Google",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 50.0
+               }
+             ]
+    end
+
+    test "calculates bounce rate and visit duration for sources with imported data", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_visitors, date: ~D[2021-01-01]),
+        build(:imported_visitors, date: ~D[2021-01-01]),
+        build(:imported_visitors, date: ~D[2021-01-01]),
+        build(:imported_sources,
+          source: "Google",
+          date: ~D[2021-01-01],
+          visitors: 2,
+          visits: 3,
+          bounces: 1,
+          visit_duration: 900
+        ),
+        build(:imported_sources,
+          source: "DuckDuckGo",
+          date: ~D[2021-01-01],
+          visitors: 1,
+          visits: 1,
+          visit_duration: 100,
+          bounces: 0
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&detailed=true"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "DuckDuckGo",
+                 "visitors" => 1,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 50.0
+               },
+               %{
+                 "name" => "Google",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 50.0
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&detailed=true&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "Google",
+                 "visitors" => 3,
+                 "bounce_rate" => 25.0,
+                 "visit_duration" => 450.0,
+                 "percentage" => 60.0
+               },
+               %{
+                 "name" => "DuckDuckGo",
+                 "visitors" => 2,
+                 "bounce_rate" => 50.0,
+                 "visit_duration" => 50.0,
+                 "percentage" => 40.0
+               }
+             ]
+    end
+
+    test "returns top sources in realtime report", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          timestamp: relative_time(minute: -3)
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          timestamp: relative_time(minute: -2)
+        ),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          timestamp: relative_time(minute: -1)
+        )
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/sources?period=realtime")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "can paginate the results", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
+        ),
+        build(:imported_sources,
+          source: "DuckDuckGo"
+        ),
+        build(:imported_sources,
+          source: "DuckDuckGo"
+        )
+      ])
+
+      conn1 = get(conn, "/api/stats/#{site.domain}/sources?period=day&limit=1&page=2")
+
+      assert json_response(conn1, 200)["results"] == [
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&limit=1&page=2&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67}
+             ]
+    end
+
+    test "shows sources for a page (using old page filter)", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, pathname: "/page1", referrer_source: "Google"),
+        build(:pageview, pathname: "/page1", referrer_source: "Google"),
+        build(:pageview,
+          user_id: 1,
+          pathname: "/page2",
+          referrer_source: "DuckDuckGo"
+        ),
+        build(:pageview,
+          user_id: 1,
+          pathname: "/page1",
+          referrer_source: "DuckDuckGo"
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:page", ["/page1"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "shows sources for a page (using new filters)", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, pathname: "/page1", referrer_source: "Google"),
+        build(:pageview, pathname: "/page1", referrer_source: "Google"),
+        build(:pageview,
+          user_id: 1,
+          pathname: "/page2",
+          referrer_source: "DuckDuckGo"
+        ),
+        build(:pageview,
+          user_id: 1,
+          pathname: "/page1",
+          referrer_source: "DuckDuckGo"
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:page", ["/page1"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "order_by [[visit:source, desc]] is respected", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, referrer_source: "C"),
+        build(:pageview, referrer_source: "A"),
+        build(:pageview, referrer_source: "B")
+      ])
+
+      order_by = Jason.encode!([["visit:source", "desc"]])
+      conn = get(conn, "/api/stats/#{site.domain}/sources?order_by=#{order_by}&period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "C", "visitors" => 1, "percentage" => 33.33},
+               %{"name" => "B", "visitors" => 1, "percentage" => 33.33},
+               %{"name" => "A", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "order_by [[visit_duration, asc], [visit:source, desc]]] is respected and flipping the sort orders works",
+         %{
+           conn: conn,
+           site: site
+         } do
+      populate_stats(site, [
+        build(:pageview,
+          pathname: "/in",
+          user_id: @user_id,
+          referrer_source: "B",
+          timestamp: ~N[2024-08-10 09:00:00]
+        ),
+        build(:pageview,
+          pathname: "/out",
+          user_id: @user_id,
+          referrer_source: "B",
+          timestamp: ~N[2024-08-10 09:00:45]
+        ),
+        build(:pageview,
+          pathname: "/in",
+          user_id: @user_id,
+          referrer_source: "C",
+          timestamp: ~N[2024-08-10 10:00:00]
+        ),
+        build(:pageview,
+          pathname: "/out",
+          user_id: @user_id,
+          referrer_source: "C",
+          timestamp: ~N[2024-08-10 10:00:30]
+        ),
+        build(:pageview, referrer_source: "A", timestamp: ~N[2024-08-10 10:00:30]),
+        build(:pageview, referrer_source: "A", timestamp: ~N[2024-08-10 10:00:30]),
+        build(:pageview, referrer_source: "Z", timestamp: ~N[2024-08-10 10:00:30])
+      ])
+
+      order_by_asc = Jason.encode!([["visit_duration", "asc"], ["visit:source", "desc"]])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2024-08-10&detailed=true&order_by=#{order_by_asc}"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "Z",
+                 "visitors" => 1,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 25.0
+               },
+               %{
+                 "name" => "A",
+                 "visitors" => 2,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 50.0
+               },
+               %{
+                 "name" => "C",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 30,
+                 "percentage" => 25.0
+               },
+               %{
+                 "name" => "B",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 45,
+                 "percentage" => 25.0
+               }
+             ]
+
+      order_by_flipped = Jason.encode!([["visit_duration", "desc"], ["visit:source", "asc"]])
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2024-08-10&detailed=true&order_by=#{order_by_flipped}"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "B",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 45,
+                 "percentage" => 25.0
+               },
+               %{
+                 "name" => "C",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 30,
+                 "percentage" => 25.0
+               },
+               %{
+                 "name" => "A",
+                 "visitors" => 2,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 50.0
+               },
+               %{
+                 "name" => "Z",
+                 "visitors" => 1,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 25.0
+               }
+             ]
+    end
+
+    test "can compare with previous period", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          timestamp: ~N[2021-01-02 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          timestamp: ~N[2021-01-02 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Google",
+          referrer: "google.com",
+          timestamp: ~N[2021-01-02 00:00:00]
+        )
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-02&comparison=previous_period&detailed=true"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Google",
+                 "visitors" => 2,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 66.67,
+                 "comparison" => %{
+                   "visitors" => 0,
+                   "bounce_rate" => 0,
+                   "visit_duration" => nil,
+                   "percentage" => 0.0,
+                   "change" => %{
+                     "visitors" => 100,
+                     "bounce_rate" => nil,
+                     "visit_duration" => nil,
+                     "percentage" => 100
+                   }
+                 }
+               },
+               %{
+                 "name" => "DuckDuckGo",
+                 "visitors" => 1,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 33.33,
+                 "comparison" => %{
+                   "visitors" => 1,
+                   "bounce_rate" => 100,
+                   "visit_duration" => 0,
+                   "percentage" => 100.0,
+                   "change" => %{
+                     "visitors" => 0,
+                     "bounce_rate" => 0,
+                     "visit_duration" => 0,
+                     "percentage" => -67
+                   }
+                 }
+               }
+             ]
+
+      assert json_response(conn, 200)["meta"] == %{
+               "date_range_label" => "2 Jan 2021",
+               "comparison_date_range_label" => "1 Jan 2021"
+             }
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for sources breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:pageview,
+          user_id: 4,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com"
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        ),
+        build(:pageview,
+          user_id: 8,
+          referrer_source: "Bing",
+          referrer: "bing.com"
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/sources#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Direct / None",
+                 "visitors" => 2,
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$600.00",
+                   "short" => "$600.0",
+                   "value" => 600.0
+                 },
+                 "conversion_rate" => 100.0,
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$600.00",
+                   "short" => "$600.0",
+                   "value" => 600.0
+                 },
+                 "total_visitors" => 2
+               },
+               %{
+                 "name" => "Google",
+                 "visitors" => 2,
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3
+               },
+               %{
+                 "name" => "DuckDuckGo",
+                 "visitors" => 1,
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2
+               }
+             ]
+    end
+  end
+
+  describe "UTM parameters with hostname filter" do
+    setup [:create_user, :log_in, :create_site]
+
+    for {resource, attr} <- [
+          utm_campaigns: :utm_campaign,
+          utm_sources: :utm_source,
+          utm_terms: :utm_term,
+          utm_contents: :utm_content
+        ] do
+      test "returns #{resource} when filtered by hostname", %{conn: conn, site: site} do
+        populate_stats(site, [
+          # session starts at two.example.com with utm_param=ad
+          build(
+            :pageview,
+            [
+              {unquote(attr), "ad"},
+              {:user_id, @user_id},
+              {:hostname, "two.example.com"},
+              {:timestamp, ~N[2021-01-01 00:00:00]}
+            ]
+          ),
+          # session continues on one.example.com without any utm_params
+          build(
+            :pageview,
+            [
+              {:user_id, @user_id},
+              {:hostname, "one.example.com"},
+              {:timestamp, ~N[2021-01-01 00:15:00]}
+            ]
+          )
+        ])
+
+        filters = Jason.encode!([[:is, "event:hostname", ["one.example.com"]]])
+
+        conn =
+          get(
+            conn,
+            "/api/stats/#{site.domain}/#{unquote(resource)}?period=day&date=2021-01-01&filters=#{filters}"
+          )
+
+        # nobody landed on one.example.com from utm_param=ad
+        assert json_response(conn, 200)["results"] == []
+      end
+    end
+  end
+
+  describe "GET /api/stats/:domain/channels" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "returns top channels by unique user ids", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "Bing",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Bing",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          referrer_source: "Facebook",
+          utm_source: "fb-ads",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "Facebook",
+          utm_source: "fb-ads",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/channels?period=day&&detailed=true&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "Paid Social",
+                 "visitors" => 2,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 66.67
+               },
+               %{
+                 "name" => "Organic Search",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 33.33
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for channels breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          referrer_source: "Google",
+          referrer: "google.com"
+        ),
+        build(:pageview,
+          user_id: 4,
+          referrer_source: "Facebook",
+          utm_source: "fb-ads"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          referrer_source: "Facebook",
+          utm_source: "fb-ads"
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/channels#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Direct",
+                 "visitors" => 2,
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$600.00",
+                   "short" => "$600.0",
+                   "value" => 600.0
+                 },
+                 "conversion_rate" => 100.0,
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$600.00",
+                   "short" => "$600.0",
+                   "value" => 600.0
+                 },
+                 "total_visitors" => 2
+               },
+               %{
+                 "name" => "Organic Search",
+                 "visitors" => 2,
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3
+               },
+               %{
+                 "name" => "Paid Social",
+                 "visitors" => 1,
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/utm_mediums" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns top utm_mediums by unique user ids", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_medium: "social",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_medium: "social",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_medium: "email",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_sources,
+          utm_medium: "social",
+          date: ~D[2021-01-01],
+          visit_duration: 700,
+          bounces: 1,
+          visits: 1,
+          visitors: 1
+        ),
+        build(:imported_sources,
+          utm_medium: "email",
+          date: ~D[2021-01-01],
+          bounces: 0,
+          visits: 1,
+          visitors: 1,
+          visit_duration: 100
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "email",
+                 "visitors" => 1,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 50.0
+               },
+               %{
+                 "name" => "social",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 50.0
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "email",
+                 "visitors" => 2,
+                 "bounce_rate" => 50,
+                 "visit_duration" => 50,
+                 "percentage" => 50.0
+               },
+               %{
+                 "name" => "social",
+                 "visitors" => 2,
+                 "bounce_rate" => 50,
+                 "visit_duration" => 800.0,
+                 "percentage" => 50.0
+               }
+             ]
+    end
+
+    test "filters out entries without utm_medium present", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_medium: "social",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_medium: "social",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_medium: "",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_sources,
+          utm_medium: "social",
+          date: ~D[2021-01-01],
+          visit_duration: 700,
+          bounces: 1,
+          visits: 1,
+          visitors: 1
+        ),
+        build(:imported_sources,
+          utm_medium: "",
+          date: ~D[2021-01-01],
+          bounces: 0,
+          visits: 1,
+          visitors: 1,
+          visit_duration: 100
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "social",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 100.0
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "social",
+                 "visitors" => 2,
+                 "bounce_rate" => 50.0,
+                 "visit_duration" => 800.0,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for UTM mediums breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          utm_medium: "social"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          utm_medium: "social"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          utm_medium: "social"
+        ),
+        build(:pageview,
+          user_id: 4,
+          utm_medium: "email"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          utm_medium: "email"
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/utm_mediums#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "name" => "social",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "name" => "email",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/utm_campaigns" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns top utm_campaigns by unique user ids", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_campaign: "profile",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_campaign: "profile",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_campaign: "august",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_campaign: "august",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_sources,
+          utm_campaign: "profile",
+          date: ~D[2021-01-01],
+          visit_duration: 700,
+          bounces: 1,
+          visits: 1,
+          visitors: 1
+        ),
+        build(:imported_sources,
+          utm_campaign: "august",
+          date: ~D[2021-01-01],
+          bounces: 0,
+          visits: 1,
+          visitors: 1,
+          visit_duration: 900
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "august",
+                 "visitors" => 2,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 66.67
+               },
+               %{
+                 "name" => "profile",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 33.33
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "august",
+                 "visitors" => 3,
+                 "bounce_rate" => 67,
+                 "visit_duration" => 300,
+                 "percentage" => 60.0
+               },
+               %{
+                 "name" => "profile",
+                 "visitors" => 2,
+                 "bounce_rate" => 50,
+                 "visit_duration" => 800.0,
+                 "percentage" => 40.0
+               }
+             ]
+    end
+
+    test "filters out entries without utm_campaign present", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_campaign: "profile",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_campaign: "profile",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_campaign: "",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_campaign: "",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_sources,
+          utm_campaign: "profile",
+          date: ~D[2021-01-01],
+          visit_duration: 700,
+          bounces: 1,
+          visits: 1,
+          visitors: 1
+        ),
+        build(:imported_sources,
+          utm_campaign: "",
+          date: ~D[2021-01-01],
+          bounces: 0,
+          visits: 1,
+          visitors: 1,
+          visit_duration: 900
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "profile",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 100.0
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "profile",
+                 "visitors" => 2,
+                 "bounce_rate" => 50.0,
+                 "visit_duration" => 800.0,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for UTM campaigns breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          utm_campaign: "profile"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          utm_campaign: "profile"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          utm_campaign: "profile"
+        ),
+        build(:pageview,
+          user_id: 4,
+          utm_campaign: "august"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          utm_campaign: "august"
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/utm_campaigns#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "name" => "profile",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "name" => "august",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/utm_sources" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns top utm_sources by unique user ids", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_source: "Twitter",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_source: "Twitter",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_source: "newsletter",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_source: "newsletter",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_sources?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "newsletter",
+                 "visitors" => 2,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 66.67
+               },
+               %{
+                 "name" => "Twitter",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 33.33
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for UTM sources breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          utm_source: "Twitter"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          utm_source: "Twitter"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          utm_source: "Twitter"
+        ),
+        build(:pageview,
+          user_id: 4,
+          utm_source: "newsletter"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          utm_source: "newsletter"
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/utm_sources#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "name" => "Twitter",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "name" => "newsletter",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/utm_terms" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns top utm_terms by unique user ids", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_term: "oat milk",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_term: "oat milk",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_term: "Sweden",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_term: "Sweden",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_sources,
+          utm_term: "oat milk",
+          date: ~D[2021-01-01],
+          visit_duration: 700,
+          bounces: 1,
+          visits: 1,
+          visitors: 1
+        ),
+        build(:imported_sources,
+          utm_term: "Sweden",
+          date: ~D[2021-01-01],
+          bounces: 0,
+          visits: 1,
+          visitors: 1,
+          visit_duration: 900
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "Sweden",
+                 "visitors" => 2,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 66.67
+               },
+               %{
+                 "name" => "oat milk",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 33.33
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "Sweden",
+                 "visitors" => 3,
+                 "bounce_rate" => 67.0,
+                 "visit_duration" => 300.0,
+                 "percentage" => 60.0
+               },
+               %{
+                 "name" => "oat milk",
+                 "visitors" => 2,
+                 "bounce_rate" => 50.0,
+                 "visit_duration" => 800.0,
+                 "percentage" => 40.0
+               }
+             ]
+    end
+
+    test "filters out entries without utm_term present", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_term: "oat milk",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_term: "oat milk",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_term: "",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_term: "",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_sources,
+          utm_term: "oat milk",
+          date: ~D[2021-01-01],
+          visit_duration: 700,
+          bounces: 1,
+          visits: 1,
+          visitors: 1
+        ),
+        build(:imported_sources,
+          utm_term: "",
+          date: ~D[2021-01-01],
+          bounces: 0,
+          visits: 1,
+          visitors: 1,
+          visit_duration: 900
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "oat milk",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 100.0
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "oat milk",
+                 "visitors" => 2,
+                 "bounce_rate" => 50.0,
+                 "visit_duration" => 800.0,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for UTM terms breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          utm_term: "oat milk"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          utm_term: "oat milk"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          utm_term: "oat milk"
+        ),
+        build(:pageview,
+          user_id: 4,
+          utm_term: "Sweden"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          utm_term: "Sweden"
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/utm_terms#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "name" => "oat milk",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "name" => "Sweden",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/utm_contents" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns top utm_contents by unique user ids", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_content: "ad",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_content: "ad",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_content: "blog",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_content: "blog",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_sources,
+          utm_content: "ad",
+          date: ~D[2021-01-01],
+          visit_duration: 700,
+          bounces: 1,
+          visits: 1,
+          visitors: 1
+        ),
+        build(:imported_sources,
+          utm_content: "blog",
+          date: ~D[2021-01-01],
+          bounces: 0,
+          visits: 1,
+          visitors: 1,
+          visit_duration: 900
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "blog",
+                 "visitors" => 2,
+                 "bounce_rate" => 100,
+                 "visit_duration" => 0,
+                 "percentage" => 66.67
+               },
+               %{
+                 "name" => "ad",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 33.33
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "blog",
+                 "visitors" => 3,
+                 "bounce_rate" => 67.0,
+                 "visit_duration" => 300.0,
+                 "percentage" => 60.0
+               },
+               %{
+                 "name" => "ad",
+                 "visitors" => 2,
+                 "bounce_rate" => 50.0,
+                 "visit_duration" => 800.0,
+                 "percentage" => 40.0
+               }
+             ]
+    end
+
+    test "filters out entries without utm_content present", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          utm_content: "ad",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_content: "ad",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          utm_content: "",
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          utm_content: "",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      populate_stats(site, [
+        build(:imported_sources,
+          utm_content: "ad",
+          date: ~D[2021-01-01],
+          visit_duration: 700,
+          bounces: 1,
+          visits: 1,
+          visitors: 1
+        ),
+        build(:imported_sources,
+          utm_content: "",
+          date: ~D[2021-01-01],
+          bounces: 0,
+          visits: 1,
+          visitors: 1,
+          visit_duration: 900
+        )
+      ])
+
+      conn1 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01"
+        )
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "name" => "ad",
+                 "visitors" => 1,
+                 "bounce_rate" => 0,
+                 "visit_duration" => 900,
+                 "percentage" => 100.0
+               }
+             ]
+
+      conn2 =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01&with_imported=true"
+        )
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "name" => "ad",
+                 "visitors" => 2,
+                 "bounce_rate" => 50.0,
+                 "visit_duration" => 800.0,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for UTM contents breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          utm_content: "ad"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          utm_content: "ad"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          utm_content: "ad"
+        ),
+        build(:pageview,
+          user_id: 4,
+          utm_content: "blog"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          utm_content: "blog"
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/utm_contents#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "name" => "ad",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "name" => "blog",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/sources - with goal filter" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "returns top referrers for a custom goal including conversion_rate", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "Twitter",
+          user_id: @user_id
+        ),
+        build(:event,
+          name: "Signup",
+          user_id: @user_id
+        ),
+        build(:pageview,
+          referrer_source: "Twitter"
+        )
+      ])
+
+      # Imported data is ignored when filtering
+      populate_stats(site, [
+        build(:imported_sources, source: "Twitter")
+      ])
+
+      insert(:goal, site: site, event_name: "Signup")
+      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Twitter",
+                 "total_visitors" => 2,
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0
+               }
+             ]
+    end
+
+    test "returns no top referrers for a custom goal and filtered by hostname",
+         %{
+           conn: conn,
+           site: site
+         } do
+      populate_stats(site, [
+        build(:pageview,
+          hostname: "blog.example.com",
+          referrer_source: "Facebook",
+          user_id: @user_id
+        ),
+        build(:pageview,
+          hostname: "app.example.com",
+          pathname: "/register",
+          user_id: @user_id
+        ),
+        build(:event,
+          name: "Signup",
+          hostname: "app.example.com",
+          pathname: "/register",
+          user_id: @user_id
+        )
+      ])
+
+      filters =
+        Jason.encode!([
+          [:is, "event:goal", ["Signup"]],
+          [:is, "event:hostname", ["app.example.com"]]
+        ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == []
+    end
+
+    test "returns top referrers for a custom goal and filtered by hostname (2)",
+         %{
+           conn: conn,
+           site: site
+         } do
+      populate_stats(site, [
+        build(:pageview,
+          hostname: "app.example.com",
+          referrer_source: "Facebook",
+          pathname: "/register",
+          user_id: @user_id
+        ),
+        build(:event,
+          name: "Signup",
+          hostname: "app.example.com",
+          pathname: "/register",
+          user_id: @user_id
+        )
+      ])
+
+      insert(:goal, site: site, event_name: "Signup")
+
+      filters =
+        Jason.encode!([
+          [:is, "event:goal", ["Signup"]],
+          [:is, "event:hostname", ["app.example.com"]]
+        ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "conversion_rate" => 100.0,
+                 "name" => "Facebook",
+                 "total_visitors" => 1,
+                 "visitors" => 1
+               }
+             ]
+    end
+
+    test "returns top referrers with goal filter + :is prop filter", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Download",
+          "meta.key": ["method", "logged_in"],
+          "meta.value": ["HTTP", "true"],
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          "meta.key": ["logged_in"],
+          "meta.value": ["true"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          referrer_source: "Facebook",
+          referrer: "facebook.com",
+          name: "Download",
+          "meta.key": ["method", "logged_in"],
+          "meta.value": ["HTTP", "false"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      insert(:goal, site: site, event_name: "Download")
+
+      filters =
+        Jason.encode!([
+          [:is, "event:goal", ["Download"]],
+          [:is, "event:props:logged_in", ["true"]]
+        ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "DuckDuckGo",
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0,
+                 "total_visitors" => 2
+               }
+             ]
+    end
+
+    test "returns top referrers with goal filter + prop :is_not filter", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "DuckDuckGo",
+          referrer: "duckduckgo.com",
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Download",
+          "meta.key": ["method"],
+          "meta.value": ["HTTP"],
+          user_id: 123,
+          timestamp: ~N[2021-01-01 00:01:00]
+        ),
+        build(:event,
+          name: "Download",
+          referrer_source: "Google",
+          referrer: "google.com",
+          "meta.key": ["method", "logged_in"],
+          "meta.value": ["HTTP", "true"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:event,
+          name: "Download",
+          referrer_source: "Google",
+          referrer: "google.com",
+          "meta.key": ["method", "logged_in"],
+          "meta.value": ["HTTP", "false"],
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      insert(:goal, site: site, event_name: "Download")
+
+      filters =
+        Jason.encode!([
+          [:is, "event:goal", ["Download"]],
+          [:is_not, "event:props:logged_in", ["true"]]
+        ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "DuckDuckGo",
+                 "visitors" => 1,
+                 "conversion_rate" => 100.0,
+                 "total_visitors" => 1
+               },
+               %{
+                 "name" => "Google",
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0,
+                 "total_visitors" => 2
+               }
+             ]
+    end
+
+    test "returns top referrers for a pageview goal including conversion_rate", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "Twitter",
+          user_id: @user_id
+        ),
+        build(:pageview,
+          pathname: "/register",
+          user_id: @user_id
+        ),
+        build(:pageview,
+          referrer_source: "Twitter"
+        )
+      ])
+
+      insert(:goal, site: site, page_path: "/register")
+      filters = Jason.encode!([[:is, "event:goal", ["Visit /register"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "Twitter",
+                 "total_visitors" => 2,
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0
+               }
+             ]
+    end
+  end
+
+  describe "GET /api/stats/:domain/referrer-drilldown (Google Search Terms)" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "gets keywords from Google", %{conn: conn, site: site} do
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/Google?period=day")
+
+      assert %{
+               "results" => [
+                 %{
+                   "name" => "simple web analytics",
+                   "visitors" => 25,
+                   "impressions" => 50,
+                   "position" => 2.0,
+                   "ctr" => 37.0
+                 },
+                 %{
+                   "name" => "open-source analytics",
+                   "visitors" => 15,
+                   "impressions" => 25,
+                   "position" => 4.0,
+                   "ctr" => 50.0
+                 }
+               ]
+             } = json_response(conn, 200)
+    end
+
+    test "returns 200 with empty keywords list when no data returned from last 30d", %{
+      conn: conn,
+      site: site
+    } do
+      filters = Jason.encode!([[:is, "event:page", ["/empty"]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/Google?period=30d&filters=#{filters}")
+
+      assert json_response(conn, 200) == %{"results" => []}
+    end
+
+    test "returns 422 with error when no data returned and queried range is too recent", %{
+      conn: conn,
+      site: site
+    } do
+      filters = Jason.encode!([[:is, "event:page", ["/empty"]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/Google?period=day&filters=#{filters}")
+
+      assert json_response(conn, 422) == %{"error_code" => "period_too_recent"}
+    end
+
+    test "returns 422 with error when Google account not connected (admin)", %{
+      conn: conn,
+      site: site
+    } do
+      filters = Jason.encode!([[:is, "event:page", ["/not-configured"]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/Google?period=day&filters=#{filters}")
+
+      assert %{"error_code" => "not_configured", "is_admin" => true} = json_response(conn, 422)
+    end
+
+    test "returns 422 with error when Google account not connected (non-admin)", %{conn: conn} do
+      site = new_site(public: true)
+
+      filters = Jason.encode!([[:is, "event:page", ["/not-configured"]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/Google?period=day&filters=#{filters}")
+
+      %{
+        "error_code" => "not_configured",
+        "is_admin" => false
+      } = json_response(conn, 422)
+    end
+
+    test "returns 422 with error when unsupported filters used", %{conn: conn, site: site} do
+      filters = Jason.encode!([[:is, "event:page", ["/unsupported-filters"]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/Google?period=day&filters=#{filters}")
+
+      assert %{"error_code" => "unsupported_filters"} = json_response(conn, 422)
+    end
+
+    @tag :capture_log
+    test "returns 502 when Google API responds with an unexpected error", %{
+      conn: conn,
+      site: site
+    } do
+      filters = Jason.encode!([[:is, "event:page", ["/unexpected-error"]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/referrers/Google?period=day&filters=#{filters}")
+
+      assert %{"error_code" => "not_configured"} = json_response(conn, 502)
+    end
+  end
+
+  describe "GET /api/stats/:domain/referrer-drilldown" do
+    setup [:create_user, :log_in, :create_site]
+
+    test "returns top referrers for a particular source", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com"
+        ),
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com"
+        ),
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com/page1"
+        ),
+        build(:pageview,
+          referrer_source: "ignored",
+          referrer: "ignored"
+        )
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/referrers/10words?period=day"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "10words.com", "visitors" => 2, "percentage" => 66.67},
+               %{"name" => "10words.com/page1", "visitors" => 1, "percentage" => 33.33}
+             ]
+    end
+
+    test "returns top referrers for a particular source filtered by hostname", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "example",
+          referrer: "example.com",
+          hostname: "two.example.com"
+        ),
+        build(:pageview,
+          referrer_source: "example",
+          referrer: "example.com",
+          hostname: "two.example.com",
+          user_id: @user_id
+        ),
+        build(:pageview,
+          hostname: "one.example.com",
+          user_id: @user_id
+        ),
+        build(:pageview,
+          referrer_source: "example",
+          referrer: "example.com/page1",
+          hostname: "one.example.com"
+        ),
+        build(:pageview,
+          referrer_source: "ignored",
+          referrer: "ignored",
+          hostname: "two.example.com"
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:hostname", ["one.example.com"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/referrers/example?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{"name" => "example.com/page1", "visitors" => 1, "percentage" => 100.0}
+             ]
+    end
+
+    test "calculates bounce rate and visit duration for referrer urls", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:00:00]
+        ),
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com",
+          user_id: @user_id,
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com",
+          timestamp: ~N[2021-01-01 00:15:00]
+        ),
+        build(:pageview,
+          referrer_source: "ignored",
+          referrer: "ignored",
+          timestamp: ~N[2021-01-01 00:00:00]
+        )
+      ])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/referrers/10words?period=day&date=2021-01-01&detailed=true"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "10words.com",
+                 "visitors" => 2,
+                 "bounce_rate" => 50.0,
+                 "visit_duration" => 450,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    test "returns top referring urls for a custom goal", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com"
+        ),
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com",
+          user_id: @user_id
+        ),
+        build(:event,
+          name: "Signup",
+          user_id: @user_id
+        ),
+        build(:event,
+          name: "Signup"
+        )
+      ])
+
+      insert(:goal, site: site, event_name: "Signup")
+      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/referrers/10words?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "10words.com",
+                 "total_visitors" => 2,
+                 "conversion_rate" => 50.0,
+                 "visitors" => 1
+               }
+             ]
+    end
+
+    test "returns top referring urls for a pageview goal", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com"
+        ),
+        build(:pageview,
+          referrer_source: "10words",
+          referrer: "10words.com",
+          user_id: @user_id
+        ),
+        build(:pageview,
+          pathname: "/register",
+          user_id: @user_id
+        ),
+        build(:pageview,
+          pathname: "/register"
+        )
+      ])
+
+      insert(:goal, site: site, page_path: "/register")
+
+      filters = Jason.encode!([[:is, "event:goal", ["Visit /register"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/referrers/10words?period=day&filters=#{filters}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "name" => "10words.com",
+                 "total_visitors" => 2,
+                 "conversion_rate" => 50.0,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/sources_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/sources_test.exs
@@ -3,6 +3,23 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
   @user_id Enum.random(1000..9999)
 
+  defp query_sources(conn, site, opts) do
+    params = %{
+      "dimensions" => Keyword.get(opts, :dimensions, ["visit:source"]),
+      "date_range" => Keyword.get(opts, :date_range, "all"),
+      "relative_date" => Keyword.get(opts, :relative_date, nil),
+      "filters" => Keyword.get(opts, :filters, []),
+      "metrics" => Keyword.get(opts, :metrics, ["visitors", "percentage"]),
+      "include" => Keyword.get(opts, :include, nil),
+      "pagination" => Keyword.get(opts, :pagination, nil),
+      "order_by" => Keyword.get(opts, :order_by, nil)
+    }
+
+    conn
+    |> post("/api/stats/#{site.domain}/query", params)
+    |> json_response(200)
+  end
+
   describe "GET /api/stats/:domain/sources" do
     setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
 
@@ -31,12 +48,12 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         build(:pageview)
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/sources?period=day")
+      response = query_sources(conn, site, date_range: "day")
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 3, "percentage" => 50.0},
-               %{"name" => "DuckDuckGo", "visitors" => 2, "percentage" => 33.33},
-               %{"name" => "Direct / None", "visitors" => 1, "percentage" => 16.67}
+      assert response["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [3, 50.0]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [2, 33.33]},
+               %{"dimensions" => ["Direct / None"], "metrics" => [1, 16.67]}
              ]
     end
 
@@ -75,22 +92,21 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "event:props:author", ["John Doe"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is", "event:props:author", ["John Doe"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 33.33]}
              ]
 
-      assert json_response(conn, 200)["meta"] == %{
-               "date_range_label" => "1 Jan 2021"
-             }
+      assert response["query"]["date_range"] == [
+               "2021-01-01T00:00:00Z",
+               "2021-01-01T23:59:59Z"
+             ]
     end
 
     test "returns top sources with :is_not filter on custom pageview props", %{
@@ -133,17 +149,15 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is_not, "event:props:author", ["John Doe"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is_not", "event:props:author", ["John Doe"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -183,17 +197,15 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "event:props:author", ["(none)"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is", "event:props:author", ["(none)"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Facebook", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["Facebook"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -237,17 +249,15 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is_not, "event:props:author", ["(none)"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          filters: [["is_not", "event:props:author", ["(none)"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -275,18 +285,18 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 = get(conn, "/api/stats/#{site.domain}/sources?period=day")
+      response1 = query_sources(conn, site, date_range: "day")
 
-      assert json_response(conn1, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+      assert response1["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 33.33]}
              ]
 
-      conn2 = get(conn, "/api/stats/#{site.domain}/sources?period=day&with_imported=true")
+      response2 = query_sources(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn2, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 4, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 2, "percentage" => 33.33}
+      assert response2["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [4, 66.67]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [2, 33.33]}
              ]
     end
 
@@ -311,27 +321,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&detailed=true"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          order_by: [["visit_duration", "asc"]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "DuckDuckGo",
-                 "visitors" => 1,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 50.0
-               },
-               %{
-                 "name" => "Google",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 50.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 100, 0, 50.0]},
+               %{"dimensions" => ["Google"], "metrics" => [1, 0, 900, 50.0]}
              ]
     end
 
@@ -381,50 +380,28 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&detailed=true"
+      response1 =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          order_by: [["visit_duration", "asc"]]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "DuckDuckGo",
-                 "visitors" => 1,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 50.0
-               },
-               %{
-                 "name" => "Google",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 50.0
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 100, 0, 50.0]},
+               %{"dimensions" => ["Google"], "metrics" => [1, 0, 900, 50.0]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&detailed=true&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "Google",
-                 "visitors" => 3,
-                 "bounce_rate" => 25.0,
-                 "visit_duration" => 450.0,
-                 "percentage" => 60.0
-               },
-               %{
-                 "name" => "DuckDuckGo",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 50.0,
-                 "percentage" => 40.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [3, 25.0, 450.0, 60.0]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [2, 50.0, 50.0, 40.0]}
              ]
     end
 
@@ -447,11 +424,11 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/sources?period=realtime")
+      response = query_sources(conn, site, date_range: "realtime")
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -477,24 +454,26 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 = get(conn, "/api/stats/#{site.domain}/sources?period=day&limit=1&page=2")
+      response1 =
+        query_sources(conn, site, date_range: "day", pagination: %{"limit" => 1, "offset" => 1})
 
-      assert json_response(conn1, 200)["results"] == [
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+      assert response1["results"] == [
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 33.33]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&limit=1&page=2&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          date_range: "day",
+          pagination: %{"limit" => 1, "offset" => 1},
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67}
+      assert response2["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [2, 66.67]}
              ]
     end
 
-    test "shows sources for a page (using old page filter)", %{conn: conn, site: site} do
+    test "shows sources for a page", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, pathname: "/page1", referrer_source: "Google"),
         build(:pageview, pathname: "/page1", referrer_source: "Google"),
@@ -510,37 +489,15 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "event:page", ["/page1"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
-             ]
-    end
-
-    test "shows sources for a page (using new filters)", %{conn: conn, site: site} do
-      populate_stats(site, [
-        build(:pageview, pathname: "/page1", referrer_source: "Google"),
-        build(:pageview, pathname: "/page1", referrer_source: "Google"),
-        build(:pageview,
-          user_id: 1,
-          pathname: "/page2",
-          referrer_source: "DuckDuckGo"
-        ),
-        build(:pageview,
-          user_id: 1,
-          pathname: "/page1",
-          referrer_source: "DuckDuckGo"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          filters: [["is", "event:page", ["/page1"]]]
         )
-      ])
 
-      filters = Jason.encode!([[:is, "event:page", ["/page1"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "Google", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "DuckDuckGo", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["Google"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -551,13 +508,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         build(:pageview, referrer_source: "B")
       ])
 
-      order_by = Jason.encode!([["visit:source", "desc"]])
-      conn = get(conn, "/api/stats/#{site.domain}/sources?order_by=#{order_by}&period=day")
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          order_by: [["visit:source", "desc"]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "C", "visitors" => 1, "percentage" => 33.33},
-               %{"name" => "B", "visitors" => 1, "percentage" => 33.33},
-               %{"name" => "A", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["C"], "metrics" => [1, 33.33]},
+               %{"dimensions" => ["B"], "metrics" => [1, 33.33]},
+               %{"dimensions" => ["A"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -596,82 +556,32 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         build(:pageview, referrer_source: "Z", timestamp: ~N[2024-08-10 10:00:30])
       ])
 
-      order_by_asc = Jason.encode!([["visit_duration", "asc"], ["visit:source", "desc"]])
-
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2024-08-10&detailed=true&order_by=#{order_by_asc}"
+      response1 =
+        query_sources(conn, site,
+          date_range: ["2024-08-10", "2024-08-10"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          order_by: [["visit_duration", "asc"], ["visit:source", "desc"]]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "Z",
-                 "visitors" => 1,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 25.0
-               },
-               %{
-                 "name" => "A",
-                 "visitors" => 2,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 50.0
-               },
-               %{
-                 "name" => "C",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 30,
-                 "percentage" => 25.0
-               },
-               %{
-                 "name" => "B",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 45,
-                 "percentage" => 25.0
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["Z"], "metrics" => [1, 100, 0, 25.0]},
+               %{"dimensions" => ["A"], "metrics" => [2, 100, 0, 50.0]},
+               %{"dimensions" => ["C"], "metrics" => [1, 0, 30, 25.0]},
+               %{"dimensions" => ["B"], "metrics" => [1, 0, 45, 25.0]}
              ]
 
-      order_by_flipped = Jason.encode!([["visit_duration", "desc"], ["visit:source", "asc"]])
-
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2024-08-10&detailed=true&order_by=#{order_by_flipped}"
+      response2 =
+        query_sources(conn, site,
+          date_range: ["2024-08-10", "2024-08-10"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          order_by: [["visit_duration", "desc"], ["visit:source", "asc"]]
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "B",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 45,
-                 "percentage" => 25.0
-               },
-               %{
-                 "name" => "C",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 30,
-                 "percentage" => 25.0
-               },
-               %{
-                 "name" => "A",
-                 "visitors" => 2,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 50.0
-               },
-               %{
-                 "name" => "Z",
-                 "visitors" => 1,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 25.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["B"], "metrics" => [1, 0, 45, 25.0]},
+               %{"dimensions" => ["C"], "metrics" => [1, 0, 30, 25.0]},
+               %{"dimensions" => ["A"], "metrics" => [2, 100, 0, 50.0]},
+               %{"dimensions" => ["Z"], "metrics" => [1, 100, 0, 25.0]}
              ]
     end
 
@@ -699,57 +609,43 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-02&comparison=previous_period&detailed=true"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-02", "2021-01-02"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          include: %{"compare" => "previous_period"}
         )
 
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "name" => "Google",
-                 "visitors" => 2,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 66.67,
+                 "dimensions" => ["Google"],
+                 "metrics" => [2, 100, 0, 66.67],
                  "comparison" => %{
-                   "visitors" => 0,
-                   "bounce_rate" => 0,
-                   "visit_duration" => nil,
-                   "percentage" => 0.0,
-                   "change" => %{
-                     "visitors" => 100,
-                     "bounce_rate" => nil,
-                     "visit_duration" => nil,
-                     "percentage" => 100
-                   }
+                   "dimensions" => ["Google"],
+                   "metrics" => [0, 0, nil, 0.0],
+                   "change" => [100, nil, nil, 100]
                  }
                },
                %{
-                 "name" => "DuckDuckGo",
-                 "visitors" => 1,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 33.33,
+                 "dimensions" => ["DuckDuckGo"],
+                 "metrics" => [1, 100, 0, 33.33],
                  "comparison" => %{
-                   "visitors" => 1,
-                   "bounce_rate" => 100,
-                   "visit_duration" => 0,
-                   "percentage" => 100.0,
-                   "change" => %{
-                     "visitors" => 0,
-                     "bounce_rate" => 0,
-                     "visit_duration" => 0,
-                     "percentage" => -67
-                   }
+                   "dimensions" => ["DuckDuckGo"],
+                   "metrics" => [1, 100, 0, 100.0],
+                   "change" => [0, 0, 0, -67]
                  }
                }
              ]
 
-      assert json_response(conn, 200)["meta"] == %{
-               "date_range_label" => "2 Jan 2021",
-               "comparison_date_range_label" => "1 Jan 2021"
-             }
+      assert response["query"]["date_range"] == [
+               "2021-01-02T00:00:00Z",
+               "2021-01-02T23:59:59Z"
+             ]
+
+      assert response["query"]["comparison_date_range"] == [
+               "2021-01-01T00:00:00Z",
+               "2021-01-01T23:59:59Z"
+             ]
     end
 
     @tag :ee_only
@@ -820,67 +716,80 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          metrics: [
+            "visitors",
+            "group_conversion_rate",
+            "total_visitors",
+            "average_revenue",
+            "total_revenue"
+          ],
+          filters: [["is", "event:goal", ["Payment"]]],
+          order_by: [["visitors", "desc"], ["visit:source", "asc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/sources#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "name" => "Direct / None",
-                 "visitors" => 2,
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$600.00",
-                   "short" => "$600.0",
-                   "value" => 600.0
-                 },
-                 "conversion_rate" => 100.0,
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$600.00",
-                   "short" => "$600.0",
-                   "value" => 600.0
-                 },
-                 "total_visitors" => 2
+                 "dimensions" => ["Direct / None"],
+                 "metrics" => [
+                   2,
+                   100.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$600.00",
+                     "short" => "$600.0",
+                     "value" => 600.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$600.00",
+                     "short" => "$600.0",
+                     "value" => 600.0
+                   }
+                 ]
                },
                %{
-                 "name" => "Google",
-                 "visitors" => 2,
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3
+                 "dimensions" => ["Google"],
+                 "metrics" => [
+                   2,
+                   66.67,
+                   3,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "name" => "DuckDuckGo",
-                 "visitors" => 1,
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2
+                 "dimensions" => ["DuckDuckGo"],
+                 "metrics" => [
+                   1,
+                   50.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -889,11 +798,11 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
   describe "UTM parameters with hostname filter" do
     setup [:create_user, :log_in, :create_site]
 
-    for {resource, attr} <- [
-          utm_campaigns: :utm_campaign,
-          utm_sources: :utm_source,
-          utm_terms: :utm_term,
-          utm_contents: :utm_content
+    for {resource, attr, dimension} <- [
+          {:utm_campaigns, :utm_campaign, "visit:utm_campaign"},
+          {:utm_sources, :utm_source, "visit:utm_source"},
+          {:utm_terms, :utm_term, "visit:utm_term"},
+          {:utm_contents, :utm_content, "visit:utm_content"}
         ] do
       test "returns #{resource} when filtered by hostname", %{conn: conn, site: site} do
         populate_stats(site, [
@@ -918,16 +827,15 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
           )
         ])
 
-        filters = Jason.encode!([[:is, "event:hostname", ["one.example.com"]]])
-
-        conn =
-          get(
-            conn,
-            "/api/stats/#{site.domain}/#{unquote(resource)}?period=day&date=2021-01-01&filters=#{filters}"
+        response =
+          query_sources(conn, site,
+            dimensions: [unquote(dimension)],
+            date_range: ["2021-01-01", "2021-01-01"],
+            filters: [["is", "event:hostname", ["one.example.com"]]]
           )
 
         # nobody landed on one.example.com from utm_param=ad
-        assert json_response(conn, 200)["results"] == []
+        assert response["results"] == []
       end
     end
   end
@@ -959,27 +867,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/channels?period=day&&detailed=true&date=2021-01-01"
+      response =
+        query_sources(conn, site,
+          dimensions: ["visit:channel"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "Paid Social",
-                 "visitors" => 2,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 66.67
-               },
-               %{
-                 "name" => "Organic Search",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 33.33
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Paid Social"], "metrics" => [2, 100, 0, 66.67]},
+               %{"dimensions" => ["Organic Search"], "metrics" => [1, 0, 900, 33.33]}
              ]
     end
 
@@ -1046,67 +943,81 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_sources(conn, site,
+          dimensions: ["visit:channel"],
+          date_range: "day",
+          metrics: [
+            "visitors",
+            "group_conversion_rate",
+            "total_visitors",
+            "average_revenue",
+            "total_revenue"
+          ],
+          filters: [["is", "event:goal", ["Payment"]]],
+          order_by: [["visitors", "desc"], ["visit:channel", "asc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/channels#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "name" => "Direct",
-                 "visitors" => 2,
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$600.00",
-                   "short" => "$600.0",
-                   "value" => 600.0
-                 },
-                 "conversion_rate" => 100.0,
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$600.00",
-                   "short" => "$600.0",
-                   "value" => 600.0
-                 },
-                 "total_visitors" => 2
+                 "dimensions" => ["Direct"],
+                 "metrics" => [
+                   2,
+                   100.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$600.00",
+                     "short" => "$600.0",
+                     "value" => 600.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$600.00",
+                     "short" => "$600.0",
+                     "value" => 600.0
+                   }
+                 ]
                },
                %{
-                 "name" => "Organic Search",
-                 "visitors" => 2,
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3
+                 "dimensions" => ["Organic Search"],
+                 "metrics" => [
+                   2,
+                   66.67,
+                   3,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "name" => "Paid Social",
-                 "visitors" => 1,
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2
+                 "dimensions" => ["Paid Social"],
+                 "metrics" => [
+                   1,
+                   50.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -1134,6 +1045,13 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       populate_stats(site, [
+        build(:imported_visitors,
+          date: ~D[2021-01-01],
+          visit_duration: 800,
+          bounces: 1,
+          visits: 2,
+          visitors: 2
+        ),
         build(:imported_sources,
           utm_medium: "social",
           date: ~D[2021-01-01],
@@ -1152,50 +1070,31 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01"
+      response1 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_medium"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"],
+          order_by: [["visit:utm_medium", "asc"]]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "email",
-                 "visitors" => 1,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 50.0
-               },
-               %{
-                 "name" => "social",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 50.0
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["email"], "metrics" => [1, 100, 0, 50.0]},
+               %{"dimensions" => ["social"], "metrics" => [1, 0, 900, 50.0]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_medium"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"],
+          order_by: [["visit:utm_medium", "asc"]],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "email",
-                 "visitors" => 2,
-                 "bounce_rate" => 50,
-                 "visit_duration" => 50,
-                 "percentage" => 50.0
-               },
-               %{
-                 "name" => "social",
-                 "visitors" => 2,
-                 "bounce_rate" => 50,
-                 "visit_duration" => 800.0,
-                 "percentage" => 50.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["email"], "metrics" => [2, 50, 50, 50.0]},
+               %{"dimensions" => ["social"], "metrics" => [2, 50, 800.0, 50.0]}
              ]
     end
 
@@ -1218,6 +1117,13 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       populate_stats(site, [
+        build(:imported_visitors,
+          date: ~D[2021-01-01],
+          visit_duration: 800,
+          bounces: 1,
+          visits: 2,
+          visitors: 2
+        ),
         build(:imported_sources,
           utm_medium: "social",
           date: ~D[2021-01-01],
@@ -1236,36 +1142,29 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01"
+      response1 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_medium"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          filters: [["is_not", "visit:utm_medium", [""]]],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "social",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 100.0
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["social"], "metrics" => [1, 0, 900, 100.0]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_mediums?period=day&date=2021-01-01&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_medium"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          filters: [["is_not", "visit:utm_medium", [""]]],
+          date_range: ["2021-01-01", "2021-01-01"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "social",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 800.0,
-                 "percentage" => 100.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["social"], "metrics" => [2, 50.0, 800.0, 100.0]}
              ]
     end
 
@@ -1327,49 +1226,61 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_medium"],
+          date_range: "day",
+          metrics: [
+            "visitors",
+            "group_conversion_rate",
+            "total_visitors",
+            "average_revenue",
+            "total_revenue"
+          ],
+          filters: [["is", "event:goal", ["Payment"]], ["is_not", "visit:utm_medium", [""]]],
+          order_by: [["visitors", "desc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/utm_mediums#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "name" => "social",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3,
-                 "visitors" => 2
+                 "dimensions" => ["social"],
+                 "metrics" => [
+                   2,
+                   66.67,
+                   3,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "name" => "email",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 1
+                 "dimensions" => ["email"],
+                 "metrics" => [
+                   1,
+                   50.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -1401,6 +1312,13 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       populate_stats(site, [
+        build(:imported_visitors,
+          date: ~D[2021-01-01],
+          visit_duration: 1600,
+          bounces: 1,
+          visits: 2,
+          visitors: 2
+        ),
         build(:imported_sources,
           utm_campaign: "profile",
           date: ~D[2021-01-01],
@@ -1419,50 +1337,29 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01"
+      response1 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_campaign"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "august",
-                 "visitors" => 2,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 66.67
-               },
-               %{
-                 "name" => "profile",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 33.33
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["august"], "metrics" => [2, 100, 0, 66.67]},
+               %{"dimensions" => ["profile"], "metrics" => [1, 0, 900, 33.33]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_campaign"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "august",
-                 "visitors" => 3,
-                 "bounce_rate" => 67,
-                 "visit_duration" => 300,
-                 "percentage" => 60.0
-               },
-               %{
-                 "name" => "profile",
-                 "visitors" => 2,
-                 "bounce_rate" => 50,
-                 "visit_duration" => 800.0,
-                 "percentage" => 40.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["august"], "metrics" => [3, 67, 300, 60.0]},
+               %{"dimensions" => ["profile"], "metrics" => [2, 50, 800.0, 40.0]}
              ]
     end
 
@@ -1489,6 +1386,13 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       populate_stats(site, [
+        build(:imported_visitors,
+          date: ~D[2021-01-01],
+          visit_duration: 1600,
+          bounces: 1,
+          visits: 2,
+          visitors: 2
+        ),
         build(:imported_sources,
           utm_campaign: "profile",
           date: ~D[2021-01-01],
@@ -1507,36 +1411,29 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01"
+      response1 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_campaign"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          filters: [["is_not", "visit:utm_campaign", [""]]],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "profile",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 100.0
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["profile"], "metrics" => [1, 0, 900, 100.0]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_campaigns?period=day&date=2021-01-01&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_campaign"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          filters: [["is_not", "visit:utm_campaign", [""]]],
+          date_range: ["2021-01-01", "2021-01-01"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "profile",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 800.0,
-                 "percentage" => 100.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["profile"], "metrics" => [2, 50.0, 800.0, 100.0]}
              ]
     end
 
@@ -1598,49 +1495,61 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_campaign"],
+          date_range: "day",
+          metrics: [
+            "visitors",
+            "group_conversion_rate",
+            "total_visitors",
+            "average_revenue",
+            "total_revenue"
+          ],
+          filters: [["is", "event:goal", ["Payment"]], ["is_not", "visit:utm_campaign", [""]]],
+          order_by: [["visitors", "desc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/utm_campaigns#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "name" => "profile",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3,
-                 "visitors" => 2
+                 "dimensions" => ["profile"],
+                 "metrics" => [
+                   2,
+                   66.67,
+                   3,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "name" => "august",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 1
+                 "dimensions" => ["august"],
+                 "metrics" => [
+                   1,
+                   50.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -1671,27 +1580,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_sources?period=day&date=2021-01-01"
+      response =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_source"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "newsletter",
-                 "visitors" => 2,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 66.67
-               },
-               %{
-                 "name" => "Twitter",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 33.33
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["newsletter"], "metrics" => [2, 100, 0, 66.67]},
+               %{"dimensions" => ["Twitter"], "metrics" => [1, 0, 900, 33.33]}
              ]
     end
 
@@ -1753,49 +1651,61 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_source"],
+          date_range: "day",
+          metrics: [
+            "visitors",
+            "group_conversion_rate",
+            "total_visitors",
+            "average_revenue",
+            "total_revenue"
+          ],
+          filters: [["is", "event:goal", ["Payment"]], ["is_not", "visit:utm_source", [""]]],
+          order_by: [["visitors", "desc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/utm_sources#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "name" => "Twitter",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3,
-                 "visitors" => 2
+                 "dimensions" => ["Twitter"],
+                 "metrics" => [
+                   2,
+                   66.67,
+                   3,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "name" => "newsletter",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 1
+                 "dimensions" => ["newsletter"],
+                 "metrics" => [
+                   1,
+                   50.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -1827,6 +1737,13 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       populate_stats(site, [
+        build(:imported_visitors,
+          date: ~D[2021-01-01],
+          visit_duration: 1600,
+          bounces: 1,
+          visits: 2,
+          visitors: 2
+        ),
         build(:imported_sources,
           utm_term: "oat milk",
           date: ~D[2021-01-01],
@@ -1845,50 +1762,29 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01"
+      response1 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_term"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "Sweden",
-                 "visitors" => 2,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 66.67
-               },
-               %{
-                 "name" => "oat milk",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 33.33
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["Sweden"], "metrics" => [2, 100, 0, 66.67]},
+               %{"dimensions" => ["oat milk"], "metrics" => [1, 0, 900, 33.33]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_term"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "Sweden",
-                 "visitors" => 3,
-                 "bounce_rate" => 67.0,
-                 "visit_duration" => 300.0,
-                 "percentage" => 60.0
-               },
-               %{
-                 "name" => "oat milk",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 800.0,
-                 "percentage" => 40.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["Sweden"], "metrics" => [3, 67.0, 300.0, 60.0]},
+               %{"dimensions" => ["oat milk"], "metrics" => [2, 50.0, 800.0, 40.0]}
              ]
     end
 
@@ -1915,6 +1811,13 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       populate_stats(site, [
+        build(:imported_visitors,
+          date: ~D[2021-01-01],
+          visit_duration: 1600,
+          bounces: 1,
+          visits: 2,
+          visitors: 2
+        ),
         build(:imported_sources,
           utm_term: "oat milk",
           date: ~D[2021-01-01],
@@ -1933,36 +1836,29 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01"
+      response1 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_term"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          filters: [["is_not", "visit:utm_term", [""]]],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "oat milk",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 100.0
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["oat milk"], "metrics" => [1, 0, 900, 100.0]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_terms?period=day&date=2021-01-01&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_term"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          filters: [["is_not", "visit:utm_term", [""]]],
+          date_range: ["2021-01-01", "2021-01-01"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "oat milk",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 800.0,
-                 "percentage" => 100.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["oat milk"], "metrics" => [2, 50.0, 800.0, 100.0]}
              ]
     end
 
@@ -2024,49 +1920,61 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_term"],
+          date_range: "day",
+          metrics: [
+            "visitors",
+            "group_conversion_rate",
+            "total_visitors",
+            "average_revenue",
+            "total_revenue"
+          ],
+          filters: [["is", "event:goal", ["Payment"]], ["is_not", "visit:utm_term", [""]]],
+          order_by: [["visitors", "desc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/utm_terms#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "name" => "oat milk",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3,
-                 "visitors" => 2
+                 "dimensions" => ["oat milk"],
+                 "metrics" => [
+                   2,
+                   66.67,
+                   3,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "name" => "Sweden",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 1
+                 "dimensions" => ["Sweden"],
+                 "metrics" => [
+                   1,
+                   50.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -2098,6 +2006,13 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       populate_stats(site, [
+        build(:imported_visitors,
+          date: ~D[2021-01-01],
+          visit_duration: 1600,
+          bounces: 1,
+          visits: 2,
+          visitors: 2
+        ),
         build(:imported_sources,
           utm_content: "ad",
           date: ~D[2021-01-01],
@@ -2116,50 +2031,29 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01"
+      response1 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_content"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "blog",
-                 "visitors" => 2,
-                 "bounce_rate" => 100,
-                 "visit_duration" => 0,
-                 "percentage" => 66.67
-               },
-               %{
-                 "name" => "ad",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 33.33
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["blog"], "metrics" => [2, 100, 0, 66.67]},
+               %{"dimensions" => ["ad"], "metrics" => [1, 0, 900, 33.33]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_content"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          date_range: ["2021-01-01", "2021-01-01"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "blog",
-                 "visitors" => 3,
-                 "bounce_rate" => 67.0,
-                 "visit_duration" => 300.0,
-                 "percentage" => 60.0
-               },
-               %{
-                 "name" => "ad",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 800.0,
-                 "percentage" => 40.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["blog"], "metrics" => [3, 67.0, 300.0, 60.0]},
+               %{"dimensions" => ["ad"], "metrics" => [2, 50.0, 800.0, 40.0]}
              ]
     end
 
@@ -2186,6 +2080,13 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       populate_stats(site, [
+        build(:imported_visitors,
+          date: ~D[2021-01-01],
+          visit_duration: 1600,
+          bounces: 1,
+          visits: 2,
+          visitors: 2
+        ),
         build(:imported_sources,
           utm_content: "ad",
           date: ~D[2021-01-01],
@@ -2204,36 +2105,29 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn1 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01"
+      response1 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_content"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          filters: [["is_not", "visit:utm_content", [""]]],
+          date_range: ["2021-01-01", "2021-01-01"]
         )
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "name" => "ad",
-                 "visitors" => 1,
-                 "bounce_rate" => 0,
-                 "visit_duration" => 900,
-                 "percentage" => 100.0
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["ad"], "metrics" => [1, 0, 900, 100.0]}
              ]
 
-      conn2 =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/utm_contents?period=day&date=2021-01-01&with_imported=true"
+      response2 =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_content"],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"],
+          filters: [["is_not", "visit:utm_content", [""]]],
+          date_range: ["2021-01-01", "2021-01-01"],
+          include: %{"imports" => true}
         )
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "name" => "ad",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 800.0,
-                 "percentage" => 100.0
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["ad"], "metrics" => [2, 50.0, 800.0, 100.0]}
              ]
     end
 
@@ -2295,49 +2189,61 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_sources(conn, site,
+          dimensions: ["visit:utm_content"],
+          date_range: "day",
+          metrics: [
+            "visitors",
+            "group_conversion_rate",
+            "total_visitors",
+            "average_revenue",
+            "total_revenue"
+          ],
+          filters: [["is", "event:goal", ["Payment"]], ["is_not", "visit:utm_content", [""]]],
+          order_by: [["visitors", "desc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/utm_contents#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "name" => "ad",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3,
-                 "visitors" => 2
+                 "dimensions" => ["ad"],
+                 "metrics" => [
+                   2,
+                   66.67,
+                   3,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "name" => "blog",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 1
+                 "dimensions" => ["blog"],
+                 "metrics" => [
+                   1,
+                   50.0,
+                   2,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end
@@ -2370,21 +2276,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       insert(:goal, site: site, event_name: "Signup")
-      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          metrics: ["visitors", "group_conversion_rate", "total_visitors"],
+          filters: [["is", "event:goal", ["Signup"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Twitter",
-                 "total_visitors" => 2,
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Twitter"], "metrics" => [1, 50.0, 2]}
              ]
     end
 
@@ -2412,19 +2313,17 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      filters =
-        Jason.encode!([
-          [:is, "event:goal", ["Signup"]],
-          [:is, "event:hostname", ["app.example.com"]]
-        ])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          metrics: ["visitors", "group_conversion_rate", "total_visitors"],
+          filters: [
+            ["is", "event:goal", ["Signup"]],
+            ["is", "event:hostname", ["app.example.com"]]
+          ]
         )
 
-      assert json_response(conn, 200)["results"] == []
+      assert response["results"] == []
     end
 
     test "returns top referrers for a custom goal and filtered by hostname (2)",
@@ -2449,25 +2348,18 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, site: site, event_name: "Signup")
 
-      filters =
-        Jason.encode!([
-          [:is, "event:goal", ["Signup"]],
-          [:is, "event:hostname", ["app.example.com"]]
-        ])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          metrics: ["visitors", "group_conversion_rate", "total_visitors"],
+          filters: [
+            ["is", "event:goal", ["Signup"]],
+            ["is", "event:hostname", ["app.example.com"]]
+          ]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "conversion_rate" => 100.0,
-                 "name" => "Facebook",
-                 "total_visitors" => 1,
-                 "visitors" => 1
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Facebook"], "metrics" => [1, 100.0, 1]}
              ]
     end
 
@@ -2505,25 +2397,18 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, site: site, event_name: "Download")
 
-      filters =
-        Jason.encode!([
-          [:is, "event:goal", ["Download"]],
-          [:is, "event:props:logged_in", ["true"]]
-        ])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          metrics: ["visitors", "group_conversion_rate", "total_visitors"],
+          filters: [
+            ["is", "event:goal", ["Download"]],
+            ["is", "event:props:logged_in", ["true"]]
+          ]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "DuckDuckGo",
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0,
-                 "total_visitors" => 2
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 50.0, 2]}
              ]
     end
 
@@ -2562,31 +2447,20 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, site: site, event_name: "Download")
 
-      filters =
-        Jason.encode!([
-          [:is, "event:goal", ["Download"]],
-          [:is_not, "event:props:logged_in", ["true"]]
-        ])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&date=2021-01-01&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          metrics: ["visitors", "group_conversion_rate", "total_visitors"],
+          filters: [
+            ["is", "event:goal", ["Download"]],
+            ["is_not", "event:props:logged_in", ["true"]]
+          ],
+          order_by: [["visit:source", "asc"]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "DuckDuckGo",
-                 "visitors" => 1,
-                 "conversion_rate" => 100.0,
-                 "total_visitors" => 1
-               },
-               %{
-                 "name" => "Google",
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0,
-                 "total_visitors" => 2
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["DuckDuckGo"], "metrics" => [1, 100.0, 1]},
+               %{"dimensions" => ["Google"], "metrics" => [1, 50.0, 2]}
              ]
     end
 
@@ -2609,21 +2483,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       insert(:goal, site: site, page_path: "/register")
-      filters = Jason.encode!([[:is, "event:goal", ["Visit /register"]]])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/sources?period=day&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          metrics: ["visitors", "group_conversion_rate", "total_visitors"],
+          filters: [["is", "event:goal", ["Visit /register"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "Twitter",
-                 "total_visitors" => 2,
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["Twitter"], "metrics" => [1, 50.0, 2]}
              ]
     end
   end
@@ -2744,15 +2613,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/referrers/10words?period=day"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          dimensions: ["visit:referrer"],
+          filters: [["is", "visit:source", ["10words"]]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "10words.com", "visitors" => 2, "percentage" => 66.67},
-               %{"name" => "10words.com/page1", "visitors" => 1, "percentage" => 33.33}
+      assert response["results"] == [
+               %{"dimensions" => ["10words.com"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["10words.com/page1"], "metrics" => [1, 33.33]}
              ]
     end
 
@@ -2788,16 +2658,18 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "event:hostname", ["one.example.com"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/referrers/example?period=day&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          dimensions: ["visit:referrer"],
+          filters: [
+            ["is", "visit:source", ["example"]],
+            ["is", "event:hostname", ["one.example.com"]]
+          ]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{"name" => "example.com/page1", "visitors" => 1, "percentage" => 100.0}
+      assert response["results"] == [
+               %{"dimensions" => ["example.com/page1"], "metrics" => [1, 100.0]}
              ]
     end
 
@@ -2827,20 +2699,16 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
         )
       ])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/referrers/10words?period=day&date=2021-01-01&detailed=true"
+      response =
+        query_sources(conn, site,
+          date_range: ["2021-01-01", "2021-01-01"],
+          dimensions: ["visit:referrer"],
+          filters: [["is", "visit:source", ["10words"]]],
+          metrics: ["visitors", "bounce_rate", "visit_duration", "percentage"]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "10words.com",
-                 "visitors" => 2,
-                 "bounce_rate" => 50.0,
-                 "visit_duration" => 450,
-                 "percentage" => 100.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["10words.com"], "metrics" => [2, 50.0, 450, 100.0]}
              ]
     end
 
@@ -2865,21 +2733,20 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
       ])
 
       insert(:goal, site: site, event_name: "Signup")
-      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
 
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/referrers/10words?period=day&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          dimensions: ["visit:referrer"],
+          filters: [
+            ["is", "visit:source", ["10words"]],
+            ["is", "event:goal", ["Signup"]]
+          ],
+          metrics: ["visitors", "total_visitors", "group_conversion_rate"]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "10words.com",
-                 "total_visitors" => 2,
-                 "conversion_rate" => 50.0,
-                 "visitors" => 1
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["10words.com"], "metrics" => [1, 2, 50.0]}
              ]
     end
 
@@ -2905,21 +2772,19 @@ defmodule PlausibleWeb.Api.StatsController.SourcesTest do
 
       insert(:goal, site: site, page_path: "/register")
 
-      filters = Jason.encode!([[:is, "event:goal", ["Visit /register"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/referrers/10words?period=day&filters=#{filters}"
+      response =
+        query_sources(conn, site,
+          date_range: "day",
+          dimensions: ["visit:referrer"],
+          filters: [
+            ["is", "visit:source", ["10words"]],
+            ["is", "event:goal", ["Visit /register"]]
+          ],
+          metrics: ["visitors", "total_visitors", "group_conversion_rate"]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "name" => "10words.com",
-                 "total_visitors" => 2,
-                 "conversion_rate" => 50.0,
-                 "visitors" => 1
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["10words.com"], "metrics" => [1, 2, 50.0]}
              ]
     end
   end


### PR DESCRIPTION
### Changes

* Duplicate all `Api.StatsController` tests into new legacy files (e.g. `BrowsersTest` -> `BrowsersLegacyTest`)
* Modify the existing tests to target the new /query API.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
