### PR TITLE
Ensures locations can be requested over POST /query endpoint with full parity

### DIFF
--- a/test/plausible_web/controllers/api/stats_controller/cities_legacy_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/cities_legacy_test.exs
@@ -1,0 +1,222 @@
+defmodule PlausibleWeb.Api.StatsController.CitiesLegacyTest do
+  @moduledoc """
+  [DEPRECATED] Still used for CSV export but to be removed.
+  """
+  use PlausibleWeb.ConnCase
+
+  describe "GET /api/stats/:domain/cities" do
+    defp seed(%{site: site}) do
+      populate_stats(site, [
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
+        ),
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
+        )
+      ])
+    end
+
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import, :seed]
+
+    test "returns top cities by new visitors", %{conn: conn, site: site} do
+      conn = get(conn, "/api/stats/#{site.domain}/cities?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => 588_409,
+                 "country_flag" => "🇪🇪",
+                 "name" => "Tallinn",
+                 "visitors" => 3,
+                 "percentage" => 60.0
+               },
+               %{
+                 "code" => 591_632,
+                 "country_flag" => "🇪🇪",
+                 "name" => "Kärdla",
+                 "visitors" => 2,
+                 "percentage" => 40.0
+               }
+             ]
+    end
+
+    test "when list is filtered returns one city only", %{conn: conn, site: site} do
+      filters = Jason.encode!([[:is, "visit:city", ["591632"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/cities?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => 591_632,
+                 "country_flag" => "🇪🇪",
+                 "name" => "Kärdla",
+                 "visitors" => 2,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    test "does not return missing cities from imported data", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:imported_locations, country: "EE", region: "EE-37", city: 588_409),
+        build(:imported_locations, country: nil, region: nil, city: 0),
+        build(:imported_locations, country: nil, region: nil, city: nil)
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/cities?period=day&with_imported=true")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => 588_409,
+                 "country_flag" => "🇪🇪",
+                 "name" => "Tallinn",
+                 "visitors" => 4,
+                 "percentage" => 66.67
+               },
+               %{
+                 "code" => 591_632,
+                 "country_flag" => "🇪🇪",
+                 "name" => "Kärdla",
+                 "visitors" => 2,
+                 "percentage" => 33.33
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for cities breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:pageview,
+          user_id: 4,
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/cities#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 33.33,
+                 "name" => "Tallinn",
+                 "code" => 588_409,
+                 "country_flag" => "🇪🇪",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 6,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 25.0,
+                 "name" => "Kärdla",
+                 "code" => 591_632,
+                 "country_flag" => "🇪🇪",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 4,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/cities_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/cities_test.exs
@@ -1,7 +1,28 @@
 defmodule PlausibleWeb.Api.StatsController.CitiesTest do
   use PlausibleWeb.ConnCase
 
-  describe "GET /api/stats/:domain/cities" do
+  defp query_cities(conn, site, opts) do
+    always_on_filters = ["is_not", "visit:city", [0]]
+
+    params = %{
+      "dimensions" => Keyword.get(opts, :dimensions, ["visit:city", "visit:city_name"]),
+      "date_range" => Keyword.get(opts, :date_range, "all"),
+      "filters" => [
+        always_on_filters
+        | Keyword.get(opts, :filters, [])
+      ],
+      "metrics" => Keyword.get(opts, :metrics, ["visitors", "percentage"]),
+      "include" => Keyword.get(opts, :include, nil),
+      "pagination" => Keyword.get(opts, :pagination, nil),
+      "order_by" => Keyword.get(opts, :order_by, nil)
+    }
+
+    conn
+    |> post("/api/stats/#{site.domain}/query", params)
+    |> json_response(200)
+  end
+
+  describe "querying for cities with POST /query" do
     defp seed(%{site: site}) do
       populate_stats(site, [
         build(:pageview,
@@ -34,39 +55,24 @@ defmodule PlausibleWeb.Api.StatsController.CitiesTest do
 
     setup [:create_user, :log_in, :create_site, :create_legacy_site_import, :seed]
 
-    test "returns top cities by new visitors", %{conn: conn, site: site} do
-      conn = get(conn, "/api/stats/#{site.domain}/cities?period=day")
+    test "returns top cities by visitors", %{conn: conn, site: site} do
+      response = query_cities(conn, site, date_range: "day")
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => 588_409,
-                 "country_flag" => "🇪🇪",
-                 "name" => "Tallinn",
-                 "visitors" => 3,
-                 "percentage" => 60.0
-               },
-               %{
-                 "code" => 591_632,
-                 "country_flag" => "🇪🇪",
-                 "name" => "Kärdla",
-                 "visitors" => 2,
-                 "percentage" => 40.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => [588_409, "Tallinn"], "metrics" => [3, 60.0]},
+               %{"dimensions" => [591_632, "Kärdla"], "metrics" => [2, 40.0]}
              ]
     end
 
     test "when list is filtered returns one city only", %{conn: conn, site: site} do
-      filters = Jason.encode!([[:is, "visit:city", ["591632"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/cities?period=day&filters=#{filters}")
+      response =
+        query_cities(conn, site,
+          date_range: "day",
+          filters: [["is", "visit:city", [591_632]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => 591_632,
-                 "country_flag" => "🇪🇪",
-                 "name" => "Kärdla",
-                 "visitors" => 2,
-                 "percentage" => 100.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => [591_632, "Kärdla"], "metrics" => [2, 100.0]}
              ]
     end
 
@@ -77,23 +83,15 @@ defmodule PlausibleWeb.Api.StatsController.CitiesTest do
         build(:imported_locations, country: nil, region: nil, city: nil)
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/cities?period=day&with_imported=true")
+      response =
+        query_cities(conn, site,
+          date_range: "day",
+          include: %{"imports" => true}
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => 588_409,
-                 "country_flag" => "🇪🇪",
-                 "name" => "Tallinn",
-                 "visitors" => 4,
-                 "percentage" => 66.67
-               },
-               %{
-                 "code" => 591_632,
-                 "country_flag" => "🇪🇪",
-                 "name" => "Kärdla",
-                 "visitors" => 2,
-                 "percentage" => 33.33
-               }
+      assert response["results"] == [
+               %{"dimensions" => [588_409, "Tallinn"], "metrics" => [4, 66.67]},
+               %{"dimensions" => [591_632, "Kärdla"], "metrics" => [2, 33.33]}
              ]
     end
 
@@ -165,53 +163,60 @@ defmodule PlausibleWeb.Api.StatsController.CitiesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_cities(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Payment"]]],
+          metrics: [
+            "visitors",
+            "total_visitors",
+            "group_conversion_rate",
+            "average_revenue",
+            "total_revenue"
+          ],
+          order_by: [["visitors", "desc"], ["visit:city", "asc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/cities#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 33.33,
-                 "name" => "Tallinn",
-                 "code" => 588_409,
-                 "country_flag" => "🇪🇪",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 6,
-                 "visitors" => 2
+                 "dimensions" => [588_409, "Tallinn"],
+                 "metrics" => [
+                   2,
+                   6,
+                   33.33,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 25.0,
-                 "name" => "Kärdla",
-                 "code" => 591_632,
-                 "country_flag" => "🇪🇪",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 4,
-                 "visitors" => 1
+                 "dimensions" => [591_632, "Kärdla"],
+                 "metrics" => [
+                   1,
+                   4,
+                   25.0,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end

--- a/test/plausible_web/controllers/api/stats_controller/countries_legacy_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_legacy_test.exs
@@ -1,0 +1,559 @@
+defmodule PlausibleWeb.Api.StatsController.CountriesLegacyTest do
+  @moduledoc """
+  [DEPRECATED] Still used for CSV export but to be removed.
+  """
+  use PlausibleWeb.ConnCase
+
+  describe "GET /api/stats/:domain/countries" do
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
+
+    test "returns top countries by new visitors", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "GB"),
+        build(:imported_locations, country: "EE"),
+        build(:imported_locations, country: "GB"),
+        build(:imported_visitors, visitors: 2)
+      ])
+
+      conn1 = get(conn, "/api/stats/#{site.domain}/countries?period=day")
+
+      assert json_response(conn1, 200)["results"] == [
+               %{
+                 "code" => "EE",
+                 "alpha_3" => "EST",
+                 "name" => "Estonia",
+                 "flag" => "🇪🇪",
+                 "visitors" => 2,
+                 "percentage" => 66.67
+               },
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "visitors" => 1,
+                 "percentage" => 33.33
+               }
+             ]
+
+      conn2 = get(conn, "/api/stats/#{site.domain}/countries?period=day&with_imported=true")
+
+      assert json_response(conn2, 200)["results"] == [
+               %{
+                 "code" => "EE",
+                 "alpha_3" => "EST",
+                 "name" => "Estonia",
+                 "flag" => "🇪🇪",
+                 "visitors" => 3,
+                 "percentage" => 60
+               },
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "visitors" => 2,
+                 "percentage" => 40
+               }
+             ]
+    end
+
+    test "ignores unknown country code ZZ", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, country_code: "ZZ"),
+        build(:imported_locations, country: "ZZ")
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&with_imported=true")
+
+      assert json_response(conn, 200)["results"] == []
+    end
+
+    test "includes anonymous VPN country code A1", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, country_code: "A1"),
+        build(:pageview, country_code: "A1"),
+        build(:pageview, country_code: "EE")
+      ])
+
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "A1",
+                 "alpha_3" => nil,
+                 "name" => "Anonymous VPN Service",
+                 "flag" => "🏳️",
+                 "visitors" => 2,
+                 "percentage" => 66.67
+               },
+               %{
+                 "code" => "EE",
+                 "alpha_3" => "EST",
+                 "name" => "Estonia",
+                 "flag" => "🇪🇪",
+                 "visitors" => 1,
+                 "percentage" => 33.33
+               }
+             ]
+    end
+
+    test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          country_code: "EE"
+        ),
+        build(:event, user_id: 1, name: "Signup"),
+        build(:pageview,
+          user_id: 2,
+          country_code: "EE"
+        ),
+        build(:pageview,
+          user_id: 3,
+          country_code: "GB"
+        ),
+        build(:event, user_id: 3, name: "Signup")
+      ])
+
+      insert(:goal, site: site, event_name: "Signup")
+
+      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "EE",
+                 "alpha_3" => "EST",
+                 "name" => "Estonia",
+                 "flag" => "🇪🇪",
+                 "total_visitors" => 2,
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0
+               },
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "total_visitors" => 1,
+                 "visitors" => 1,
+                 "conversion_rate" => 100.0
+               }
+             ]
+    end
+
+    test "handles conversion_rate sort directive", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          country_code: "EE"
+        ),
+        build(:event, user_id: 1, name: "Signup"),
+        build(:pageview,
+          user_id: 2,
+          country_code: "EE"
+        ),
+        build(:pageview,
+          user_id: 3,
+          country_code: "GB"
+        ),
+        build(:event, user_id: 3, name: "Signup")
+      ])
+
+      insert(:goal, site: site, event_name: "Signup")
+
+      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}&order_by=#{Jason.encode!([["conversion_rate", "desc"]])}"
+        )
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "total_visitors" => 1,
+                 "visitors" => 1,
+                 "conversion_rate" => 100.0
+               },
+               %{
+                 "code" => "EE",
+                 "alpha_3" => "EST",
+                 "name" => "Estonia",
+                 "flag" => "🇪🇪",
+                 "total_visitors" => 2,
+                 "visitors" => 1,
+                 "conversion_rate" => 50.0
+               }
+             ]
+    end
+
+    test "returns top countries with :is filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          country_code: "EE"
+        ),
+        build(:pageview,
+          user_id: 123,
+          country_code: "EE",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          country_code: "GB",
+          "meta.key": ["author"],
+          "meta.value": ["other"]
+        ),
+        build(:pageview,
+          country_code: "US"
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:props:author", ["John Doe"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "EE",
+                 "alpha_3" => "EST",
+                 "name" => "Estonia",
+                 "flag" => "🇪🇪",
+                 "visitors" => 1,
+                 "percentage" => 100
+               }
+             ]
+    end
+
+    test "returns top countries with :is_not filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 123,
+          country_code: "EE",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          user_id: 123,
+          country_code: "EE",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          country_code: "GB",
+          "meta.key": ["author"],
+          "meta.value": ["other"]
+        ),
+        build(:pageview,
+          country_code: "GB"
+        )
+      ])
+
+      filters = Jason.encode!([[:is_not, "event:props:author", ["John Doe"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "visitors" => 2,
+                 "percentage" => 100
+               }
+             ]
+    end
+
+    test "returns top countries with :is (none) filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          country_code: "EE",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          country_code: "GB",
+          "meta.key": ["logged_in"],
+          "meta.value": ["true"]
+        ),
+        build(:pageview,
+          country_code: "GB"
+        )
+      ])
+
+      filters = Jason.encode!([[:is, "event:props:author", ["(none)"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "visitors" => 2,
+                 "percentage" => 100
+               }
+             ]
+    end
+
+    test "returns top countries with :is_not (none) filter on custom pageview props", %{
+      conn: conn,
+      site: site
+    } do
+      populate_stats(site, [
+        build(:pageview,
+          country_code: "EE",
+          "meta.key": ["author"],
+          "meta.value": ["John Doe"]
+        ),
+        build(:pageview,
+          country_code: "EE",
+          "meta.key": ["author"],
+          "meta.value": [""]
+        ),
+        build(:pageview,
+          country_code: "GB",
+          "meta.key": ["logged_in"],
+          "meta.value": ["true"]
+        ),
+        build(:pageview,
+          country_code: "GB"
+        )
+      ])
+
+      filters = Jason.encode!([[:is_not, "event:props:author", ["(none)"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "EE",
+                 "alpha_3" => "EST",
+                 "name" => "Estonia",
+                 "flag" => "🇪🇪",
+                 "visitors" => 2,
+                 "percentage" => 100
+               }
+             ]
+    end
+
+    test "when list is filtered by country returns one country only", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "GB")
+      ])
+
+      filters = Jason.encode!([[:is, "visit:country", ["GB"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "visitors" => 1,
+                 "percentage" => 100
+               }
+             ]
+    end
+
+    test "handles multiple segment filters", %{conn: conn, site: site, user: user} do
+      %{id: segment_alfa} =
+        insert(:segment,
+          site_id: site.id,
+          owner_id: user.id,
+          name: "Ireland and Britain (excl London)",
+          type: :site,
+          segment_data: %{
+            "filters" => [
+              ["is", "visit:country", ["IE", "GB"]],
+              ["is_not", "visit:city", [2_643_743]]
+            ]
+          }
+        )
+
+      %{id: segment_beta} =
+        insert(:segment,
+          site_id: site.id,
+          owner_id: user.id,
+          name: "Entered on root or blog",
+          type: :personal,
+          segment_data: %{
+            "filters" => [
+              ["is", "visit:entry_page", ["/", "/blog"]]
+            ]
+          }
+        )
+
+      populate_stats(site, [
+        build(:pageview, country_code: "EE"),
+        build(:pageview,
+          country_code: "GB",
+          # London
+          city_geoname_id: 2_643_743
+        ),
+        build(:pageview,
+          country_code: "GB",
+          # London
+          city_geoname_id: 2_643_743
+        ),
+        build(:pageview, country_code: "GB"),
+        build(:pageview, country_code: "IE", pathname: "/other"),
+        build(:pageview, country_code: "IE")
+      ])
+
+      filters =
+        Jason.encode!([["is", "segment", [segment_alfa]], ["is", "segment", [segment_beta]]])
+
+      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "GB",
+                 "alpha_3" => "GBR",
+                 "name" => "United Kingdom",
+                 "flag" => "🇬🇧",
+                 "visitors" => 1,
+                 "percentage" => 50
+               },
+               %{
+                 "code" => "IE",
+                 "alpha_3" => "IRL",
+                 "name" => "Ireland",
+                 "flag" => "🇮🇪",
+                 "visitors" => 1,
+                 "percentage" => 50
+               }
+             ]
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for countries breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          country_code: "EE"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          country_code: "EE"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          country_code: "EE"
+        ),
+        build(:pageview,
+          user_id: 4,
+          country_code: "GB"
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          country_code: "GB"
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/countries#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 66.67,
+                 "name" => "Estonia",
+                 "alpha_3" => "EST",
+                 "code" => "EE",
+                 "flag" => "🇪🇪",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 3,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 50.0,
+                 "name" => "United Kingdom",
+                 "alpha_3" => "GBR",
+                 "code" => "GB",
+                 "flag" => "🇬🇧",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 2,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -82,7 +82,10 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
              ]
     end
 
