### PR TITLE
Remove stale [DEV ONLY] delete site link

### DIFF
--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -651,15 +651,6 @@ defmodule PlausibleWeb.Live.Sites do
             />
             {if @site.pinned_at, do: "Unpin site", else: "Pin site"}
           </PrimaDropdown.dropdown_item>
-
-          <PrimaDropdown.dropdown_item
-            :if={Application.get_env(:plausible, :environment) == "dev" and Sites.regular?(@site)}
-            id={"#{@dropdown_id}-item-3"}
-            phx-click="delete-site"
-            phx-value-domain={@site.domain}
-          >
-            <Heroicons.trash class="size-4 text-red-600" /> [DEV ONLY] Quick delete
-          </PrimaDropdown.dropdown_item>
         </PrimaDropdown.dropdown_menu>
       </PrimaDropdown.dropdown>
     </div>


### PR DESCRIPTION
Not sure when this became inaccessible or what's the real use, but it doesn't work so let's get rid of it. Regular site delete is perfectly functional and for dev we can execute iex function calls.