### PR TITLE
Bugfix: sites ellipsis menu and allowed roles

### DIFF
--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -121,7 +121,15 @@ defmodule Plausible.Sites do
 
   @spec set_option(Auth.User.t(), Site.t(), atom(), any()) :: Site.UserPreference.t()
   def set_option(user, site, option, value) when option in Site.UserPreference.options() do
-    get_for_user!(user, site.domain)
+    get_for_user!(user, site.domain,
+      roles: [
+        :owner,
+        :admin,
+        :editor,
+        :viewer,
+        :billing
+      ]
+    )
 
     user
     |> Site.UserPreference.changeset(site, %{option => value})

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -573,7 +573,7 @@ defmodule PlausibleWeb.Live.Sites do
       </.unstyled_link>
 
       <div class="absolute right-1 top-3.5">
-        <.ellipsis_menu site={@site} can_manage?={List.first(@site.memberships).role != :viewer} />
+        <.ellipsis_menu site={@site} can_manage?={List.first(@site.memberships).role in [:owner, :admin, :editor]} />
       </div>
     </li>
     """

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -573,7 +573,10 @@ defmodule PlausibleWeb.Live.Sites do
       </.unstyled_link>
 
       <div class="absolute right-1 top-3.5">
-        <.ellipsis_menu site={@site} can_manage?={List.first(@site.memberships).role in [:owner, :admin, :editor]} />
+        <.ellipsis_menu
+          site={@site}
+          can_manage?={List.first(@site.memberships).role in [:owner, :admin, :editor]}
+        />
       </div>
     </li>
     """

--- a/test/plausible/sites_test.exs
+++ b/test/plausible/sites_test.exs
@@ -268,4 +268,29 @@ defmodule Plausible.SitesTest do
       assert Sites.get_for_user!(user, domain, include_consolidated?: true)
     end
   end
+
+  describe "toggle_pin/2" do
+    test "billing role team member can pin a site" do
+      owner = new_user()
+      site = new_site(owner: owner)
+      team = site.team |> Plausible.Teams.complete_setup()
+      billing_user = add_member(team, role: :billing)
+
+      assert {:ok, preference} = Sites.toggle_pin(billing_user, site)
+      assert preference.pinned_at
+    end
+
+    test "billing role team member can unpin a site" do
+      owner = new_user()
+      site = new_site(owner: owner)
+      team = site.team |> Plausible.Teams.complete_setup()
+      billing_user = add_member(team, role: :billing)
+
+      {:ok, pref} = Sites.toggle_pin(billing_user, site)
+      pinned_site = %{site | pinned_at: pref.pinned_at}
+
+      assert {:ok, preference} = Sites.toggle_pin(billing_user, pinned_site)
+      refute preference.pinned_at
+    end
+  end
 end

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -705,6 +705,41 @@ defmodule PlausibleWeb.Live.SitesTest do
                button_selector
              )
     end
+
+    test "billing role member can pin a site via the ellipsis menu", %{conn: conn, user: user} do
+      site = new_site(owner: user)
+      team = site.team |> Plausible.Teams.complete_setup()
+      billing_user = add_member(team, role: :billing)
+
+      {:ok, conn: conn} = log_in(%{user: billing_user, conn: conn})
+
+      {:ok, lv, _html} = live(conn, "/sites?__team=#{team.identifier}")
+
+      button_selector =
+        ~s/button[phx-value-domain="#{site.domain}"][data-test-id="ellipsis-menu-pin-item"]/
+
+      html = lv |> element(button_selector) |> render_click()
+
+      assert html =~ "Site pinned"
+    end
+
+    test "billing role member does not see Settings in the ellipsis menu", %{
+      conn: conn,
+      user: user
+    } do
+      site = new_site(owner: user)
+      team = site.team |> Plausible.Teams.complete_setup()
+      billing_user = add_member(team, role: :billing)
+
+      {:ok, conn: conn} = log_in(%{user: billing_user, conn: conn})
+
+      {:ok, _lv, html} = live(conn, "/sites?__team=#{team.identifier}")
+
+      settings_selector =
+        ~s|li[data-domain="#{site.domain}"] a[href$="/settings/general"]|
+
+      refute element_exists?(html, settings_selector)
+    end
   end
 
   describe "sort widget" do

--- a/test/plausible_web/live/sites_test.exs
+++ b/test/plausible_web/live/sites_test.exs
@@ -742,6 +742,43 @@ defmodule PlausibleWeb.Live.SitesTest do
     end
   end
 
+  describe "ellipsis menu settings visibility" do
+    @allowed_to_see_settings [:owner, :editor, :admin]
+    for role <- @allowed_to_see_settings do
+      test "#{role} can see settings", %{conn: conn, user: user} do
+        site = new_site(owner: user)
+        team = site.team |> Plausible.Teams.complete_setup()
+        member = add_member(team, role: unquote(role))
+
+        {:ok, conn: conn} = log_in(%{user: member, conn: conn})
+
+        {:ok, _lv, html} = live(conn, "/sites?__team=#{team.identifier}")
+
+        assert element_exists?(
+                 html,
+                 ~s|li[data-domain="#{site.domain}"] a[href$="/settings/general"]|
+               )
+      end
+    end
+
+    for role <- Plausible.Teams.Membership.roles() -- @allowed_to_see_settings do
+      test "#{role} can't see settings", %{conn: conn, user: user} do
+        site = new_site(owner: user)
+        team = site.team |> Plausible.Teams.complete_setup()
+        member = add_member(team, role: :viewer)
+
+        {:ok, conn: conn} = log_in(%{user: member, conn: conn})
+
+        {:ok, _lv, html} = live(conn, "/sites?__team=#{team.identifier}")
+
+        refute element_exists?(
+                 html,
+                 ~s|li[data-domain="#{site.domain}"] a[href$="/settings/general"]|
+               )
+      end
+    end
+  end
+
   describe "sort widget" do
     test "renders sort widget with default 'Most visitors' label", %{conn: conn, user: user} do
       new_site(owner: user)


### PR DESCRIPTION
Site settings should be only seen by editors, admins and owners.
The only option for billing users should be the capability of pinning sites via the ellipsis menu. Both were broken.