-    test "filtering by A1 returns only anonymous VPN visitors", %{conn: conn, site: site} do
+    test "searching for 'Anonymous' returns VPN visitors", %{
+      conn: conn,
+      site: site
+    } do
       populate_stats(site, [
         build(:pageview, country_code: "A1"),
         build(:pageview, country_code: "A1"),
@@ -93,7 +96,7 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
       response =
         query_countries(conn, site,
           date_range: "day",
-          filters: [["is", "visit:country", ["A1"]]]
+          filters: [["contains", "visit:country_name", ["Anonymous"]]]
         )
 
       assert response["results"] == [

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -379,12 +379,13 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
           filters: [
             ["is", "segment", [segment_alfa]],
             ["is", "segment", [segment_beta]]
-          ]
+          ],
+          order_by: [["visitors", "desc"], ["visit:country", "asc"]]
         )
 
       assert response["results"] == [
-               %{"dimensions" => ["IE", "Ireland"], "metrics" => [1, 50.0]},
-               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [1, 50.0]}
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [1, 50.0]},
+               %{"dimensions" => ["IE", "Ireland"], "metrics" => [1, 50.0]}
              ]
     end
 

--- a/test/plausible_web/controllers/api/stats_controller/countries_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/countries_test.exs
@@ -1,7 +1,28 @@
 defmodule PlausibleWeb.Api.StatsController.CountriesTest do
   use PlausibleWeb.ConnCase
 
