### PR TITLE
Exploration UI refactor

### DIFF
--- a/assets/js/dashboard/extra/exploration/exploration-column.tsx
+++ b/assets/js/dashboard/extra/exploration/exploration-column.tsx
@@ -4,7 +4,8 @@ import { useSiteContext } from '../../site-context'
 import { useDebounce } from '../../custom-hooks'
 import {
   numberShortFormatter,
-  numberLongFormatter
+  numberLongFormatter,
+  roundedNumberFormatter
 } from '../../util/number-formatter'
 import { CursorIcon, FolderIcon } from '../../components/icons'
 import { popover } from '../../components/popover'
@@ -13,7 +14,6 @@ import {
   EllipsisHorizontalIcon
 } from '@heroicons/react/20/solid'
 import { FlagIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
-import { roundedPercentage } from './helpers'
 import { journeyStepsEqual, JourneyStep, JourneySuggestion } from './journey'
 import {
   DIRECTION,
@@ -117,7 +117,10 @@ function CandidateCard({
   const barWidth =
     isSelected && selectedConversionRate !== null
       ? Math.max(1, Number(selectedConversionRate))
-      : Math.max(1, roundedPercentage(visitors, stepMaxVisitors))
+      : Math.max(
+          1,
+          Number(roundedNumberFormatter((visitors / stepMaxVisitors) * 100))
+        )
 
   const textColor = isDimmed
     ? 'text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-400'

--- a/assets/js/dashboard/extra/exploration/exploration-column.tsx
+++ b/assets/js/dashboard/extra/exploration/exploration-column.tsx
@@ -373,7 +373,7 @@ export function ExplorationColumn({
       ? [{ step: selected, visitors: selectedVisitors ?? 0 }]
       : results.slice(0, visibleCount)
 
-  const stepMaxVisitors = maxVisitors ?? results[0]?.visitors
+  const stepMaxVisitors = maxVisitors ?? results[0]?.visitors ?? 1
 
   const showSearch = active && !selected && (results.length > 0 || filter)
 

--- a/assets/js/dashboard/extra/exploration/exploration-column.tsx
+++ b/assets/js/dashboard/extra/exploration/exploration-column.tsx
@@ -101,8 +101,8 @@ function CandidateCard({
   visitors: number
   isSelected: boolean
   isDimmed: boolean
-  selectedVisitors: number
-  selectedConversionRate: number
+  selectedVisitors: number | null
+  selectedConversionRate: string | null
   stepMaxVisitors: number
   colIndex: number
   onSelect: (step: JourneyStep | null) => void
@@ -116,7 +116,7 @@ function CandidateCard({
     isSelected && selectedVisitors !== null ? selectedVisitors : visitors
   const barWidth =
     isSelected && selectedConversionRate !== null
-      ? Math.max(1, selectedConversionRate)
+      ? Math.max(1, Number(selectedConversionRate))
       : Math.max(1, roundedPercentage(visitors, stepMaxVisitors))
 
   const textColor = isDimmed
@@ -324,9 +324,9 @@ export function ExplorationColumn({
   loading: boolean
   loadingInBackground: boolean
   results: JourneySuggestion[]
-  selected: JourneyStep
-  selectedVisitors: number
-  selectedConversionRate: number
+  selected: JourneyStep | null
+  selectedVisitors: number | null
+  selectedConversionRate: string | null
   maxVisitors: number
   filter: string
   onFilterChange: (filter: string) => void

--- a/assets/js/dashboard/extra/exploration/exploration-column.tsx
+++ b/assets/js/dashboard/extra/exploration/exploration-column.tsx
@@ -14,7 +14,12 @@ import {
   EllipsisHorizontalIcon
 } from '@heroicons/react/20/solid'
 import { FlagIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
-import { journeyStepsEqual, JourneyStep, JourneySuggestion } from './journey'
+import {
+  journeyStepsEqual,
+  JourneyStep,
+  JourneySuggestion,
+  SelectedSuggestion
+} from './journey'
 import {
   DIRECTION,
   DIRECTION_OPTIONS,
@@ -89,34 +94,33 @@ function DirectionDropdown({
 function CandidateCard({
   step,
   visitors,
-  isSelected,
-  isDimmed,
-  selectedVisitors,
-  selectedConversionRate,
+  selected,
   stepMaxVisitors,
   colIndex,
   onSelect
 }: {
   step: JourneyStep
   visitors: number
-  isSelected: boolean
-  isDimmed: boolean
-  selectedVisitors: number | null
-  selectedConversionRate: string | null
+  selected: SelectedSuggestion | null
   stepMaxVisitors: number
   colIndex: number
   onSelect: (step: JourneyStep | null) => void
 }): ReactNode {
   const { explorationJourneyEndEvent: journeyEndEvent } = useSiteContext()
+
+  const isSelected = !!selected && journeyStepsEqual(step, selected.step)
+  const isDimmed = !!selected && !journeyStepsEqual(step, selected.step)
+
   const isCustomEvent =
     step.name !== 'pageview' && step.name !== journeyEndEvent
   const isGoal = step.is_goal
 
   const visitorsToShow =
-    isSelected && selectedVisitors !== null ? selectedVisitors : visitors
+    isSelected && selected.visitors !== null ? selected.visitors : visitors
+
   const barWidth =
-    isSelected && selectedConversionRate !== null
-      ? Math.max(1, Number(selectedConversionRate))
+    isSelected && selected.conversion_rate !== null
+      ? Math.max(1, Number(selected.conversion_rate))
       : Math.max(
           1,
           Number(roundedNumberFormatter((visitors / stepMaxVisitors) * 100))
@@ -309,8 +313,6 @@ export function ExplorationColumn({
   loadingInBackground,
   results,
   selected,
-  selectedVisitors,
-  selectedConversionRate,
   maxVisitors,
   filter,
   onFilterChange,
@@ -327,9 +329,7 @@ export function ExplorationColumn({
   loading: boolean
   loadingInBackground: boolean
   results: JourneySuggestion[]
-  selected: JourneyStep | null
-  selectedVisitors: number | null
-  selectedConversionRate: string | null
+  selected: SelectedSuggestion | null
   maxVisitors: number
   filter: string
   onFilterChange: (filter: string) => void
@@ -355,7 +355,7 @@ export function ExplorationColumn({
   // remain visible after selection.
   const selectedIndex =
     selected && results.length > 0
-      ? results.findIndex(({ step }) => journeyStepsEqual(step, selected))
+      ? results.findIndex(({ step }) => journeyStepsEqual(step, selected.step))
       : -1
   const baseVisibleCount = Math.max(
     INITIAL_VISIBLE_CANDIDATES,
@@ -373,7 +373,7 @@ export function ExplorationColumn({
   // the selected step is still rendered in the column.
   const listItems =
     selected && results.length === 0
-      ? [{ step: selected, visitors: selectedVisitors ?? 0 }]
+      ? [{ step: selected.step, visitors: selected.visitors ?? 0 }]
       : results.slice(0, visibleCount)
 
   const stepMaxVisitors = maxVisitors ?? results[0]?.visitors ?? 1
@@ -445,10 +445,7 @@ export function ExplorationColumn({
               key={`${step.name}:${step.label}:${step.includes_subpaths ? step.subpaths_count : 0}`}
               step={step}
               visitors={visitors}
-              isSelected={!!selected && journeyStepsEqual(step, selected)}
-              isDimmed={!!selected && !journeyStepsEqual(step, selected)}
-              selectedVisitors={selectedVisitors}
-              selectedConversionRate={selectedConversionRate}
+              selected={selected}
               stepMaxVisitors={stepMaxVisitors}
               colIndex={colIndex}
               onSelect={onSelectHandler}

--- a/assets/js/dashboard/extra/exploration/helpers.ts
+++ b/assets/js/dashboard/extra/exploration/helpers.ts
@@ -1,6 +1,0 @@
-export function roundedPercentage(value: number, total: number): number {
-  const percentage: number = (value / total) * 100
-  // Rounding to 2 decimal places using Math.round()
-  // (https://stackoverflow.com/a/11832950)
-  return Math.round((percentage + Number.EPSILON) * 100) / 100
-}

--- a/assets/js/dashboard/extra/exploration/index.tsx
+++ b/assets/js/dashboard/extra/exploration/index.tsx
@@ -13,6 +13,7 @@ import { PathConnectors } from './path-connectors'
 import { ExplorationColumn, MaxDepthColumn } from './exploration-column'
 import { useExplorationData } from './exploration-state'
 import { DIRECTION, MIN_GRID_COLUMNS, ExplorationDirection } from './constants'
+import { getSelectedSuggestion } from './journey'
 
 // Column header label based on index and direction.
 function columnHeader(index: number, direction: ExplorationDirection): string {
@@ -182,12 +183,12 @@ export function FunnelExploration() {
               const colLoading =
                 colLoadingInBackground && (!frozen[i] || !!colFilter)
 
-              const colSelectedVisitors =
-                provisional[i]?.visitors ?? funnel[i]?.visitors ?? null
-              const colSelectedConversionRate =
-                provisional[i]?.conversion_rate ??
-                funnel[i]?.conversion_rate ??
-                null
+              const selected = getSelectedSuggestion({
+                i,
+                steps,
+                provisional,
+                funnel
+              })
 
               const colHeaderConversionRate =
                 funnel[i]?.conversion_rate != null
@@ -218,9 +219,7 @@ export function FunnelExploration() {
                   loadingInBackground={colLoadingInBackground}
                   loading={colLoading}
                   results={colResults}
-                  selected={steps[i] ?? null}
-                  selectedVisitors={colSelectedVisitors}
-                  selectedConversionRate={colSelectedConversionRate}
+                  selected={selected}
                   maxVisitors={funnel[0]?.visitors ?? null}
                   filter={colFilter}
                   onFilterChange={isActive ? setActiveFilter : () => {}}

--- a/assets/js/dashboard/extra/exploration/index.tsx
+++ b/assets/js/dashboard/extra/exploration/index.tsx
@@ -127,7 +127,7 @@ export function FunnelExploration() {
             <div className="order-last sm:order-none w-full sm:w-auto flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
               <span>
                 <span className="font-medium sm:font-semibold text-gray-700 dark:text-gray-200">
-                  CR: {percentageFormatter(parseFloat(overallConversionRate!))}{' '}
+                  CR: {percentageFormatter(Number(overallConversionRate!))}{' '}
                 </span>
                 <span className="text-gray-500 dark:text-gray-400">
                   ({numberShortFormatter(overallConversionVisitors!)})
@@ -194,7 +194,7 @@ export function FunnelExploration() {
                 funnel[i]?.conversion_rate != null
                   ? i === 0
                     ? '100%'
-                    : `${parseFloat(funnel[i].conversion_rate).toFixed(1)}%`
+                    : `${Number(funnel[i].conversion_rate).toFixed(1)}%`
                   : null
 
               if (isActive && steps.length >= maxJourneySteps) {

--- a/assets/js/dashboard/extra/exploration/journey.ts
+++ b/assets/js/dashboard/extra/exploration/journey.ts
@@ -1,4 +1,4 @@
-import { roundedPercentage } from './helpers'
+import { roundedNumberFormatter } from '../../util/number-formatter'
 
 export type JourneyStep = {
   label: string
@@ -74,7 +74,10 @@ function provisionalEntry(
   if (!match) return {}
 
   const firstStepVisitors = existingFunnel[0]?.visitors ?? match.visitors
-  const conversionRate = roundedPercentage(match.visitors, firstStepVisitors).toString()
+  const conversionRate = roundedNumberFormatter(
+    (match.visitors / firstStepVisitors) * 100
+  )
+
   return {
     [columnIndex]: { visitors: match.visitors, conversion_rate: conversionRate }
   }

--- a/assets/js/dashboard/extra/exploration/journey.ts
+++ b/assets/js/dashboard/extra/exploration/journey.ts
@@ -14,6 +14,12 @@ export type JourneySuggestion = {
   visitors: number
 }
 
+export type SelectedSuggestion = {
+  step: JourneyStep
+  visitors: number | null
+  conversion_rate: string | null
+}
+
 export type FunnelStep = {
   step: JourneyStep
   visitors: number
@@ -29,7 +35,9 @@ type ProvisionalFunnelStep = {
 }
 
 type FrozenSuggestions = { [columnIndex: string]: JourneySuggestion[] }
-type ProvisionalFunnelSteps = { [columnIndex: string]: ProvisionalFunnelStep }
+type ProvisionalFunnelSteps = {
+  [columnIndex: string]: ProvisionalFunnelStep
+}
 
 export type Journey = {
   steps: JourneyStep[]
@@ -145,6 +153,36 @@ function maybeEmptyResults(
     return []
   } else {
     return results
+  }
+}
+
+// Build selected suggestion at index on the basis of current steps,
+// provisional entries and a funnel.
+export function getSelectedSuggestion({
+  i,
+  steps,
+  provisional,
+  funnel
+}: {
+  i: number
+  steps: JourneyStep[]
+  provisional: ProvisionalFunnelSteps
+  funnel: FunnelStep[]
+}): SelectedSuggestion | null {
+  const step = steps[i] ?? null
+
+  if (step !== null) {
+    const visitors = provisional[i]?.visitors ?? funnel[i]?.visitors ?? null
+    const conversionRate =
+      provisional[i]?.conversion_rate ?? funnel[i]?.conversion_rate ?? null
+
+    return {
+      step: step,
+      visitors: visitors,
+      conversion_rate: conversionRate
+    }
+  } else {
+    return null
   }
 }
 

--- a/assets/js/dashboard/extra/exploration/journey.ts
+++ b/assets/js/dashboard/extra/exploration/journey.ts
@@ -25,7 +25,7 @@ export type FunnelStep = {
 
 type ProvisionalFunnelStep = {
   visitors: number
-  conversion_rate: number
+  conversion_rate: string
 }
 
 type FrozenSuggestions = { [columnIndex: string]: JourneySuggestion[] }
@@ -74,7 +74,7 @@ function provisionalEntry(
   if (!match) return {}
 
   const firstStepVisitors = existingFunnel[0]?.visitors ?? match.visitors
-  const conversionRate = roundedPercentage(match.visitors, firstStepVisitors)
+  const conversionRate = roundedPercentage(match.visitors, firstStepVisitors).toString()
   return {
     [columnIndex]: { visitors: match.visitors, conversion_rate: conversionRate }
   }

--- a/assets/js/dashboard/util/number-formatter.ts
+++ b/assets/js/dashboard/util/number-formatter.ts
@@ -67,13 +67,17 @@ export function durationFormatter(duration: number): string {
   }
 }
 
+export function roundedNumberFormatter(number: number): string {
+  if (Math.abs(number) > 0 && Math.abs(number) < 0.1) {
+    return number.toFixed(2)
+  } else {
+    return number.toFixed(1).replace(/\.0$/, '')
+  }
+}
+
 export function percentageFormatter(number: number | null): string {
   if (typeof number === 'number') {
-    if (Math.abs(number) > 0 && Math.abs(number) < 0.1) {
-      return number.toFixed(2) + '%'
-    } else {
-      return number.toFixed(1).replace(/\.0$/, '') + '%'
-    }
+    return roundedNumberFormatter(number) + '%'
   } else {
     return '-'
   }


### PR DESCRIPTION
### Changes

This PR attempts to do some gradual refactoring improvements to exploration UI logic.

So far, following changes were made:

- conversion rate type in funnel and provisional funnel types is now always a string, for consistency as that's how we get it from the backend to avoid float related inaccuracies
- the rounded percentage helper got removed with a more general round number formatter
- the selected suggestion is now passed as a single object instead of a collection of fields/arguments
- ensure `stepMaxVisitors` is always a numeric value to avoid potential division by zero (TS did not catch that, strangely)
- always user `Number` for casting strings to numeric values (instead of `parseFloat`)

There's definitely potential for more but that's at least some small start.

@apata if you have any free cycles, I'd really appreciate your eyes on this. I'd be keen on going over the exploration UI code together if you'd like to, to provide any missing context or unclear intent.
