### PR TITLE
Adjust custom props of demo CTA events

### DIFF
--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -57,7 +57,7 @@
   >
   </div>
   <div id="modal_root"></div>
-  <%= if !@conn.assigns[:current_user] && @conn.assigns[:demo] do %>
+  <%= if ee?() && !@conn.assigns[:current_user] && @conn.assigns[:demo] do %>
     <div class="py-12 lg:py-16 lg:flex lg:items-center lg:justify-between">
       <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 leading-9 sm:text-4xl sm:leading-10 dark:text-gray-100">
         You just saw how Plausible tracks plausible.io <br />

--- a/lib/plausible_web/templates/stats/stats.html.heex
+++ b/lib/plausible_web/templates/stats/stats.html.heex
@@ -67,7 +67,7 @@
         <div class="inline-flex shadow-sm rounded-md">
           <a
             href="/register"
-            onclick="plausible('CTA Click', {props: {location: 'Live demo', button: 'Start free trial'}})"
+            onclick="plausible('CTA Click', {props: {position: 'Bottom', type: 'Live demo', button: 'Start free trial'}})"
             class="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-white bg-indigo-600 border border-transparent leading-6 rounded-md hover:bg-indigo-500 focus:outline-hidden focus:ring transition duration-150 ease-in-out"
           >
             Start free trial
@@ -76,7 +76,7 @@
         <div class="inline-flex ml-3 shadow-xs rounded-md">
           <a
             href="/#pricing"
-            onclick="plausible('CTA Click', {props: {location: 'Live demo', button: 'See pricing'}})"
+            onclick="plausible('CTA Click', {props: {position: 'Bottom', type: 'Live demo', button: 'See pricing'}})"
             class="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-indigo-600 bg-white border border-transparent leading-6 rounded-md dark:text-gray-100 dark:bg-gray-800 hover:text-indigo-500 dark:hover:text-indigo-500 focus:outline-hidden focus:ring transition duration-150 ease-in-out"
           >
             See pricing

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -77,6 +77,7 @@ defmodule PlausibleWeb.StatsControllerTest do
                ])
     end
 
+    @tag :ee_only
     test "plausible.io live demo - shows site stats, header and footer", %{conn: conn} do
       site = new_site(domain: "plausible.io", public: true)
       populate_stats(site, [build(:pageview)])


### PR DESCRIPTION
to keep things consistent with the custom props on the other CTA buttons around the site