-  describe "GET /api/stats/:domain/countries" do
+  defp query_countries(conn, site, opts) do
+    always_on_filters = ["is_not", "visit:country", [<<0, 0>>, "ZZ"]]
+
+    params = %{
+      "dimensions" => Keyword.get(opts, :dimensions, ["visit:country", "visit:country_name"]),
+      "date_range" => Keyword.get(opts, :date_range, "all"),
+      "filters" => [
+        always_on_filters
+        | Keyword.get(opts, :filters, [])
+      ],
+      "metrics" => Keyword.get(opts, :metrics, ["visitors", "percentage"]),
+      "include" => Keyword.get(opts, :include, nil),
+      "pagination" => Keyword.get(opts, :pagination, nil),
+      "order_by" => Keyword.get(opts, :order_by, nil)
+    }
+
+    conn
+    |> post("/api/stats/#{site.domain}/query", params)
+    |> json_response(200)
+  end
+
+  describe "querying for countries with POST /query" do
     setup [:create_user, :log_in, :create_site, :create_legacy_site_import]
 
     test "returns top countries by new visitors", %{conn: conn, site: site} do
@@ -14,46 +35,19 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
         build(:imported_visitors, visitors: 2)
       ])
 
-      conn1 = get(conn, "/api/stats/#{site.domain}/countries?period=day")
+      response1 = query_countries(conn, site, date_range: "day")
 
