### PR TITLE
Add ability to make the FE trigger automatic dashboard refresh

### DIFF
--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -7,6 +7,9 @@ import { serializeApiFilters } from './util/filters'
 import * as url from './util/url'
 import { MainGraphResponse } from './stats/graph/fetch-main-graph'
 import { CsvExportRequestBody } from './stats/csv-export/csv-export-body'
+import { maybeReloadForApiVersion } from './util/url-search-params'
+
+const EXPECTED_API_VERSION = '0'
 
 let abortController = new AbortController()
 let SHARED_LINK_AUTH: null | string = null
@@ -149,6 +152,12 @@ async function throwApiErrorIfNotOk(response: Response) {
 }
 
 async function handleApiResponse(response: Response) {
+  const apiVersion = response.headers.get('x-api-version')
+
+  if (apiVersion && apiVersion !== EXPECTED_API_VERSION) {
+    maybeReloadForApiVersion(window.location, EXPECTED_API_VERSION)
+  }
+
   await throwApiErrorIfNotOk(response)
   return response.json()
 }

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -149,8 +149,11 @@ async function throwApiErrorIfNotOk(response: Response) {
   }
 }
 
-async function handleApiResponse(response: Response) {
-  maybeReloadForApiVersion(window.location, response.headers)
+async function handleApiResponse(response: Response, opts: Record<'idempotent', boolean> = {idempotent: true}) {
+  if (opts.idempotent) {
+    maybeReloadForApiVersion(window.location, response.headers)
+  }
+
   await throwApiErrorIfNotOk(response)
   return response.json()
 }
@@ -264,5 +267,5 @@ export const mutation = async <
     body: fetchOptions.body,
     signal: abortController.signal
   })
-  return handleApiResponse(response)
+  return handleApiResponse(response, {idempotent: false})
 }

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -149,7 +149,10 @@ async function throwApiErrorIfNotOk(response: Response) {
   }
 }
 
-async function handleApiResponse(response: Response, opts: Record<'idempotent', boolean> = {idempotent: true}) {
+async function handleApiResponse(
+  response: Response,
+  opts: Record<'idempotent', boolean> = { idempotent: true }
+) {
   if (opts.idempotent) {
     maybeReloadForApiVersion(window.location, response.headers)
   }
@@ -267,5 +270,5 @@ export const mutation = async <
     body: fetchOptions.body,
     signal: abortController.signal
   })
-  return handleApiResponse(response, {idempotent: false})
+  return handleApiResponse(response, { idempotent: false })
 }

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -9,11 +9,6 @@ import { MainGraphResponse } from './stats/graph/fetch-main-graph'
 import { CsvExportRequestBody } from './stats/csv-export/csv-export-body'
 import { maybeReloadForApiVersion } from './util/url-search-params'
 
-const EXPECTED_API_VERSION =
-  document
-    .querySelector('meta[name="x-api-version"]')
-    ?.getAttribute('content') ?? '0'
-
 let abortController = new AbortController()
 let SHARED_LINK_AUTH: null | string = null
 
