### PR TITLE
Fix IndexBreakdown fade-in animation

### DIFF
--- a/assets/js/dashboard/stats/reports/index-breakdown.tsx
+++ b/assets/js/dashboard/stats/reports/index-breakdown.tsx
@@ -194,6 +194,10 @@ export function IndexBreakdown({
   return (
     <LazyLoader onVisible={() => setVisible(true)}>
       <IndexBreakdownRenderer<QueryResultRow>
+        // The key forces remount on every query change so that fade-in
+        // animation could trigger, even when results are instantly
+        // available from TanStack cache.
+        key={JSON.stringify(statsReportQueryKey)}
         {...apiState}
         rows={apiState.data?.results?.slice(0, MAX_ITEMS) ?? []}
         getDimensionValue={(row) => row.dimensions[0]}
@@ -453,6 +457,7 @@ export function IndexBreakdownRenderer<TRow>({
   if (!columns || isPending || (isPlaceholderData && !isRealtimeSilentUpdate)) {
     return (
       <div
+        key="loading"
         className="w-full flex flex-col justify-center"
         style={{ minHeight: `${MIN_HEIGHT}px` }}
       >
@@ -466,6 +471,7 @@ export function IndexBreakdownRenderer<TRow>({
   if (rows.length === 0) {
     return (
       <div
+        key="empty"
         className="w-full h-full flex flex-col justify-center"
         style={{ minHeight: `${MIN_HEIGHT}px` }}
       >
@@ -477,7 +483,10 @@ export function IndexBreakdownRenderer<TRow>({
   }
 
   return (
-    <div className="h-full flex flex-col opacity-100 transition-opacity duration-300 starting:opacity-0">
+    <div
+      key="data"
+      className="h-full flex flex-col opacity-100 transition-opacity duration-300 starting:opacity-0"
+    >
       <div
         style={{ height: ROW_HEIGHT }}
         className="pt-3 w-full text-xs font-medium text-gray-500 dark:text-gray-400 flex items-center"

--- a/assets/js/dashboard/stats/sources/search-terms.tsx
+++ b/assets/js/dashboard/stats/sources/search-terms.tsx
@@ -3,6 +3,7 @@ import { numberShortFormatter } from '../../util/number-formatter'
 import RocketIcon from '../modals/rocket-icon'
 import LazyLoader from '../../components/lazy-loader'
 import { PlausibleSite, useSiteContext } from '../../site-context'
+import { useDashboardStateContext } from '../../dashboard-state-context'
 import {
   SearchTermsErrorCode,
   SearchTermsErrorPayload,
@@ -72,6 +73,7 @@ export function SearchTerms({
   onDataReady: (data: SearchTermsSuccessResponse) => void
 }) {
   const site = useSiteContext()
+  const { dashboardState } = useDashboardStateContext()
 
   const [visible, setVisible] = React.useState(false)
 
@@ -140,6 +142,10 @@ export function SearchTerms({
   return (
     <LazyLoader onVisible={() => setVisible(true)}>
       <IndexBreakdownRenderer<SearchTermsResultItem>
+        // The key forces remount on every query change so that fade-in
+        // animation could trigger, even when results are instantly
+        // available from TanStack cache.
+        key={JSON.stringify(dashboardState)}
         {...apiState}
         rows={apiState.data?.results ?? []}
         getDimensionValue={(row) => row.name}


### PR DESCRIPTION
### Changes

The fade-in animation was intended from the start of the v2 FE migration. It used to work for pages until https://github.com/plausible/analytics/pull/6395 broke it. This was due to switching to a single component that doesn't get re-mounted.

This PR fixes that by giving a unique React `key` for the currently displayed query in each `IndexBreakdownRenderer` call, forcing the component to re-mount.

_EDIT: Leaving this in a draft state for now. Will be re-visited later. Graph should animate too._

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