-      assert json_response(conn1, 200)["results"] == [
-               %{
-                 "code" => "EE",
-                 "alpha_3" => "EST",
-                 "name" => "Estonia",
-                 "flag" => "🇪🇪",
-                 "visitors" => 2,
-                 "percentage" => 66.67
-               },
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "visitors" => 1,
-                 "percentage" => 33.33
-               }
+      assert response1["results"] == [
+               %{"dimensions" => ["EE", "Estonia"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [1, 33.33]}
              ]
 
-      conn2 = get(conn, "/api/stats/#{site.domain}/countries?period=day&with_imported=true")
+      response2 =
+        query_countries(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn2, 200)["results"] == [
-               %{
-                 "code" => "EE",
-                 "alpha_3" => "EST",
-                 "name" => "Estonia",
-                 "flag" => "🇪🇪",
-                 "visitors" => 3,
-                 "percentage" => 60
-               },
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "visitors" => 2,
-                 "percentage" => 40
-               }
+      assert response2["results"] == [
+               %{"dimensions" => ["EE", "Estonia"], "metrics" => [3, 60.0]},
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [2, 40.0]}
              ]
     end
 
@@ -63,9 +57,48 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
         build(:imported_locations, country: "ZZ")
       ])
 
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&with_imported=true")
+      response =
+        query_countries(conn, site, date_range: "day", include: %{"imports" => true})
 
