### PR TITLE
Fix issue in e2e tests with clicking tab dropdown before data is loaded

### DIFF
--- a/assets/js/dashboard/components/tabs.tsx
+++ b/assets/js/dashboard/components/tabs.tsx
@@ -97,6 +97,7 @@ export const DropdownTabButton = ({
             })}
           >
             <Popover.Button
+              data-testid="tab-button-with-dropdown"
               className="group/tab relative inline-flex justify-between rounded-xs before:absolute before:inset-[-16px_-6px] before:content-[' ']"
               ref={dropdownButtonRef}
             >

--- a/e2e/tests/dashboard/behaviours.spec.ts
+++ b/e2e/tests/dashboard/behaviours.spec.ts
@@ -19,7 +19,8 @@ import {
   detailsLink,
   modal,
   closeModalButton,
-  searchInput
+  searchInput,
+  tabButtonWithDropdown
 } from '../test-utils'
 
 const getReport = (page: Page) => page.getByTestId('report-behaviours')
@@ -631,7 +632,7 @@ test('props breakdown', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  const propsTabButton = tabButton(report, 'Properties')
+  const propsTabButton = tabButtonWithDropdown(report, 'Properties')
 
   await test.step('listing props', async () => {
     await propsTabButton.scrollIntoViewIfNeeded()
@@ -640,7 +641,10 @@ test('props breakdown', async ({ page, request }) => {
       .getByRole('button', { name: 'browser_language' })
       .click()
 
-    await expect(propsTabButton).toHaveAttribute('data-active', 'true')
+    await expect(tabButton(propsTabButton, 'Properties')).toHaveAttribute(
+      'data-active',
+      'true'
+    )
 
     await expectHeaders(report, ['browser_language', 'Visitors', 'Events', '%'])
 
@@ -694,7 +698,10 @@ test('props breakdown', async ({ page, request }) => {
 
     await rowLink(report, 'Visit /page').click()
 
-    await expect(propsTabButton).toHaveAttribute('data-active', 'true')
+    await expect(tabButton(propsTabButton, 'Properties')).toHaveAttribute(
+      'data-active',
+      'true'
+    )
 
     await expectHeaders(report, [
       'browser_language',
@@ -772,7 +779,7 @@ test('funnels', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  const funnelsTabButton = tabButton(report, 'Funnels')
+  const funnelsTabButton = tabButtonWithDropdown(report, 'Funnels')
 
   await test.step('rendering funnels', async () => {
     await funnelsTabButton.scrollIntoViewIfNeeded()
@@ -781,7 +788,10 @@ test('funnels', async ({ page, request }) => {
       .getByRole('button', { name: 'Shopping 11 Funnel' })
       .click()
 
-    await expect(funnelsTabButton).toHaveAttribute('data-active', 'true')
+    await expect(tabButton(funnelsTabButton, 'Funnels')).toHaveAttribute(
+      'data-active',
+      'true'
+    )
 
     await expect(report.getByRole('heading')).toHaveText('Shopping 11 Funnel')
 

--- a/e2e/tests/test-utils.ts
+++ b/e2e/tests/test-utils.ts
@@ -28,6 +28,11 @@ export function randomID() {
 export const tabButton = (page: Page | Locator, label: HasTextArg) =>
   page.getByTestId('tab-button').filter({ hasText: label })
 
+export const tabButtonWithDropdown = (
+  page: Page | Locator,
+  label: HasTextArg
+) => page.getByTestId('tab-button-with-dropdown').filter({ hasText: label })
+
 export const header = (report: Locator, label: HasTextArg) =>
   report
     .getByTestId('report-header')


### PR DESCRIPTION
### Changes

Fixes issue in e2e tests with clicking a tab with dropdown before the data in the dropdown has been fetched.