### PR TITLE
Improve team manegement UX for member removal and role change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Improve team member removal/team role change
 - Validate empty filter clauses list in Stats API v2
 - Fixed Stats API timeseries returning time buckets falling outside the queried range
 - Fixed issue with all non-interactive events being counted as interactive

--- a/lib/plausible_web/live/components/team.ex
+++ b/lib/plausible_web/live/components/team.ex
@@ -12,6 +12,7 @@ defmodule PlausibleWeb.Live.Components.Team do
   attr(:label, :string, default: nil)
   attr(:role, :atom, default: nil)
   attr(:my_role, :atom, required: true)
+  attr(:me?, :boolean, default: false)
   attr(:disabled, :boolean, default: false)
   attr(:remove_disabled, :boolean, default: false)
 
@@ -87,6 +88,7 @@ defmodule PlausibleWeb.Live.Components.Team do
                 role={:editor}
                 disabled={@disabled or @role == :editor}
                 dispatch_animation?={@role == :guest}
+                data-confirm={if @me?, do: lower_role_warning()}
               >
                 Create and view new sites
               </.role_item>
@@ -98,6 +100,7 @@ defmodule PlausibleWeb.Live.Components.Team do
                 role={:billing}
                 disabled={@disabled or @role == :billing}
                 dispatch_animation?={@role == :guest}
+                data-confirm={if @me?, do: lower_role_warning()}
               >
                 Manage subscription
               </.role_item>
@@ -109,6 +112,7 @@ defmodule PlausibleWeb.Live.Components.Team do
                 role={:viewer}
                 disabled={@disabled or @role == :viewer}
                 dispatch_animation?={@role == :guest}
+                data-confirm={if @me?, do: lower_role_warning()}
               >
                 View all sites under your team
               </.role_item>