-      assert json_response(conn, 200)["results"] == []
+      assert response["results"] == []
+    end
+
+    test "includes anonymous VPN country code A1", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, country_code: "A1"),
+        build(:pageview, country_code: "A1"),
+        build(:pageview, country_code: "EE")
+      ])
+
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          order_by: [["visitors", "desc"]]
+        )
+
+      assert response["results"] == [
+               %{"dimensions" => ["A1", "Anonymous VPN Service"], "metrics" => [2, 66.67]},
+               %{"dimensions" => ["EE", "Estonia"], "metrics" => [1, 33.33]}
+             ]
+    end
+
+    test "filtering by A1 returns only anonymous VPN visitors", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview, country_code: "A1"),
+        build(:pageview, country_code: "A1"),
+        build(:pageview, country_code: "EE"),
+        build(:pageview, country_code: "GB")
+      ])
+
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is", "visit:country", ["A1"]]]
+        )
+
+      assert response["results"] == [
+               %{"dimensions" => ["A1", "Anonymous VPN Service"], "metrics" => [2, 100.0]}
+             ]
     end
 
     test "calculates conversion_rate when filtering for goal", %{conn: conn, site: site} do
@@ -88,29 +121,17 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
       insert(:goal, site: site, event_name: "Signup")
 
-      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Signup"]]],
+          metrics: ["visitors", "total_visitors", "group_conversion_rate"],
+          order_by: [["visit:country", "asc"]]
+        )
 
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "EE",
-                 "alpha_3" => "EST",
-                 "name" => "Estonia",
-                 "flag" => "🇪🇪",
-                 "total_visitors" => 2,
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0
-               },
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "total_visitors" => 1,
-                 "visitors" => 1,
-                 "conversion_rate" => 100.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["EE", "Estonia"], "metrics" => [1, 2, 50.0]},
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [1, 1, 100.0]}
              ]
     end
 
@@ -134,33 +155,17 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
       insert(:goal, site: site, event_name: "Signup")
 
-      filters = Jason.encode!([[:is, "event:goal", ["Signup"]]])
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}&order_by=#{Jason.encode!([["conversion_rate", "desc"]])}"
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Signup"]]],
+          metrics: ["visitors", "total_visitors", "group_conversion_rate"],
+          order_by: [["group_conversion_rate", "desc"]]
         )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "total_visitors" => 1,
-                 "visitors" => 1,
-                 "conversion_rate" => 100.0
-               },
-               %{
-                 "code" => "EE",
-                 "alpha_3" => "EST",
-                 "name" => "Estonia",
-                 "flag" => "🇪🇪",
-                 "total_visitors" => 2,
-                 "visitors" => 1,
-                 "conversion_rate" => 50.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [1, 1, 100.0]},
+               %{"dimensions" => ["EE", "Estonia"], "metrics" => [1, 2, 50.0]}
              ]
     end
 
@@ -189,18 +194,14 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "event:props:author", ["John Doe"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is", "event:props:author", ["John Doe"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "EE",
-                 "alpha_3" => "EST",
-                 "name" => "Estonia",
-                 "flag" => "🇪🇪",
-                 "visitors" => 1,
-                 "percentage" => 100
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["EE", "Estonia"], "metrics" => [1, 100.0]}
              ]
     end
 
@@ -231,18 +232,14 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is_not, "event:props:author", ["John Doe"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is_not", "event:props:author", ["John Doe"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "visitors" => 2,
-                 "percentage" => 100
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [2, 100.0]}
              ]
     end
 
@@ -266,18 +263,14 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is, "event:props:author", ["(none)"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is", "event:props:author", ["(none)"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "visitors" => 2,
-                 "percentage" => 100
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [2, 100.0]}
              ]
     end
 
@@ -306,18 +299,14 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
         )
       ])
 
-      filters = Jason.encode!([[:is_not, "event:props:author", ["(none)"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is_not", "event:props:author", ["(none)"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "EE",
-                 "alpha_3" => "EST",
-                 "name" => "Estonia",
-                 "flag" => "🇪🇪",
-                 "visitors" => 2,
-                 "percentage" => 100
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["EE", "Estonia"], "metrics" => [2, 100.0]}
              ]
     end
 
@@ -328,18 +317,14 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
         build(:pageview, country_code: "GB")
       ])
 
-      filters = Jason.encode!([[:is, "visit:country", ["GB"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is", "visit:country", ["GB"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "visitors" => 1,
-                 "percentage" => 100
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [1, 100.0]}
              ]
     end
 
@@ -388,28 +373,18 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
         build(:pageview, country_code: "IE")
       ])
 