@@ -155,12 +150,7 @@ async function throwApiErrorIfNotOk(response: Response) {
 }
 
 async function handleApiResponse(response: Response) {
-  const currentApiVersion = response.headers?.get('x-api-version')
-
-  if (currentApiVersion && currentApiVersion !== EXPECTED_API_VERSION) {
-    maybeReloadForApiVersion(window.location, currentApiVersion)
-  }
-
+  maybeReloadForApiVersion(window.location, response.headers)
   await throwApiErrorIfNotOk(response)
   return response.json()
 }

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -155,10 +155,10 @@ async function throwApiErrorIfNotOk(response: Response) {
 }
 
 async function handleApiResponse(response: Response) {
-  const apiVersion = response.headers.get('x-api-version')
+  const currentApiVersion = response.headers.get('x-api-version')
 
-  if (apiVersion && apiVersion !== EXPECTED_API_VERSION) {
-    maybeReloadForApiVersion(window.location, EXPECTED_API_VERSION)
+  if (currentApiVersion && currentApiVersion !== EXPECTED_API_VERSION) {
+    maybeReloadForApiVersion(window.location, currentApiVersion)
   }
 
   await throwApiErrorIfNotOk(response)

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -9,7 +9,10 @@ import { MainGraphResponse } from './stats/graph/fetch-main-graph'
 import { CsvExportRequestBody } from './stats/csv-export/csv-export-body'
 import { maybeReloadForApiVersion } from './util/url-search-params'
 
-const EXPECTED_API_VERSION = '0'
+const EXPECTED_API_VERSION =
+  document
+    .querySelector('meta[name="x-api-version"]')
+    ?.getAttribute('content') ?? '0'
 
 let abortController = new AbortController()
 let SHARED_LINK_AUTH: null | string = null

--- a/assets/js/dashboard/api.ts
+++ b/assets/js/dashboard/api.ts
@@ -155,7 +155,7 @@ async function throwApiErrorIfNotOk(response: Response) {
 }
 
 async function handleApiResponse(response: Response) {
-  const currentApiVersion = response.headers.get('x-api-version')
+  const currentApiVersion = response.headers?.get('x-api-version')
 
   if (currentApiVersion && currentApiVersion !== EXPECTED_API_VERSION) {
     maybeReloadForApiVersion(window.location, currentApiVersion)

--- a/assets/js/dashboard/stats/modals/filter-modal-props-row.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-props-row.js
@@ -8,10 +8,10 @@ import { apiPath } from '../../util/url'
 import {
   EVENT_PROPS_PREFIX,
   FILTER_OPERATIONS,
-  fetchSuggestions,
   getPropertyKeyFromFilterKey,
   isFreeChoiceFilterOperation
 } from '../../util/filters'
+import { fetchSuggestions } from '../../util/fetch-suggestions'
 import { useDashboardStateContext } from '../../dashboard-state-context'
 import { useSiteContext } from '../../site-context'
 

--- a/assets/js/dashboard/stats/modals/filter-modal-row.js
+++ b/assets/js/dashboard/stats/modals/filter-modal-row.js
@@ -7,11 +7,11 @@ import Combobox from '../../components/combobox'
 
 import {
   FILTER_OPERATIONS,
-  fetchSuggestions,
   isFreeChoiceFilterOperation,
   getLabel,
   formattedFilters
 } from '../../util/filters'
+import { fetchSuggestions } from '../../util/fetch-suggestions'
 import { apiPath } from '../../util/url'
 import { useDashboardStateContext } from '../../dashboard-state-context'
 import { useSiteContext } from '../../site-context'

--- a/assets/js/dashboard/util/fetch-suggestions.ts
+++ b/assets/js/dashboard/util/fetch-suggestions.ts
@@ -1,0 +1,35 @@
+import * as api from '../api'
+import { DashboardState, Filter } from '../dashboard-state'
+import { replaceFilterByPrefix, omitFiltersByKeyPrefix } from './filters'
+
+export function fetchSuggestions(
+  apiPath: string,
+  dashboardState: DashboardState,
+  input: string,
+  additionalFilter?: Filter
+) {
+  const updatedQuery = queryForSuggestions(dashboardState, additionalFilter)
+  return api.get(apiPath, updatedQuery, { q: input.trim() })
+}
+
+function queryForSuggestions(
+  dashboardState: DashboardState,
+  additionalFilter?: Filter
+): DashboardState {
+  let filters = dashboardState.filters
+  if (additionalFilter) {
+    const [_operation, filterKey, clauses] = additionalFilter
+
+    // For suggestions, we remove already-applied filter with same key from dashboardState and add new filter (if feasible)
+    if (clauses.length > 0) {
+      filters = replaceFilterByPrefix(
+        dashboardState,
+        filterKey,
+        additionalFilter
+      )
+    } else {
+      filters = omitFiltersByKeyPrefix(dashboardState, filterKey)
+    }
+  }
+  return { ...dashboardState, filters }
+}

--- a/assets/js/dashboard/util/filters.js
+++ b/assets/js/dashboard/util/filters.js
@@ -1,4 +1,3 @@
-import * as api from '../api'
 import { formatSegmentIdAsLabelKey } from '../filtering/segments'
 
 export const FILTER_MODAL_TO_FILTER_GROUP = {
@@ -95,7 +94,7 @@ const hasDimensionPrefix =
   ([_operation, dimension, _clauses]) =>
     dimension.startsWith(prefix)
 
-function omitFiltersByKeyPrefix(dashboardState, prefix) {
+export function omitFiltersByKeyPrefix(dashboardState, prefix) {
   return dashboardState.filters.filter(
     ([_operation, filterKey, _clauses]) => !filterKey.startsWith(prefix)
   )
@@ -277,35 +276,6 @@ function remapToApiFilter([operation, filterKey, clauses, ...modifiers]) {
   } else {
     return [operation, apiFilterKey, clauses, ...modifiers]
   }
-}
-
-export function fetchSuggestions(
-  apiPath,
-  dashboardState,
-  input,
-  additionalFilter
-) {
-  const updatedQuery = queryForSuggestions(dashboardState, additionalFilter)
-  return api.get(apiPath, updatedQuery, { q: input.trim() })
-}
-
-function queryForSuggestions(dashboardState, additionalFilter) {
-  let filters = dashboardState.filters
-  if (additionalFilter) {
-    const [_operation, filterKey, clauses] = additionalFilter
-
-    // For suggestions, we remove already-applied filter with same key from dashboardState and add new filter (if feasible)
-    if (clauses.length > 0) {
-      filters = replaceFilterByPrefix(
-        dashboardState,
-        filterKey,
-        additionalFilter
-      )
-    } else {
-      filters = omitFiltersByKeyPrefix(dashboardState, filterKey)
-    }
-  }
-  return { ...dashboardState, filters }
 }
 
 export function getFilterGroup([_operation, filterKey, _clauses]) {

--- a/assets/js/dashboard/util/url-search-params.test.ts
+++ b/assets/js/dashboard/util/url-search-params.test.ts
@@ -4,6 +4,7 @@ import {
   getSearchWithEnforcedSegment,
   isSearchEntryDefined,
   maybeGetLatestReadableSearch,
+  maybeReloadForApiVersion,
   parseFilter,
   parseLabelsEntry,
   parseSearch,
@@ -257,5 +258,66 @@ describe(`${getSearchWithEnforcedSegment.name}`, () => {
     expect(
       getSearchWithEnforcedSegment(expectedUpdatedSearch, segment)
     ).toEqual(expectedUpdatedSearch)
+  })
+})
+
+describe(`${maybeReloadForApiVersion.name}`, () => {
+  const dashboardPathname = '/example.com'
+
+  type MockWindowLocation = Location & { replace: jest.Mock }
+
+  function makeLocation(search: string): MockWindowLocation {
+    return {
+      pathname: dashboardPathname,
+      search,
+      hash: '',
+      replace: jest.fn()
+    } as unknown as MockWindowLocation
+  }
+
+  function makeHeaders(version: string | null): Headers {
+    const headers = new Headers()
+    if (version !== null) headers.set('x-api-version', version)
+    return headers
+  }
+
+  it('reloads when effective API version is greater than expected', () => {
+    const location = makeLocation('')
+    maybeReloadForApiVersion(location, makeHeaders('1'))
+    expect(location.replace).toHaveBeenCalledWith(
+      `${dashboardPathname}?api_version_reloaded=1`
+    )
+  })
+
+  it('does not reload when effective API version equals expected', () => {
+    const location = makeLocation('')
+    maybeReloadForApiVersion(location, makeHeaders('0'))
+    expect(location.replace).not.toHaveBeenCalled()
+  })
+
+  it('does not reload when effective API version is less than expected (FE loaded from newer node, cluster not fully updated)', () => {
+    const location = makeLocation('')
+    maybeReloadForApiVersion(location, makeHeaders('-1'))
+    expect(location.replace).not.toHaveBeenCalled()
+  })
+
+  it('does not reload when x-api-version header is absent', () => {
+    const location = makeLocation('')
+    maybeReloadForApiVersion(location, makeHeaders(null))
+    expect(location.replace).not.toHaveBeenCalled()
+  })
+
+  it('does not reload when already reloaded for this version', () => {
+    const location = makeLocation('?api_version_reloaded=1')
+    maybeReloadForApiVersion(location, makeHeaders('1'))
+    expect(location.replace).not.toHaveBeenCalled()
+  })
+
+  it('reloads again if a newer version is detected after a previous reload', () => {
+    const location = makeLocation('?api_version_reloaded=1')
+    maybeReloadForApiVersion(location, makeHeaders('2'))
+    expect(location.replace).toHaveBeenCalledWith(
+      `${dashboardPathname}?api_version_reloaded=2`
+    )
   })
 })

--- a/assets/js/dashboard/util/url-search-params.ts
+++ b/assets/js/dashboard/util/url-search-params.ts
@@ -46,7 +46,7 @@ export function maybeReloadForApiVersion(
     currentApiVersion
   )
 
-  console.log('API version mismatch detected, reloading...')
+  console.warn('API version mismatch detected, reloading...')
   windowLocation.replace(
     `${windowLocation.pathname}${newSearch}${windowLocation.hash}`
   )

--- a/assets/js/dashboard/util/url-search-params.ts
+++ b/assets/js/dashboard/util/url-search-params.ts
@@ -22,26 +22,28 @@ const REDIRECTED_SEARCH_PARAM_NAME = 'r'
 const API_VERSION_RELOAD_PARAM_NAME = 'api_version_reloaded'
 
 /**
- * Navigates to the current URL with `api_version_reloaded=<expectedVersion>`
+ * Navigates to the current URL with `api_version_reloaded=<currentApiVersion>`
  * appended, using `location.replace` so the pre-reload entry is not kept in
  * browser history. Returns early without navigating when the param is already
  * present, which prevents an infinite reload loop when the versions are
  * permanently out of sync.
+ *
+ * BE: lib/plausible_web/plugs/internal_stats_api_version.ex
  */
 export function maybeReloadForApiVersion(
   windowLocation: Location,
-  expectedVersion: string
+  currentApiVersion: string
 ) {
   const params = new URLSearchParams(windowLocation.search)
 
-  if (params.get(API_VERSION_RELOAD_PARAM_NAME) === expectedVersion) {
+  if (params.get(API_VERSION_RELOAD_PARAM_NAME) === currentApiVersion) {
     return
   }
 
   const newSearch = addOrReplaceSearch(
     windowLocation.search,
     API_VERSION_RELOAD_PARAM_NAME,
-    expectedVersion
+    currentApiVersion
   )
 
   console.log('API version mismatch detected, reloading...')

--- a/assets/js/dashboard/util/url-search-params.ts
+++ b/assets/js/dashboard/util/url-search-params.ts
@@ -19,6 +19,49 @@ const LABEL_URL_PARAM_NAME = 'l'
 
 const REDIRECTED_SEARCH_PARAM_NAME = 'r'
 
+const API_VERSION_RELOAD_PARAM_NAME = 'api_version_reloaded'
+
+/**
+ * Navigates to the current URL with `api_version_reloaded=<expectedVersion>`
+ * appended, using `location.replace` so the pre-reload entry is not kept in
+ * browser history. Returns early without navigating when the param is already
+ * present, which prevents an infinite reload loop when the versions are
+ * permanently out of sync.
+ */
+export function maybeReloadForApiVersion(
+  windowLocation: Location,
+  expectedVersion: string
+) {
+  const params = new URLSearchParams(windowLocation.search)
+
+  if (params.get(API_VERSION_RELOAD_PARAM_NAME) === expectedVersion) {
+    return
+  }
+
+  const newSearch = addOrReplaceSearch(
+    windowLocation.search,
+    API_VERSION_RELOAD_PARAM_NAME,
+    expectedVersion
+  )
+
+  console.log('API version mismatch detected, reloading...')
+  windowLocation.replace(
+    `${windowLocation.pathname}${newSearch}${windowLocation.hash}`
+  )
+}
+
+function addOrReplaceSearch(
+  search: string,
+  key: string,
+  value: string
+): string {
+  const param = `${key}=${value}`
+  if (new URLSearchParams(search).has(key)) {
+    return search.replace(new RegExp(`([?&])${key}=[^&]*`), `$1${param}`)
+  }
+  return search ? `${search}&${param}` : `?${param}`
+}
+
 /**
  * This function is able to serialize for URL simple params @see serializeSimpleSearchEntry as well
  * two complex params, labels and filters.

--- a/assets/js/dashboard/util/url-search-params.ts
+++ b/assets/js/dashboard/util/url-search-params.ts
@@ -21,22 +21,24 @@ const REDIRECTED_SEARCH_PARAM_NAME = 'r'
 
 const API_VERSION_RELOAD_PARAM_NAME = 'api_version_reloaded'
 
-const EXPECTED_API_VERSION =
+const EXPECTED_API_VERSION = parseInt(
   document
     .querySelector('meta[name="x-api-version"]')
-    ?.getAttribute('content') ?? '0'
+    ?.getAttribute('content') ?? '0',
+  10
+)
 
 /**
  * Navigates to the current URL with `api_version_reloaded=<currentApiVersion>`
  * appended, using `location.replace` so the pre-reload entry is not kept in
  * browser history.
- * 
+ *
  * Returns early without navigating if:
- * 
+ *
  * - the x-plausible-version response header is not present
  * - the expected version matches the actual version
  * - the version is already present in search params
- * 
+ *
  * The latter prevents an infinite reload loop when the versions are
  * permanently out of sync.
  *
@@ -48,31 +50,35 @@ export function maybeReloadForApiVersion(
 ) {
   const currentApiVersion = getCurrentApiVersion(responseHeaders)
   const params = new URLSearchParams(windowLocation.search)
-  
-  if (!currentApiVersion || currentApiVersion === EXPECTED_API_VERSION) {
-    return
-  }
 
-  if (params.get(API_VERSION_RELOAD_PARAM_NAME) === currentApiVersion) {
+  if (
+    currentApiVersion === null ||
+    currentApiVersion <= EXPECTED_API_VERSION ||
+    params.get(API_VERSION_RELOAD_PARAM_NAME) === currentApiVersion.toString()
+  ) {
     return
   }
 
   console.warn('API version mismatch detected, reloading...')
 
-  const newSearch = searchWithApiVersionReload(windowLocation.search, currentApiVersion)
+  const newSearch = searchWithApiVersionReload(
+    windowLocation.search,
+    currentApiVersion.toString()
+  )
   windowLocation.replace(
     `${windowLocation.pathname}${newSearch}${windowLocation.hash}`
   )
 }
 
-function getCurrentApiVersion(responseHeaders: Headers) {
-  return responseHeaders?.get('x-api-version')
+function getCurrentApiVersion(responseHeaders: Headers): number | null {
+  const versionString = responseHeaders?.get('x-api-version')
+  return versionString ? parseInt(versionString, 10) : null
 }
 
 function searchWithApiVersionReload(search: string, value: string): string {
   const key = API_VERSION_RELOAD_PARAM_NAME
   const param = `${key}=${value}`
-  
+
   if (new URLSearchParams(search).has(key)) {
     return search.replace(new RegExp(`([?&])${key}=[^&]*`), `$1${param}`)
   }

--- a/assets/js/dashboard/util/url-search-params.ts
+++ b/assets/js/dashboard/util/url-search-params.ts
@@ -21,43 +21,58 @@ const REDIRECTED_SEARCH_PARAM_NAME = 'r'
 
 const API_VERSION_RELOAD_PARAM_NAME = 'api_version_reloaded'
 
+const EXPECTED_API_VERSION =
+  document
+    .querySelector('meta[name="x-api-version"]')
+    ?.getAttribute('content') ?? '0'
+
 /**
  * Navigates to the current URL with `api_version_reloaded=<currentApiVersion>`
  * appended, using `location.replace` so the pre-reload entry is not kept in
- * browser history. Returns early without navigating when the param is already
- * present, which prevents an infinite reload loop when the versions are
+ * browser history.
+ * 
+ * Returns early without navigating if:
+ * 
+ * - the x-plausible-version response header is not present
+ * - the expected version matches the actual version
+ * - the version is already present in search params
+ * 
+ * The latter prevents an infinite reload loop when the versions are
  * permanently out of sync.
  *
  * BE: lib/plausible_web/plugs/internal_stats_api_version.ex
  */
 export function maybeReloadForApiVersion(
   windowLocation: Location,
-  currentApiVersion: string
+  responseHeaders: Headers
 ) {
+  const currentApiVersion = getCurrentApiVersion(responseHeaders)
   const params = new URLSearchParams(windowLocation.search)
+  
+  if (!currentApiVersion || currentApiVersion === EXPECTED_API_VERSION) {
+    return
+  }
 
   if (params.get(API_VERSION_RELOAD_PARAM_NAME) === currentApiVersion) {
     return
   }
 
-  const newSearch = addOrReplaceSearch(
-    windowLocation.search,
-    API_VERSION_RELOAD_PARAM_NAME,
-    currentApiVersion
-  )
-
   console.warn('API version mismatch detected, reloading...')
+
+  const newSearch = searchWithApiVersionReload(windowLocation.search, currentApiVersion)
   windowLocation.replace(
     `${windowLocation.pathname}${newSearch}${windowLocation.hash}`
   )
 }
 
-function addOrReplaceSearch(
-  search: string,
-  key: string,
-  value: string
-): string {
+function getCurrentApiVersion(responseHeaders: Headers) {
+  return responseHeaders?.get('x-api-version')
+}
+
+function searchWithApiVersionReload(search: string, value: string): string {
+  const key = API_VERSION_RELOAD_PARAM_NAME
   const param = `${key}=${value}`
+  
   if (new URLSearchParams(search).has(key)) {
     return search.replace(new RegExp(`([?&])${key}=[^&]*`), `$1${param}`)
   }

--- a/assets/js/dashboard/util/url-search-params.ts
+++ b/assets/js/dashboard/util/url-search-params.ts
@@ -76,13 +76,10 @@ function getCurrentApiVersion(responseHeaders: Headers): number | null {
 }
 
 function searchWithApiVersionReload(search: string, value: string): string {
-  const key = API_VERSION_RELOAD_PARAM_NAME
-  const param = `${key}=${value}`
-
-  if (new URLSearchParams(search).has(key)) {
-    return search.replace(new RegExp(`([?&])${key}=[^&]*`), `$1${param}`)
-  }
-  return search ? `${search}&${param}` : `?${param}`
+  return stringifySearch({
+    ...parseSearch(search),
+    [API_VERSION_RELOAD_PARAM_NAME]: value
+  })
 }
 
 /**

--- a/lib/plausible/application.ex
+++ b/lib/plausible/application.ex
@@ -31,6 +31,7 @@ defmodule Plausible.Application do
     children =
       [
         cluster,
+        Plausible.InternalStatsApiVersion,
         {PartitionSupervisor,
          child_spec: Task.Supervisor, name: Plausible.UserAgentParseTaskSupervisor},
         Plausible.Session.BalancerSupervisor,

--- a/lib/plausible/internal_stats_api_version.ex
+++ b/lib/plausible/internal_stats_api_version.ex
@@ -23,7 +23,8 @@ defmodule Plausible.InternalStatsApiVersion do
 
   @spec effective_version() :: non_neg_integer()
   def effective_version() do
-    GenServer.call(__MODULE__, :get)
+    [{:version, v}] = :ets.lookup(__MODULE__, :version)
+    v
   end
 
   def start_link(opts \\ []) do
@@ -32,24 +33,34 @@ defmodule Plausible.InternalStatsApiVersion do
 
   @impl GenServer
   def init(_opts) do
-    {:ok, @api_version, {:continue, :fetch}}
+    __MODULE__ =
+      :ets.new(__MODULE__, [
+        :named_table,
+        :set,
+        :protected,
+        {:read_concurrency, true}
+      ])
+
+    # Use 0 as a placeholder version until the first multicall completes.
+    # The FE only reloads when the received version exceeds its compiled-in
+    # expectation, so 0 is always safe regardless of current @api_version.
+    :ets.insert(__MODULE__, {:version, 0})
+
+    {:ok, nil, {:continue, :fetch}}
   end
 
   @impl GenServer
-  def handle_call(:get, _from, version) do
-    {:reply, version, version}
-  end
-
-  @impl GenServer
-  def handle_continue(:fetch, _version) do
+  def handle_continue(:fetch, state) do
     Process.send_after(self(), :refresh, @refresh_interval)
-    {:noreply, fetch_cluster_min()}
+    :ets.insert(__MODULE__, {:version, fetch_cluster_min()})
+    {:noreply, state}
   end
 
   @impl GenServer
-  def handle_info(:refresh, _version) do
+  def handle_info(:refresh, state) do
     Process.send_after(self(), :refresh, @refresh_interval)
-    {:noreply, fetch_cluster_min()}
+    :ets.insert(__MODULE__, {:version, fetch_cluster_min()})
+    {:noreply, state}
   end
 
   defp fetch_cluster_min() do

--- a/lib/plausible/internal_stats_api_version.ex
+++ b/lib/plausible/internal_stats_api_version.ex
@@ -14,7 +14,7 @@ defmodule Plausible.InternalStatsApiVersion do
   """
   use GenServer
 
-  @api_version 0
+  @api_version 1
 
   @refresh_interval :timer.seconds(30)
 

--- a/lib/plausible/internal_stats_api_version.ex
+++ b/lib/plausible/internal_stats_api_version.ex
@@ -1,0 +1,66 @@
+defmodule Plausible.InternalStatsApiVersion do
+  @moduledoc """
+  Tracks the effective internal stats API version across the cluster.
+
+  Increment `@api_version` when deploying a change that breaks dashboards
+  already loaded from a previous deployment. The FE, upon detecting a
+  version mismatch, reloads the page to fetch the new dashboard code.
+
+  Each app node has `@api_version` compiled in. The effective version served
+  to clients is the minimum across all connected nodes, fetched via
+  `:rpc.multicall` and refreshed every 30 seconds. This means the version
+  only advances once every node in a rolling deploy is running the new code,
+  avoiding repeated dashboard reloads during the deployment window.
+  """
+  use GenServer
+
+  @api_version 0
+
+  @refresh_interval :timer.seconds(30)
+
+  @spec api_version() :: non_neg_integer()
+  def api_version, do: @api_version
+
+  @spec effective_version() :: non_neg_integer()
+  def effective_version() do
+    GenServer.call(__MODULE__, :get)
+  end
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    {:ok, @api_version, {:continue, :fetch}}
+  end
+
+  @impl GenServer
+  def handle_call(:get, _from, version) do
+    {:reply, version, version}
+  end
+
+  @impl GenServer
+  def handle_continue(:fetch, _version) do
+    Process.send_after(self(), :refresh, @refresh_interval)
+    {:noreply, fetch_cluster_min()}
+  end
+
+  @impl GenServer
+  def handle_info(:refresh, _version) do
+    Process.send_after(self(), :refresh, @refresh_interval)
+    {:noreply, fetch_cluster_min()}
+  end
+
+  defp fetch_cluster_min() do
+    {results, _bad_nodes} = :rpc.multicall(__MODULE__, :api_version, [], :timer.seconds(5))
+    cluster_min(results)
+  end
+
+  def cluster_min(results) do
+    case Enum.filter(results, &is_integer/1) do
+      [] -> @api_version
+      versions -> Enum.min(versions)
+    end
+  end
+end

--- a/lib/plausible/internal_stats_api_version.ex
+++ b/lib/plausible/internal_stats_api_version.ex
@@ -14,7 +14,7 @@ defmodule Plausible.InternalStatsApiVersion do
   """
   use GenServer
 
-  @api_version 1
+  @api_version 0
 
   @refresh_interval :timer.seconds(30)
 

--- a/lib/plausible/internal_stats_api_version.ex
+++ b/lib/plausible/internal_stats_api_version.ex
@@ -23,8 +23,13 @@ defmodule Plausible.InternalStatsApiVersion do
 
   @spec effective_version() :: non_neg_integer()
   def effective_version() do
-    [{:version, v}] = :ets.lookup(__MODULE__, :version)
-    v
+    # Use 0 as a placeholder version until the first multicall completes.
+    # The FE only reloads when the received version exceeds its compiled-in
+    # expectation, so 0 is always safe regardless of current @api_version.
+    case :ets.lookup(__MODULE__, :version) do
+      [{:version, v}] -> v
+      _ -> 0
+    end
   end
 
   def start_link(opts \\ []) do
@@ -40,11 +45,6 @@ defmodule Plausible.InternalStatsApiVersion do
         :protected,
         {:read_concurrency, true}
       ])
-
-    # Use 0 as a placeholder version until the first multicall completes.
-    # The FE only reloads when the received version exceeds its compiled-in
-    # expectation, so 0 is always safe regardless of current @api_version.
-    :ets.insert(__MODULE__, {:version, 0})
 
     {:ok, nil, {:continue, :fetch}}
   end

--- a/lib/plausible_web/plugs/internal_stats_api_version.ex
+++ b/lib/plausible_web/plugs/internal_stats_api_version.ex
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.Plugs.InternalStatsApiVersion do
   @impl true
   def init(opts), do: opts
 
-  @api_version "1"
+  @api_version "0"
 
   def api_version, do: @api_version
 

--- a/lib/plausible_web/plugs/internal_stats_api_version.ex
+++ b/lib/plausible_web/plugs/internal_stats_api_version.ex
@@ -13,7 +13,7 @@ defmodule PlausibleWeb.Plugs.InternalStatsApiVersion do
   @impl true
   def init(opts), do: opts
 
-  @api_version "0"
+  @api_version "1"
 
   def api_version, do: @api_version
 

--- a/lib/plausible_web/plugs/internal_stats_api_version.ex
+++ b/lib/plausible_web/plugs/internal_stats_api_version.ex
@@ -15,6 +15,8 @@ defmodule PlausibleWeb.Plugs.InternalStatsApiVersion do
 
   @api_version "0"
 
+  def api_version, do: @api_version
+
   @impl true
   def call(conn, _opts \\ nil) do
     put_resp_header(conn, "x-api-version", @api_version)

--- a/lib/plausible_web/plugs/internal_stats_api_version.ex
+++ b/lib/plausible_web/plugs/internal_stats_api_version.ex
@@ -1,11 +1,8 @@
 defmodule PlausibleWeb.Plugs.InternalStatsApiVersion do
   @moduledoc """
-  A plug that adds the `x-api-version` response header. The goal is to make
-  it easier to deploy changes to the dashboard where the previous FE state
-  is incompatible with the new BE (e.g. removing a stats endpoint, because
-  the new FE switches to a new one). Increment it manually when introducing
-  such changes, so that the frontend could detect the version mismatch and
-  trigger a page reload.
+  Adds the `x-api-version` response header to all internal
+  stats API responses. See `Plausible.InternalStatsApiVersion`
+  for version tracking and rollout logic.
   """
   @behaviour Plug
   import Plug.Conn
@@ -13,12 +10,9 @@ defmodule PlausibleWeb.Plugs.InternalStatsApiVersion do
   @impl true
   def init(opts), do: opts
 
-  @api_version "0"
-
-  def api_version, do: @api_version
-
   @impl true
-  def call(conn, _opts \\ nil) do
-    put_resp_header(conn, "x-api-version", @api_version)
+  def call(conn, _opts) do
+    version = Plausible.InternalStatsApiVersion.effective_version()
+    put_resp_header(conn, "x-api-version", to_string(version))
   end
 end

--- a/lib/plausible_web/plugs/internal_stats_api_version.ex
+++ b/lib/plausible_web/plugs/internal_stats_api_version.ex
@@ -1,0 +1,22 @@
+defmodule PlausibleWeb.Plugs.InternalStatsApiVersion do
+  @moduledoc """
+  A plug that adds the `x-api-version` response header. The goal is to make
+  it easier to deploy changes to the dashboard where the previous FE state
+  is incompatible with the new BE (e.g. removing a stats endpoint, because
+  the new FE switches to a new one). Increment it manually when introducing
+  such changes, so that the frontend could detect the version mismatch and
+  trigger a page reload.
+  """
+  @behaviour Plug
+  import Plug.Conn
+
+  @impl true
+  def init(opts), do: opts
+
+  @api_version "0"
+
+  @impl true
+  def call(conn, _opts \\ nil) do
+    put_resp_header(conn, "x-api-version", @api_version)
+  end
+end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -74,6 +74,7 @@ defmodule PlausibleWeb.Router do
     plug PlausibleWeb.AuthPlug
     plug PlausibleWeb.Plugs.AuthorizeSiteAccess
     plug PlausibleWeb.Plugs.NoRobots
+    plug PlausibleWeb.Plugs.InternalStatsApiVersion
   end
 
   pipeline :docs_stats_api do

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -15,7 +15,7 @@
     <meta name="robots" content={@conn.private.robots} />
     <meta
       name="x-api-version"
-      content={PlausibleWeb.Plugs.InternalStatsApiVersion.api_version()}
+      content={Plausible.InternalStatsApiVersion.api_version()}
     />
 
     <PlausibleWeb.Components.Layout.favicon conn={@conn} />

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -13,6 +13,10 @@
       <meta name="websocket-url" content={websocket_url()} />
     <% end %>
     <meta name="robots" content={@conn.private.robots} />
+    <meta
+      name="x-api-version"
+      content={PlausibleWeb.Plugs.InternalStatsApiVersion.api_version()}
+    />
 
     <PlausibleWeb.Components.Layout.favicon conn={@conn} />
 

--- a/test/plausible/internal_stats_api_version_test.exs
+++ b/test/plausible/internal_stats_api_version_test.exs
@@ -1,0 +1,39 @@
+defmodule Plausible.InternalStatsApiVersionTest do
+  use ExUnit.Case, async: true
+
+  alias Plausible.InternalStatsApiVersion
+
+  describe "api_version/0" do
+    test "returns a non-negative integer" do
+      assert is_integer(InternalStatsApiVersion.api_version())
+      assert InternalStatsApiVersion.api_version() >= 0
+    end
+  end
+
+  describe "effective_version/0" do
+    test "equals api_version in single-node setup" do
+      assert InternalStatsApiVersion.effective_version() ==
+               InternalStatsApiVersion.api_version()
+    end
+  end
+
+  describe "cluster_min/1" do
+    test "returns the minimum integer from results" do
+      assert InternalStatsApiVersion.cluster_min([3, 2, 2]) == 2
+    end
+
+    test "ignores non-integer results" do
+      assert InternalStatsApiVersion.cluster_min([{:badrpc, :timeout}, 2, 3]) == 2
+    end
+
+    test "falls back to local api_version when all results are non-integer" do
+      assert InternalStatsApiVersion.cluster_min([{:badrpc, :timeout}]) ==
+               InternalStatsApiVersion.api_version()
+    end
+
+    test "falls back to local api_version for empty results" do
+      assert InternalStatsApiVersion.cluster_min([]) ==
+               InternalStatsApiVersion.api_version()
+    end
+  end
+end

--- a/test/plausible_web/controllers/api/stats_controller/query_controller_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/query_controller_test.exs
@@ -126,7 +126,7 @@ defmodule PlausibleWeb.Api.InternalController.QueryTest do
         })
 
       assert get_resp_header(conn, "x-api-version") == [
-               PlausibleWeb.Plugs.InternalStatsApiVersion.api_version()
+               to_string(Plausible.InternalStatsApiVersion.effective_version())
              ]
     end
 

--- a/test/plausible_web/controllers/api/stats_controller/query_controller_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/query_controller_test.exs
@@ -117,6 +117,19 @@ defmodule PlausibleWeb.Api.InternalController.QueryTest do
              }
     end
 
+    test "adds x-api-version response header", %{conn: conn, site: site} do
+      conn =
+        post(conn, "/api/stats/#{URI.encode(site.domain)}/query", %{
+          "metrics" => ["pageviews"],
+          "date_range" => "all",
+          "filters" => []
+        })
+
+      assert get_resp_header(conn, "x-api-version") == [
+               PlausibleWeb.Plugs.InternalStatsApiVersion.api_version()
+             ]
+    end
+
     test "returns aggregated metrics", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, user_id: 5, timestamp: ~N[2021-01-01 00:00:00]),

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -37,6 +37,11 @@ defmodule PlausibleWeb.StatsControllerTest do
                |> find("meta[name=robots]")
                |> text_of_attr("content")
 
+      assert PlausibleWeb.Plugs.InternalStatsApiVersion.api_version() ==
+               resp
+               |> find("meta[name=x-api-version]")
+               |> text_of_attr("content")
+
       assert text_of_element(resp, "title") == "Plausible · #{site.domain}"
     end
 

--- a/test/plausible_web/controllers/stats_controller_test.exs
+++ b/test/plausible_web/controllers/stats_controller_test.exs
@@ -37,7 +37,7 @@ defmodule PlausibleWeb.StatsControllerTest do
                |> find("meta[name=robots]")
                |> text_of_attr("content")
 
-      assert PlausibleWeb.Plugs.InternalStatsApiVersion.api_version() ==
+      assert to_string(Plausible.InternalStatsApiVersion.api_version()) ==
                resp
                |> find("meta[name=x-api-version]")
                |> text_of_attr("content")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,6 +3,7 @@ if not Enum.empty?(Path.wildcard("lib/**/*_test.exs")) do
 end
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)
+Plausible.InternalStatsApiVersion.start_link()
 
 if Mix.env() != :e2e_test do
   Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,7 +3,6 @@ if not Enum.empty?(Path.wildcard("lib/**/*_test.exs")) do
 end
 
 {:ok, _} = Application.ensure_all_started(:ex_machina)
-Plausible.InternalStatsApiVersion.start_link()
 
 if Mix.env() != :e2e_test do
   Mox.defmock(Plausible.HTTPClient.Mock, for: Plausible.HTTPClient.Interface)


### PR DESCRIPTION
### Changes

Resurrecting what was started in https://github.com/plausible/analytics/pull/5362.

Adds a new plug in the `:internal_stats_api` pipeline that adds an `x-api-version` response header. Incrementing the value will trigger an automatic dashboard refresh.

In order to not trigger repeated dashboard reloads during deployments, the `x-api-version` header gets the value of the minimum version across the cluster. Each node has `@api_version` compiled in. That same value gets passed into the FE via a `<meta>` tag. Without the meta tag in the DOM, the frontend defaults to `EXPECTED_API_VERSION = 0`, which:

* keeps the FE test suite working without having to worry about the api version
* makes sure that dashboard does not refresh when this PR itself is deployed

Whenever the FE version gets ahead of the BE (i.e. load the dashboard from a freshly deployed node while some app servers are still on the old version), we do not refresh the dashboard. Done by comparing version integers. 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