@@ -184,5 +188,9 @@ defmodule PlausibleWeb.Live.Components.Team do
       </div>
     </.dropdown_item>
     """
+  end
+
+  defp lower_role_warning() do
+    "You're about to lower your own role. Some team management features will no longer be accessible to you, and you'll need to ask a team owner to restore your access. Do you want to continue?"
   end
 end

--- a/lib/plausible_web/live/components/team.ex
+++ b/lib/plausible_web/live/components/team.ex
@@ -125,6 +125,7 @@ defmodule PlausibleWeb.Live.Components.Team do
                 phx-click="remove-member"
                 phx-value-email={@user.email}
                 phx-value-name={@user.name}
+                data-confirm="Are you sure you want to remove this member from the team?"
               >
                 <div class={
                   not @remove_disabled &&

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -300,7 +300,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
 
       {{:ok, _}, :team_management} ->
         case Teams.Memberships.team_role(current_team, current_user) do
-          {:ok, role} when role in [:viewer, :billing] ->
+          {:ok, role} when role in [:viewer, :billing, :editor] ->
             redirect(socket,
               to: Routes.settings_path(socket, :team_general, __team: current_team.identifier)
             )

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -300,7 +300,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
 
       {{:ok, _}, :team_management} ->
         case Teams.Memberships.team_role(current_team, current_user) do
-          {:ok, :viewer} ->
+          {:ok, role} when role in [:viewer, :billing] ->
             redirect(socket,
               to: Routes.settings_path(socket, :team_general, __team: current_team.identifier)
             )

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -300,6 +300,11 @@ defmodule PlausibleWeb.Live.TeamManagement do
 
       {{:ok, _}, :team_management} ->
         case Teams.Memberships.team_role(current_team, current_user) do
+          {:ok, :viewer} ->
+            redirect(socket,
+              to: Routes.settings_path(socket, :team_general, __team: current_team.identifier)
+            )
+
           {:ok, _} ->
             reset(socket)
 

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -299,7 +299,13 @@ defmodule PlausibleWeb.Live.TeamManagement do
         )
 
       {{:ok, _}, :team_management} ->
-        reset(socket)
+        case Teams.Memberships.team_role(current_team, current_user) do
+          {:ok, _} ->
+            reset(socket)
+
+          {:error, :not_a_member} ->
+            redirect(socket, to: Routes.site_path(socket, :index, __team: "none"))
+        end
 
       {{:error, :permission_denied}, _} ->
         socket

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -122,6 +122,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
           user={%User{email: entry.email, name: entry.name}}
           role={entry.role}
           label={entry_label(entry, @current_user)}
+          me?={entry.id == @current_user.id}
           my_role={@my_role}
           remove_disabled={not Layout.removable?(@layout, email)}
           disabled={

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -436,24 +436,17 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_team_membership(member2, team, :billing)
     end
 
-    test "demoting owner to editor makes everything read-only", %{conn: conn, team: team} do
+    test "demotes self to editor, redirecting to team general", %{
+      conn: conn,
+      team: team
+    } do
       _owner2 = add_member(team, role: :owner)
 
       lv = get_liveview(conn)
 
       change_role(lv, 1, "editor")
 
-      html = render(lv)
-
-      options =
-        lv
-        |> render()
-        |> find("#{member_el()} a")
-
-      assert Enum.empty?(options)
-
-      assert attr_defined?(html, ~s|#team-layout-form input[name="input-email"]|, "readonly")
-      assert attr_defined?(html, ~s|#invite-member|, "disabled")
+      assert_redirect(lv, "/settings/team/general?__team=#{team.identifier}")
     end
   end
 

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -387,6 +387,20 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_team_membership(member2, team, :owner)
     end
 
+    test "remove member items carry data-confirm for both self and others", %{
+      conn: conn,
+      team: team,
+      user: user
+    } do
+      member2 = add_member(team, role: :owner)
+
+      lv = get_liveview(conn)
+      html = render(lv)
+
+      assert attr_defined?(html, "##{:erlang.phash2(user.email)}-remove", "data-confirm")
+      assert attr_defined?(html, "##{:erlang.phash2(member2.email)}-remove", "data-confirm")
+    end
+
     test "self-demotion role items carry data-confirm, others do not", %{
       conn: conn,
       team: team,

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -387,6 +387,34 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_team_membership(member2, team, :owner)
     end
 
+    test "self-demotion role items carry data-confirm, others do not", %{
+      conn: conn,
+      team: team,
+      user: user
+    } do
+      # Second owner is required so the current user's own dropdown is not disabled
+      member2 = add_member(team, role: :owner)
+
+      lv = get_liveview(conn)
+      html = render(lv)
+
+      my_hash = :erlang.phash2(user.email)
+      other_hash = :erlang.phash2(member2.email)
+
+      for role <- ~w(editor billing viewer) do
+        assert attr_defined?(html, "#option-#{my_hash}-#{role}", "data-confirm"),
+               "expected data-confirm on self #{role} item"
+
+        refute attr_defined?(html, "#option-#{other_hash}-#{role}", "data-confirm"),
+               "expected no data-confirm on other member #{role} item"
+      end
+
+      for role <- ~w(owner admin) do
+        refute attr_defined?(html, "#option-#{my_hash}-#{role}", "data-confirm"),
+               "expected no data-confirm on self #{role} item"
+      end
+    end
+
     test "removes self, redirecting away from team", %{conn: conn, team: team} do
       _owner2 = add_member(team, role: :owner)
 

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -436,6 +436,25 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_team_membership(member2, team, :billing)
     end
 
+    test "demoting owner to editor makes everything read-only", %{conn: conn, team: team} do
+      _owner2 = add_member(team, role: :owner)
+
+      lv = get_liveview(conn)
+
+      change_role(lv, 1, "editor")
+
+      html = render(lv)
+
+      options =
+        lv
+        |> render()
+        |> find("#{member_el()} a")
+
+      assert Enum.empty?(options)
+
+      assert attr_defined?(html, ~s|#team-layout-form input[name="input-email"]|, "readonly")
+      assert attr_defined?(html, ~s|#invite-member|, "disabled")
+    end
   end
 
   defp change_role(lv, index, role, main_selector \\ member_el()) do

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -387,6 +387,16 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_team_membership(member2, team, :owner)
     end
 
+    test "removes self, redirecting away from team", %{conn: conn, team: team} do
+      _owner2 = add_member(team, role: :owner)
+
+      lv = get_liveview(conn)
+
+      remove_member(lv, 1)
+
+      assert_redirect(lv, "/sites?__team=none")
+    end
+
     test "billing role is supported",
          %{
            conn: conn,

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -397,6 +397,19 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_redirect(lv, "/sites?__team=none")
     end
 
+    test "demotes self to viewer, redirecting to team general", %{
+      conn: conn,
+      team: team
+    } do
+      _owner2 = add_member(team, role: :owner)
+
+      lv = get_liveview(conn)
+
+      change_role(lv, 1, "viewer")
+
+      assert_redirect(lv, "/settings/team/general?__team=#{team.identifier}")
+    end
+
     test "billing role is supported",
          %{
            conn: conn,

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -397,6 +397,19 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_redirect(lv, "/sites?__team=none")
     end
 
+    test "demotes self to billing, redirecting to team general", %{
+      conn: conn,
+      team: team
+    } do
+      _owner2 = add_member(team, role: :owner)
+
+      lv = get_liveview(conn)
+
+      change_role(lv, 1, "billing")
+
+      assert_redirect(lv, "/settings/team/general?__team=#{team.identifier}")
+    end
+
     test "demotes self to viewer, redirecting to team general", %{
       conn: conn,
       team: team
@@ -423,25 +436,6 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
       assert_team_membership(member2, team, :billing)
     end
 
-    test "degrading owner to non-admin makes everything read-only", %{conn: conn, team: team} do
-      _owner2 = add_member(team, role: :owner)
-
-      lv = get_liveview(conn)
-
-      change_role(lv, 1, "billing")
-
-      html = render(lv)
-
-      options =
-        lv
-        |> render()
-        |> find("#{member_el()} a")
-
-      assert Enum.empty?(options)
-
-      assert attr_defined?(html, ~s|#team-layout-form input[name="input-email"]|, "readonly")
-      assert attr_defined?(html, ~s|#invite-member|, "disabled")
-    end
   end
 
   defp change_role(lv, index, role, main_selector \\ member_el()) do


### PR DESCRIPTION
### Changes

This fixes various issues within team management scope:
  - prompts the user with a confirmation dialog before demoting their own role
  - prompts the user with a confirmation dialog before removing any member entry
  - redirects to team general settings in case the user demoted their own role to either billing, editor or viewer
  - redirects to /sites with no team identifier in case the user removed themselves from the team

<img width="1519" height="1317" alt="image" src="https://github.com/user-attachments/assets/3cb3dea8-f081-4bf8-96ba-a24e1b2b9dcd" />

<img width="1167" height="953" alt="image" src="https://github.com/user-attachments/assets/43271f1f-506e-4568-b659-7b0298be322b" />


### Tests
- [x] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog
- [ ] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [x] This change does not need a documentation update

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