-      filters =
-        Jason.encode!([["is", "segment", [segment_alfa]], ["is", "segment", [segment_beta]]])
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [
+            ["is", "segment", [segment_alfa]],
+            ["is", "segment", [segment_beta]]
+          ]
+        )
 
-      conn = get(conn, "/api/stats/#{site.domain}/countries?period=day&filters=#{filters}")
-
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "GB",
-                 "alpha_3" => "GBR",
-                 "name" => "United Kingdom",
-                 "flag" => "🇬🇧",
-                 "visitors" => 1,
-                 "percentage" => 50
-               },
-               %{
-                 "code" => "IE",
-                 "alpha_3" => "IRL",
-                 "name" => "Ireland",
-                 "flag" => "🇮🇪",
-                 "visitors" => 1,
-                 "percentage" => 50
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["IE", "Ireland"], "metrics" => [1, 50.0]},
+               %{"dimensions" => ["GB", "United Kingdom"], "metrics" => [1, 50.0]}
              ]
     end
 
@@ -471,55 +446,60 @@ defmodule PlausibleWeb.Api.StatsController.CountriesTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_countries(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Payment"]]],
+          metrics: [
+            "visitors",
+            "total_visitors",
+            "group_conversion_rate",
+            "average_revenue",
+            "total_revenue"
+          ],
+          order_by: [["visitors", "desc"], ["visit:country", "asc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/countries#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 66.67,
-                 "name" => "Estonia",
-                 "alpha_3" => "EST",
-                 "code" => "EE",
-                 "flag" => "🇪🇪",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 3,
-                 "visitors" => 2
+                 "dimensions" => ["EE", "Estonia"],
+                 "metrics" => [
+                   2,
+                   3,
+                   66.67,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 50.0,
-                 "name" => "United Kingdom",
-                 "alpha_3" => "GBR",
-                 "code" => "GB",
-                 "flag" => "🇬🇧",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 2,
-                 "visitors" => 1
+                 "dimensions" => ["GB", "United Kingdom"],
+                 "metrics" => [
+                   1,
+                   2,
+                   50.0,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end

--- a/test/plausible_web/controllers/api/stats_controller/regions_legacy_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/regions_legacy_test.exs
@@ -1,0 +1,237 @@
+defmodule PlausibleWeb.Api.StatsController.RegionsLegacyTest do
+  @moduledoc """
+  [DEPRECATED] Still used for CSV export but to be removed.
+  """
+  use PlausibleWeb.ConnCase
+
+  describe "GET /api/stats/:domain/regions" do
+    defp seed(%{site: site}) do
+      populate_stats(site, [
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
+        ),
+        build(:pageview,
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
+        )
+      ])
+    end
+
+    setup [:create_user, :log_in, :create_site, :create_legacy_site_import, :seed]
+
+    test "returns top cities by new visitors", %{conn: conn, site: site} do
+      conn = get(conn, "/api/stats/#{site.domain}/regions?period=day")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "EE-37",
+                 "country_flag" => "🇪🇪",
+                 "name" => "Harjumaa",
+                 "visitors" => 3,
+                 "percentage" => 60.0
+               },
+               %{
+                 "code" => "EE-39",
+                 "country_flag" => "🇪🇪",
+                 "name" => "Hiiumaa",
+                 "visitors" => 2,
+                 "percentage" => 40.0
+               }
+             ]
+    end
+
+    test "when list is filtered returns one city only", %{conn: conn, site: site} do
+      filters = Jason.encode!([[:is, "visit:region", ["EE-39"]]])
+      conn = get(conn, "/api/stats/#{site.domain}/regions?period=day&filters=#{filters}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "code" => "EE-39",
+                 "country_flag" => "🇪🇪",
+                 "name" => "Hiiumaa",
+                 "visitors" => 2,
+                 "percentage" => 100.0
+               }
+             ]
+    end
+
+    test "malicious input - date", %{conn: conn, site: site} do
+      filters = Jason.encode!([[:is, "visit:region", ["EE-39"]]])
+      garbage = "2020-07-30'||DBMS_PIPE.RECEIVE_MESSAGE(CHR(98)||CHR(98)||CHR(98),15)||'"
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/regions?period=custom&filters=#{filters}&date=#{garbage}"
+        )
+
+      assert resp = response(conn, 400)
+      assert resp =~ "Failed to parse 'date' argument."
+    end
+
+    test "malicious input - from", %{conn: conn, site: site} do
+      filters = Jason.encode!([[:is, "visit:region", ["EE-39"]]])
+      garbage = "2020-07-30'||DBMS_PIPE.RECEIVE_MESSAGE(CHR(98)||CHR(98)||CHR(98),15)||'"
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/regions?period=custom&filters=#{filters}&from=#{garbage}"
+        )
+
+      assert resp = response(conn, 400)
+      assert resp =~ "Failed to parse 'from' argument."
+    end
+
+    test "malicious input - to", %{conn: conn, site: site} do
+      filters = Jason.encode!([[:is, "visit:region", ["EE-39"]]])
+      garbage = "2020-07-30'||DBMS_PIPE.RECEIVE_MESSAGE(CHR(98)||CHR(98)||CHR(98),15)||'"
+
+      conn =
+        get(
+          conn,
+          "/api/stats/#{site.domain}/regions?period=custom&filters=#{filters}&from=2020-04-01&to=#{garbage}"
+        )
+
+      assert resp = response(conn, 400)
+      assert resp =~ "Failed to parse 'to' argument."
+    end
+
+    @tag :ee_only
+    test "return revenue metrics for regions breakdown", %{conn: conn, site: site} do
+      populate_stats(site, [
+        build(:pageview,
+          user_id: 1,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 1,
+          revenue_reporting_amount: Decimal.new("1000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 2,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 2,
+          revenue_reporting_amount: Decimal.new("2000"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 3,
+          country_code: "EE",
+          subdivision1_code: "EE-37",
+          city_geoname_id: 588_409
+        ),
+        build(:pageview,
+          user_id: 4,
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
+        ),
+        build(:event,
+          name: "Payment",
+          user_id: 4,
+          revenue_reporting_amount: Decimal.new("500"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview,
+          user_id: 5,
+          country_code: "EE",
+          subdivision1_code: "EE-39",
+          city_geoname_id: 591_632
+        ),
+        build(:pageview, user_id: 6),
+        build(:event,
+          name: "Payment",
+          user_id: 6,
+          revenue_reporting_amount: Decimal.new("600"),
+          revenue_reporting_currency: "USD"
+        ),
+        build(:pageview, user_id: 7),
+        build(:event,
+          name: "Payment",
+          user_id: 7,
+          revenue_reporting_amount: nil
+        )
+      ])
+
+      insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
+
+      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
+      order_by = Jason.encode!([["visitors", "desc"]])
+
+      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
+
+      conn = get(conn, "/api/stats/#{site.domain}/regions#{q}")
+
+      assert json_response(conn, 200)["results"] == [
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$1,500.00",
+                   "short" => "$1.5K",
+                   "value" => 1500.0
+                 },
+                 "conversion_rate" => 33.33,
+                 "name" => "Harjumaa",
+                 "code" => "EE-37",
+                 "country_flag" => "🇪🇪",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$3,000.00",
+                   "short" => "$3.0K",
+                   "value" => 3000.0
+                 },
+                 "total_visitors" => 6,
+                 "visitors" => 2
+               },
+               %{
+                 "average_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "conversion_rate" => 25.0,
+                 "name" => "Hiiumaa",
+                 "code" => "EE-39",
+                 "country_flag" => "🇪🇪",
+                 "total_revenue" => %{
+                   "currency" => "USD",
+                   "long" => "$500.00",
+                   "short" => "$500.0",
+                   "value" => 500.0
+                 },
+                 "total_visitors" => 4,
+                 "visitors" => 1
+               }
+             ]
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/regions_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/regions_test.exs
@@ -1,7 +1,28 @@
 defmodule PlausibleWeb.Api.StatsController.RegionsTest do
   use PlausibleWeb.ConnCase
 
