### PR TITLE
fix: prevent dark theme flash on navigation

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -205,7 +205,13 @@
 }
 
 html {
-  @apply text-gray-800;
+  @apply text-gray-800 bg-gray-50;
+  color-scheme: light;
+}
+
+html.dark {
+  @apply bg-gray-950;
+  color-scheme: dark;
 }
 
 body {

--- a/lib/plausible_web/components/layout.ex
+++ b/lib/plausible_web/components/layout.ex
@@ -25,6 +25,11 @@ defmodule PlausibleWeb.Components.Layout do
     """
   end
 
+  def html_classes(assigns) do
+    ["h-full plausible", if(theme_preference(assigns) == "dark", do: "dark")]
+    |> Enum.reject(&is_nil/1)
+  end
+
   def theme_script(assigns) do
     ~H"""
     <script blocking="rendering">
@@ -151,11 +156,11 @@ defmodule PlausibleWeb.Components.Layout do
     """
   end
 
-  defp theme_preference(%{theme: theme}) when not is_nil(theme), do: theme
+  defp theme_preference(%{theme: theme}) when not is_nil(theme), do: to_string(theme)
 
   defp theme_preference(%{current_user: %Plausible.Auth.User{theme: theme}})
        when not is_nil(theme) do
-    theme
+    to_string(theme)
   end
 
   defp theme_preference(_assigns), do: "system"

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full plausible">
+<html
+  lang="en"
+  class={PlausibleWeb.Components.Layout.html_classes(Map.take(assigns, [:current_user, :theme]))}
+>
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
### Changes

sets the initial dark class on the root html element when the saved theme is dark, so navigation does not briefly paint the page in light mode first

also sets the root html background and color-scheme to match the active theme

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
