### PR TITLE
Fix report out of view issue in e2e tests

### DIFF
--- a/assets/js/dashboard/stats/reports/report-layout.tsx
+++ b/assets/js/dashboard/stats/reports/report-layout.tsx
@@ -19,6 +19,7 @@ export function ReportLayout({
       )}
     >
       {children}
+      <div data-testid="report-end"></div>
     </div>
   )
 }

--- a/e2e/tests/dashboard/behaviours.spec.ts
+++ b/e2e/tests/dashboard/behaviours.spec.ts
@@ -171,7 +171,7 @@ test('special goals', async ({ page, request }, testInfo) => {
 
   const goalsTabButton = tabButton(report, 'Goals')
 
-  await goalsTabButton.scrollIntoViewIfNeeded()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
   await expect(goalsTabButton).toHaveAttribute('data-active', 'true')
 
   await expectHeaders(report, ['Goal', 'Uniques', 'Total', 'CR'])
@@ -589,7 +589,7 @@ test('goals breakdown', async ({ page, request }) => {
   const goalsTabButton = tabButton(report, 'Goals')
 
   await test.step('listing all goals', async () => {
-    await goalsTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(goalsTabButton).toHaveAttribute('data-active', 'true')
 
     await expectHeaders(report, [
@@ -670,7 +670,7 @@ test('goals breakdown', async ({ page, request }) => {
       waitUntil: 'commit'
     })
 
-    await goalsTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(goalsTabButton).toHaveAttribute('data-active', 'true')
 
     await expectHeaders(report, ['Goal', 'Uniques', 'Total', 'CR'])
@@ -773,8 +773,8 @@ test('props breakdown', async ({ page, request }) => {
   const propsTabButton = tabButtonWithDropdown(report, 'Properties')
 
   await test.step('listing props', async () => {
-    await propsTabButton.scrollIntoViewIfNeeded()
     await propsTabButton.click()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await dropdown(report)
       .getByRole('button', { name: 'browser_language' })
       .click()
@@ -921,8 +921,8 @@ test('funnels', async ({ page, request }) => {
   const funnelsTabButton = tabButtonWithDropdown(report, 'Funnels')
 
   await test.step('rendering funnels', async () => {
-    await funnelsTabButton.scrollIntoViewIfNeeded()
     await funnelsTabButton.click()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await dropdown(report)
       .getByRole('button', { name: 'Shopping 11 Funnel' })
       .click()

--- a/e2e/tests/dashboard/breakdowns.spec.ts
+++ b/e2e/tests/dashboard/breakdowns.spec.ts
@@ -55,7 +55,7 @@ test('sources breakdown', async ({ page, request }) => {
 
   await test.step('sources tab', async () => {
     const sourcesTabButton = tabButton(report, 'Sources')
-    await sourcesTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(sourcesTabButton).toHaveAttribute('data-active', 'true')
 
     await expectHeaders(report, ['Source', 'Visitors'])
@@ -462,7 +462,7 @@ test('sources breakdown - search terms failure modes', async ({
       waitUntil: 'commit'
     })
 
-    await searchTermsTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(searchTermsTabButton).toHaveAttribute('data-active', 'true')
 
     await expect(report.getByText('No data yet')).toBeVisible()
@@ -476,7 +476,7 @@ test('sources breakdown - search terms failure modes', async ({
       }
     )
 
-    await searchTermsTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(searchTermsTabButton).toHaveAttribute('data-active', 'true')
 
     await expect(
@@ -496,7 +496,7 @@ test('sources breakdown - search terms failure modes', async ({
       }
     )
 
-    await searchTermsTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(searchTermsTabButton).toHaveAttribute('data-active', 'true')
 
     await expect(
@@ -528,7 +528,7 @@ test('pages breakdown', async ({ page, request }) => {
 
   await test.step('top pages tab', async () => {
     const pagesTabButton = tabButton(report, 'Top pages')
-    await pagesTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(pagesTabButton).toHaveAttribute('data-active', 'true')
 
     await expectHeaders(report, ['Page', 'Visitors'])
@@ -664,7 +664,7 @@ test('pages breakdown modal', async ({ page, request }) => {
   const report = page.getByTestId('report-pages')
 
   const pagesTabButton = tabButton(report, 'Top pages')
-  await pagesTabButton.scrollIntoViewIfNeeded()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
   await expect(pagesTabButton).toHaveAttribute('data-active', 'true')
 
   await detailsLink(report).click()
@@ -824,7 +824,7 @@ test('pages breakdown with a pageview goal filter applied', async ({
     })
 
     const pagesTabButton = tabButton(report, 'Conversion pages')
-    await pagesTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(pagesTabButton).toHaveAttribute('data-active', 'true')
 
     await expectHeaders(report, ['Page', 'Conversions', 'CR'])
@@ -861,7 +861,7 @@ test('pages breakdown with a pageview goal filter applied', async ({
     })
 
     const pagesTabButton = tabButton(report, 'Conversion pages')
-    await pagesTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(pagesTabButton).toHaveAttribute('data-active', 'true')
 
     await expectHeaders(report, ['Page', 'Conversions', 'CR'])
@@ -939,7 +939,7 @@ test('locations breakdown', async ({ page, request }) => {
 
   await test.step('map tab', async () => {
     const mapTabButton = tabButton(report, 'Map')
-    await mapTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(mapTabButton).toHaveAttribute('data-active', 'true')
 
     // NOTE: We only check that the map is there
@@ -1147,6 +1147,7 @@ test('locations breakdown with a revenue goal filter applied', async ({
 
   await test.step('countries report shows conversions for revenue goal', async () => {
     await tabButton(report, 'Countries').click()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
     await expectHeaders(report, ['Country', 'Conversions', 'CR'])
 
@@ -1312,7 +1313,7 @@ test('devices breakdown', async ({ page, request }) => {
   const browsersTabButton = tabButton(report, 'Browsers')
 
   await test.step('browsers tab', async () => {
-    await browsersTabButton.scrollIntoViewIfNeeded()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
     await expect(browsersTabButton).toHaveAttribute('data-active', 'true')
 
     await expectHeaders(report, ['Browser', 'Visitors'])
@@ -1558,6 +1559,7 @@ test('devices breakdown with a revenue goal filter applied', async ({
 
   await test.step('browsers report shows conversions for revenue goal', async () => {
     await tabButton(report, 'Browsers').click()
+    await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
     await expectHeaders(report, ['Browser', 'Conversions', 'CR'])
 

--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -26,8 +26,8 @@ test('load user journey', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -85,8 +85,8 @@ test('load user journey and switch to a period with no events without waiting fo
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -121,8 +121,8 @@ test('load user journey and switch to a period with no events', async ({
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -204,8 +204,8 @@ test('explore a 3-step funnel', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -358,8 +358,8 @@ test('select entries in a 1-step journey', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -599,8 +599,8 @@ test('select entries in a 3-step journey', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -745,8 +745,8 @@ test('explore journey hitting 20 step limit', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -906,8 +906,8 @@ test('explore from end point', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -1070,8 +1070,8 @@ test('change filters during a 3-step journey', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -1351,8 +1351,8 @@ test('render various types of entries', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'
@@ -1415,8 +1415,8 @@ test('load more suggestions', async ({ page, request }) => {
 
   await page.goto('/' + domain, { waitUntil: 'commit' })
 
-  await explorationTabButton.scrollIntoViewIfNeeded()
   await explorationTabButton.click()
+  await report.getByTestId('report-end').scrollIntoViewIfNeeded()
 
   await expect(report.getByTestId('exploration-title')).toHaveText(
     'Explore user journeys'


### PR DESCRIPTION
### Changes

There was some flakiness with tests of reports that are wrapped by LazyLoader. 
It's a component that enables the reports and the queries driving those reports only when the report is in view.
 
Scrolling the tab buttons into view occasionally scrolled the page exactly to the bottom of the tab buttons, so not a single px of the report itself was in view. Consequently, the report was never enabled, no queries were made and the assertions failed.

The fix is to scroll more, not just to the tab buttons, but a few px more. Rather than working with a certain px count, I decided to add an empty h=0 div to the bottom of each report that we can scroll to.

To click a button, it doesn't have to be in view, playwright scrolls to it automatically (https://playwright.dev/docs/input#mouse-click:~:text=scroll%20the%20element%20into%20view), so there's no harm done by changing the existing scrollIntoView calls.