-  describe "GET /api/stats/:domain/regions" do
+  defp query_regions(conn, site, opts) do
+    always_on_filters = ["is_not", "visit:region", [""]]
+
+    params = %{
+      "dimensions" => Keyword.get(opts, :dimensions, ["visit:region", "visit:region_name"]),
+      "date_range" => Keyword.get(opts, :date_range, "all"),
+      "filters" => [
+        always_on_filters
+        | Keyword.get(opts, :filters, [])
+      ],
+      "metrics" => Keyword.get(opts, :metrics, ["visitors", "percentage"]),
+      "include" => Keyword.get(opts, :include, nil),
+      "pagination" => Keyword.get(opts, :pagination, nil),
+      "order_by" => Keyword.get(opts, :order_by, nil)
+    }
+
+    conn
+    |> post("/api/stats/#{site.domain}/query", params)
+    |> json_response(200)
+  end
+
+  describe "querying for regions with POST /query" do
     defp seed(%{site: site}) do
       populate_stats(site, [
         build(:pageview,
@@ -34,82 +55,25 @@ defmodule PlausibleWeb.Api.StatsController.RegionsTest do
 
     setup [:create_user, :log_in, :create_site, :create_legacy_site_import, :seed]
 
-    test "returns top cities by new visitors", %{conn: conn, site: site} do
-      conn = get(conn, "/api/stats/#{site.domain}/regions?period=day")
+    test "returns top regions by visitors", %{conn: conn, site: site} do
+      response = query_regions(conn, site, date_range: "day")
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "EE-37",
-                 "country_flag" => "🇪🇪",
-                 "name" => "Harjumaa",
-                 "visitors" => 3,
-                 "percentage" => 60.0
-               },
-               %{
-                 "code" => "EE-39",
-                 "country_flag" => "🇪🇪",
-                 "name" => "Hiiumaa",
-                 "visitors" => 2,
-                 "percentage" => 40.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["EE-37", "Harjumaa"], "metrics" => [3, 60.0]},
+               %{"dimensions" => ["EE-39", "Hiiumaa"], "metrics" => [2, 40.0]}
              ]
     end
 
-    test "when list is filtered returns one city only", %{conn: conn, site: site} do
-      filters = Jason.encode!([[:is, "visit:region", ["EE-39"]]])
-      conn = get(conn, "/api/stats/#{site.domain}/regions?period=day&filters=#{filters}")
+    test "when list is filtered returns one region only", %{conn: conn, site: site} do
+      response =
+        query_regions(conn, site,
+          date_range: "day",
+          filters: [["is", "visit:region", ["EE-39"]]]
+        )
 
-      assert json_response(conn, 200)["results"] == [
-               %{
-                 "code" => "EE-39",
-                 "country_flag" => "🇪🇪",
-                 "name" => "Hiiumaa",
-                 "visitors" => 2,
-                 "percentage" => 100.0
-               }
+      assert response["results"] == [
+               %{"dimensions" => ["EE-39", "Hiiumaa"], "metrics" => [2, 100.0]}
              ]
-    end
-
-    test "malicious input - date", %{conn: conn, site: site} do
-      filters = Jason.encode!([[:is, "visit:region", ["EE-39"]]])
-      garbage = "2020-07-30'||DBMS_PIPE.RECEIVE_MESSAGE(CHR(98)||CHR(98)||CHR(98),15)||'"
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/regions?period=custom&filters=#{filters}&date=#{garbage}"
-        )
-
-      assert resp = response(conn, 400)
-      assert resp =~ "Failed to parse 'date' argument."
-    end
-
-    test "malicious input - from", %{conn: conn, site: site} do
-      filters = Jason.encode!([[:is, "visit:region", ["EE-39"]]])
-      garbage = "2020-07-30'||DBMS_PIPE.RECEIVE_MESSAGE(CHR(98)||CHR(98)||CHR(98),15)||'"
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/regions?period=custom&filters=#{filters}&from=#{garbage}"
-        )
-
-      assert resp = response(conn, 400)
-      assert resp =~ "Failed to parse 'from' argument."
-    end
-
-    test "malicious input - to", %{conn: conn, site: site} do
-      filters = Jason.encode!([[:is, "visit:region", ["EE-39"]]])
-      garbage = "2020-07-30'||DBMS_PIPE.RECEIVE_MESSAGE(CHR(98)||CHR(98)||CHR(98),15)||'"
-
-      conn =
-        get(
-          conn,
-          "/api/stats/#{site.domain}/regions?period=custom&filters=#{filters}&from=2020-04-01&to=#{garbage}"
-        )
-
-      assert resp = response(conn, 400)
-      assert resp =~ "Failed to parse 'to' argument."
     end
 
     @tag :ee_only
