### PR TITLE
Make subscription_created webhook idempotent to a degree

### DIFF
--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -58,10 +58,22 @@ defmodule Plausible.Billing do
       |> format_subscription()
       |> add_last_bill_date(params)
 
-    team
-    |> Subscription.create_changeset(subscription_params)
-    |> Repo.insert!()
-    |> after_subscription_update()
+    changeset = Subscription.create_changeset(team, subscription_params)
+
+    case Repo.insert(changeset,
+           on_conflict: :nothing,
+           conflict_target: :paddle_subscription_id
+         ) do
+      {:ok, %{id: nil}} ->
+        handle_conflict(
+          "subscription_created",
+          subscription_params.paddle_subscription_id,
+          changeset
+        )
+
+      {:ok, subscription} ->
+        after_subscription_update(subscription)
+    end
   end
 
   defp handle_subscription_updated(params) do
@@ -259,6 +271,37 @@ defmodule Plausible.Billing do
     end
 
     team
+  end
+
+  defp handle_conflict(webhook_type, paddle_subscription_id, changeset) do
+    existing =
+      Repo.get_by!(Subscription,
+        paddle_subscription_id: paddle_subscription_id
+      )
+
+    diff = changeset_diff(changeset, existing)
+
+    if diff != %{} do
+      Sentry.capture_message(
+        "Duplicate #{webhook_type} webhook for paddle_subscription_id=#{existing.paddle_subscription_id}.",
+        extra: %{
+          paddle_subscription_id: existing.paddle_subscription_id,
+          team_id: existing.team_id,
+          diff: diff
+        }
+      )
+    end
+
+    existing
+  end
+
+  defp changeset_diff(%Ecto.Changeset{changes: changes}, existing) do
+    for {key, incoming_val} <- changes,
+        not is_struct(incoming_val, Ecto.Changeset),
+        existing_val = Map.get(existing, key),
+        existing_val != incoming_val,
+        into: %{},
+        do: {key, %{existing: existing_val, incoming: incoming_val}}
   end
 
   def dashboard_locked_notice_title(), do: "Dashboard locked"

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -227,6 +227,69 @@ defmodule Plausible.BillingTest do
       assert subscription.currency_code == "EUR"
     end
 
+    test "identical notification sent twice is ignored at 2nd try" do
+      user = new_user()
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+
+      Plausible.Test.Support.Sentry.setup(self())
+
+      Billing.subscription_created(%{
+        @subscription_created_params
+        | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"
+      })
+
+      Billing.subscription_created(%{
+        @subscription_created_params
+        | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"
+      })
+
+      subscription =
+        user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
+
+      assert subscription.paddle_subscription_id == @subscription_id
+      assert subscription.next_bill_date == ~D[2019-06-01]
+      assert subscription.last_bill_date == ~D[2019-05-01]
+      assert subscription.next_bill_amount == "6.00"
+      assert subscription.currency_code == "EUR"
+
+      assert [] = Sentry.Test.pop_sentry_reports()
+    end
+
+    test "secondary notification sent logs diff" do
+      user = new_user()
+      {:ok, team} = Plausible.Teams.get_or_create(user)
+
+      Plausible.Test.Support.Sentry.setup(self())
+
+      Billing.subscription_created(%{
+        @subscription_created_params
+        | "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"
+      })
+
+      Billing.subscription_created(%{
+        @subscription_created_params
+        | "subscription_plan_id" => "9999",
+          "currency" => "USD",
+          "passthrough" => "ee:true;user:#{user.id};team:#{team.id}"
+      })
+
+      assert [report] = Sentry.Test.pop_sentry_reports()
+
+      assert report.message.formatted =~
+               "Duplicate subscription_created webhook for paddle_subscription_id=subscription-123"
+
+      assert report.extra.paddle_subscription_id == @subscription_id
+      assert report.extra.team_id == team.id
+      assert report.extra.diff.paddle_plan_id == %{existing: "654177", incoming: "9999"}
+      assert report.extra.diff.currency_code == %{existing: "EUR", incoming: "USD"}
+
+      subscription =
+        user |> team_of() |> Plausible.Teams.with_subscription() |> Map.fetch!(:subscription)
+
+      assert subscription.paddle_subscription_id == @subscription_id
+      assert subscription.currency_code == "EUR"
+    end
+
     test "supports user without a team case" do
       user = new_user()
 


### PR DESCRIPTION
Using `on_conflict: :nothing` preventing infinite paddle retries on either race condition on quirky paddle message. This is rare, so Leaving Sentry trace should suffice for now, as we can inspect each case individually if need be.

More context: https://3.basecamp.com/5308029/buckets/36789884/card_tables/cards/9936470843