### PR TITLE
Fix issue with dropdown interactions in e2e tests

### DIFF
--- a/e2e/tests/dashboard/behaviours.spec.ts
+++ b/e2e/tests/dashboard/behaviours.spec.ts
@@ -16,6 +16,7 @@ import {
   rowLink,
   expectMetricValues,
   dropdown,
+  expectDropdownClosed,
   detailsLink,
   modal,
   closeModalButton,
@@ -792,6 +793,7 @@ test('props breakdown', async ({ page, request }) => {
   })
 
   await test.step('loading more', async () => {
+    await expectDropdownClosed(report)
     await propsTabButton.click()
     const showMoreButton = dropdown(report).getByRole('button', {
       name: 'Show 1 more'
@@ -938,8 +940,14 @@ test('funnels', async ({ page, request }) => {
   })
 
   await test.step('loading more', async () => {
+    await expectDropdownClosed(report)
     await funnelsTabButton.click()
-    await dropdown(report).getByRole('button', { name: 'Show 1 more' }).click()
+    const showMoreButton = dropdown(report).getByRole('button', {
+      name: 'Show 1 more'
+    })
+    await showMoreButton.click()
+    await expect(showMoreButton).toBeHidden()
+    await expect(dropdown(report).getByRole('button')).toHaveCount(11)
     await dropdown(report)
       .getByRole('button', { name: 'Shopping 1 Funnel' })
       .click()
@@ -948,6 +956,7 @@ test('funnels', async ({ page, request }) => {
   })
 
   await test.step('searching', async () => {
+    await expectDropdownClosed(report)
     await funnelsTabButton.click()
     await searchInput(report).fill('Shopping 1')
 

--- a/e2e/tests/test-utils.ts
+++ b/e2e/tests/test-utils.ts
@@ -63,6 +63,12 @@ export const expectMetricValues = async (
 export const dropdown = (report: Locator) =>
   report.getByTestId('dropdown-items')
 
+// Needed before opening dropdown again right after it closes (usually, when picking an item).
+// There's a leave transition for the dropdown and interacting with the dropdown opener
+// during the transition may mean that the dropdown doesn't actually open.
+export const expectDropdownClosed = async (report: Locator) =>
+  expect(dropdown(report)).toHaveCount(0)
+
 export const searchInput = (report: Locator) =>
   report.getByTestId('search-input')
 


### PR DESCRIPTION
### Changes

In local development, I've noticed two tests in behaviours.spec.ts being flaky. This should fix it.