@@ -180,53 +144,60 @@ defmodule PlausibleWeb.Api.StatsController.RegionsTest do
 
       insert(:goal, %{site: site, event_name: "Payment", currency: :USD})
 
-      filters = Jason.encode!([[:is, "event:goal", ["Payment"]]])
-      order_by = Jason.encode!([["visitors", "desc"]])
+      response =
+        query_regions(conn, site,
+          date_range: "day",
+          filters: [["is", "event:goal", ["Payment"]]],
+          metrics: [
+            "visitors",
+            "total_visitors",
+            "group_conversion_rate",
+            "average_revenue",
+            "total_revenue"
+          ],
+          order_by: [["visitors", "desc"], ["visit:region", "asc"]]
+        )
 
-      q = "?filters=#{filters}&order_by=#{order_by}&detailed=true&period=day&page=1&limit=100"
-
-      conn = get(conn, "/api/stats/#{site.domain}/regions#{q}")
-
-      assert json_response(conn, 200)["results"] == [
+      assert response["results"] == [
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$1,500.00",
-                   "short" => "$1.5K",
-                   "value" => 1500.0
-                 },
-                 "conversion_rate" => 33.33,
-                 "name" => "Harjumaa",
-                 "code" => "EE-37",
-                 "country_flag" => "🇪🇪",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$3,000.00",
-                   "short" => "$3.0K",
-                   "value" => 3000.0
-                 },
-                 "total_visitors" => 6,
-                 "visitors" => 2
+                 "dimensions" => ["EE-37", "Harjumaa"],
+                 "metrics" => [
+                   2,
+                   6,
+                   33.33,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$1,500.00",
+                     "short" => "$1.5K",
+                     "value" => 1500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$3,000.00",
+                     "short" => "$3.0K",
+                     "value" => 3000.0
+                   }
+                 ]
                },
                %{
-                 "average_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "conversion_rate" => 25.0,
-                 "name" => "Hiiumaa",
-                 "code" => "EE-39",
-                 "country_flag" => "🇪🇪",
-                 "total_revenue" => %{
-                   "currency" => "USD",
-                   "long" => "$500.00",
-                   "short" => "$500.0",
-                   "value" => 500.0
-                 },
-                 "total_visitors" => 4,
-                 "visitors" => 1
+                 "dimensions" => ["EE-39", "Hiiumaa"],
+                 "metrics" => [
+                   1,
+                   4,
+                   25.0,
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   },
+                   %{
+                     "currency" => "USD",
+                     "long" => "$500.00",
+                     "short" => "$500.0",
+                     "value" => 500.0
+                   }
+                 ]
                }
              ]
     end


### PR DESCRIPTION
### Changes

- Copies the legacy test files, adding a header about why they must remain
- Refactors the original test files to use /query endpoint

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
