### PR TITLE
Update auth pages visually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - Use ResizeObserver instead of polling in tracker for scroll depth. Removes forced reflows caused by the tracker script.
 - Update custom range datepicker styles
 - Improved site transfer UI
+- Redesigned authentication pages (register, sign in, 2FA, password reset, account activation)
 
 ### Fixed
 

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -87,14 +87,13 @@ export async function register({
   await page.getByLabel('Full name').fill(user.name)
   await page.getByLabel('Email').fill(user.email)
   await page.getByLabel('Password', { exact: true }).fill(user.password)
-  await page.getByLabel('Confirm password', { exact: true }).fill(user.password)
   await expect(
     page.getByRole('button', { name: 'Start my free trial' })
   ).toBeEnabled()
   await page.getByRole('button', { name: 'Start my free trial' }).click()
 
   await expect(
-    page.getByRole('heading', { name: 'Activate your account' })
+    page.getByRole('heading', { name: 'Check your email' })
   ).toBeVisible()
 
   const response = await request.get('/sent-emails-api/emails.json')

--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -124,11 +124,11 @@ export async function register({
 export async function login({ page, user }: { page: Page; user: User }) {
   await page.goto('/login', { waitUntil: 'commit' })
 
-  await expect(page.getByRole('button', { name: 'Log in' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
 
   await page.getByLabel('Email').fill(user.email)
   await page.getByLabel('Password').fill(user.password)
-  await page.getByRole('button', { name: 'Log in' }).click()
+  await page.getByRole('button', { name: 'Sign in' }).click()
 
   await expect(page.getByRole('button', { name: user.name })).toBeVisible()
 }

--- a/extra/lib/plausible_web/controllers/sso_controller.ex
+++ b/extra/lib/plausible_web/controllers/sso_controller.ex
@@ -24,7 +24,10 @@ defmodule PlausibleWeb.SSOController do
         redirect(conn, to: Routes.auth_path(conn, :login_form, return_to: params["return_to"]))
 
       _ ->
-        render(conn, "login_form.html", autosubmit: params["autosubmit"] != nil)
+        render_auth_page(conn, "login_form.html",
+          autosubmit: params["autosubmit"] != nil,
+          heading: "Sign in with SSO"
+        )
     end
   end
 
@@ -44,7 +47,10 @@ defmodule PlausibleWeb.SSOController do
     else
       {:error, :not_found} ->
         conn
-        |> put_flash(:login_error, "Wrong email.")
+        |> put_flash(
+          :login_error,
+          "We couldn't find a Single Sign-On account for that email."
+        )
         |> redirect(to: Routes.sso_path(conn, :login_form))
 
       {:error, {:rate_limit, _}} ->
@@ -59,7 +65,7 @@ defmodule PlausibleWeb.SSOController do
   end
 
   def provision_notice(conn, _params) do
-    render(conn, "provision_notice.html")
+    render_auth_page(conn, "provision_notice.html", heading: "Single Sign-On required")
   end
 
   def provision_issue(conn, params) do
@@ -73,7 +79,10 @@ defmodule PlausibleWeb.SSOController do
         _ -> :unknown
       end
 
-    render(conn, "provision_issue.html", issue: issue)
+    render_auth_page(conn, "provision_issue.html",
+      heading: "Single Sign-On required",
+      issue: issue
+    )
   end
 
   def saml_signin(conn, params) do

--- a/extra/lib/plausible_web/sso/fake_saml_adapter.ex
+++ b/extra/lib/plausible_web/sso/fake_saml_adapter.ex
@@ -56,7 +56,10 @@ defmodule PlausibleWeb.SSO.FakeSAMLAdapter do
 
       {:error, :not_found} ->
         conn
-        |> Phoenix.Controller.put_flash(:login_error, "Wrong email.")
+        |> Phoenix.Controller.put_flash(
+          :login_error,
+          "We couldn't find a Single Sign-On account for that email."
+        )
         |> Phoenix.Controller.redirect(
           to: Routes.sso_path(conn, :login_form, return_to: params["return_to"])
         )

--- a/extra/lib/plausible_web/sso/real_saml_adapter.ex
+++ b/extra/lib/plausible_web/sso/real_saml_adapter.ex
@@ -50,7 +50,10 @@ defmodule PlausibleWeb.SSO.RealSAMLAdapter do
 
       {:error, :not_found} ->
         conn
-        |> Phoenix.Controller.put_flash(:login_error, "Wrong email.")
+        |> Phoenix.Controller.put_flash(
+          :login_error,
+          "We couldn't find a Single Sign-On account for that email."
+        )
         |> Phoenix.Controller.redirect(
           to: Routes.sso_path(conn, :login_form, return_to: return_to)
         )
@@ -108,7 +111,11 @@ defmodule PlausibleWeb.SSO.RealSAMLAdapter do
       PlausibleWeb.UserAuth.log_in_user(conn, identity, cookie.return_to)
     else
       {:error, :not_found} ->
-        login_error(conn, cookie, "Wrong email")
+        login_error(
+          conn,
+          cookie,
+          "We couldn't find a Single Sign-On account for that email."
+        )
 
       {:error, reason} ->
         with {:ok, integration} <- SSO.get_integration(integration_id) do

--- a/extra/lib/plausible_web/templates/sso/login_form.html.heex
+++ b/extra/lib/plausible_web/templates/sso/login_form.html.heex
@@ -1,4 +1,4 @@
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+<.auth_container>
   <script :if={@autosubmit}>
     document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("sso-login-form").submit();
@@ -51,4 +51,4 @@
       </p>
     </div>
   </.form>
-</div>
+</.auth_container>

--- a/extra/lib/plausible_web/templates/sso/login_form.html.heex
+++ b/extra/lib/plausible_web/templates/sso/login_form.html.heex
@@ -1,52 +1,54 @@
-<.focus_box>
-  <:title>
-    {Phoenix.Flash.get(@flash, :login_title) || "Enter your Single Sign-On email"}
-  </:title>
-  <:subtitle>
-    <%= if Phoenix.Flash.get(@flash, :login_instructions) do %>
-      <p class="text-gray-500 mt-1 mb-2">
-        {Phoenix.Flash.get(@flash, :login_instructions)}
-      </p>
-    <% end %>
-  </:subtitle>
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
   <script :if={@autosubmit}>
     document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("sso-login-form").submit();
     });
   </script>
-  <.form :let={f} id="sso-login-form" for={@conn} action={Routes.sso_path(@conn, :login)}>
-    <div class="my-4 mt-8">
-      <.input
-        type="email"
-        autocomplete="username"
-        placeholder="user@example.com"
-        field={f[:email]}
-      />
+
+  <.form
+    :let={f}
+    id="sso-login-form"
+    for={@conn}
+    action={Routes.sso_path(@conn, :login)}
+    class="flex flex-col gap-y-6"
+  >
+    <div class="flex flex-col gap-y-2">
+      <label for={f[:email].id} class="text-sm font-semibold text-gray-800 dark:text-gray-200">
+        Email
+      </label>
+      <div>
+        <.input
+          type="email"
+          autocomplete="username"
+          placeholder="example@email.com"
+          field={f[:email]}
+          mt?={false}
+          autofocus="autofocus"
+        />
+      </div>
+      <p
+        :if={login_error = Phoenix.Flash.get(@flash, :login_error)}
+        class="text-xs text-red-500"
+      >
+        {login_error}
+      </p>
     </div>
 
-    <%= if login_error = Phoenix.Flash.get(@flash, :login_error) do %>
-      <div class="text-red-500 mt-4">{login_error}</div>
-    <% end %>
+    <input type="hidden" name="return_to" value={@conn.params["return_to"]} />
 
-    <.input type="hidden" field={f[:return_to]} />
+    <div class="flex flex-col gap-y-4">
+      <.button class="w-full" type="submit" mt?={false}>Sign in</.button>
 
-    <.button class="w-full" type="submit">Sign In</.button>
-  </.form>
-
-  <:footer>
-    <.focus_list>
-      <:item>
-        Have a standard account?
+      <p class="text-sm text-center text-gray-500 dark:text-gray-400">
         <.styled_link href={
           Routes.auth_path(@conn, :login_form,
             return_to: @conn.params["return_to"],
             prefer: "manual"
           )
         }>
-          Log in here
+          Use password instead
         </.styled_link>
-        instead.
-      </:item>
-    </.focus_list>
-  </:footer>
-</.focus_box>
+      </p>
+    </div>
+  </.form>
+</div>

--- a/extra/lib/plausible_web/templates/sso/provision_issue.html.heex
+++ b/extra/lib/plausible_web/templates/sso/provision_issue.html.heex
@@ -1,51 +1,36 @@
-<.focus_box>
-  <:title>
-    Single Sign-On enforcement
-  </:title>
-  <:subtitle>
-    The owner of <span :if={is_nil(@conn.assigns[:current_team])}>the team</span>
-    <span :if={@conn.assigns[:current_team]}>"{@conn.assigns[:current_team].name}"</span>
-    has turned off regular email and password logins.
-    To keep things secure and simple, you can only sign in using your organization's
-    Single Sign-On (SSO) system.
-  </:subtitle>
-
-  <p :if={@issue == :multiple_memberships} class="text-sm">
-    To access this team, you must first leave all other teams.
+<div class="w-full max-w-md mx-auto mt-6 pb-16 px-4 flex flex-col items-center gap-y-4 text-center text-base text-gray-500 dark:text-gray-400 text-pretty">
+  <p>
+    The owner of
+    <span :if={is_nil(@conn.assigns[:current_team])}>the team</span><span
+      :if={@conn.assigns[:current_team]}
+      class="font-semibold"
+    >"{@conn.assigns[:current_team].name}"</span>
+    has turned off email and password logins, so you can only sign in with your organization's Single Sign-On.
+    <span :if={@issue == :not_a_member}>
+      To access this team, you must be added as a team member first.
+    </span>
+    <span :if={@issue == :multiple_memberships}>
+      To access this team, you must leave all other teams first.
+    </span>
+    <span :if={@issue == :multiple_memberships_noforce}>
+      To sign in with SSO, you must leave all other teams first.
+    </span>
+    <span :if={@issue == :active_personal_team}>
+      To access this team, remove or transfer all sites under
+      <span class="font-semibold">"My Personal Sites"</span>
+      and cancel its subscription if active.
+    </span>
+    <span :if={@issue == :active_personal_team_noforce}>
+      To sign in with SSO, remove or transfer all sites under
+      <span class="font-semibold">"My Personal Sites"</span>
+      and cancel its subscription if active.
+    </span>
   </p>
 
-  <p :if={@issue == :multiple_memberships_noforce} class="text-sm">
-    To log in as an SSO user, you must first leave all other teams.
-  </p>
-
-  <div :if={@issue == :active_personal_team} class="text-sm flex flex-col space-y-2">
-    <p>
-      To access this team, you must either remove or transfer all sites you own under "My Personal Sites".
-    </p>
-
-    <p>
-      You also have to cancel subscription for "My Personal Sites" if there is an active one.
-    </p>
-  </div>
-
-  <div :if={@issue == :active_personal_team_noforce} class="text-sm flex flex-col space-y-2">
-    <p>
-      To log in as an SSO user, you must either remove or transfer all sites you own under "My Personal Sites".
-    </p>
-
-    <p>
-      You also have to cancel subscription on "My Personal Sites" if there is an active one.
-    </p>
-  </div>
-
-  <p :if={@issue == :not_a_member} class="text-sm">
-    To access this team, you must join as a team member first.
-  </p>
-
-  <p :if={!@conn.assigns[:current_user]} class="text-sm mt-4">
+  <p :if={!@conn.assigns[:current_user]}>
     <.styled_link href={Routes.auth_path(@conn, :login_form, prefer: "manual")}>
-      Log in
+      Sign in with email and password
     </.styled_link>
-    with your email and password to resolve the issue.
+    to resolve the issue.
   </p>
-</.focus_box>
+</div>

--- a/extra/lib/plausible_web/templates/sso/provision_issue.html.heex
+++ b/extra/lib/plausible_web/templates/sso/provision_issue.html.heex
@@ -1,36 +1,38 @@
-<div class="w-full max-w-md mx-auto mt-6 pb-16 px-4 flex flex-col items-center gap-y-4 text-center text-base text-gray-500 dark:text-gray-400 text-pretty">
-  <p>
-    The owner of
-    <span :if={is_nil(@conn.assigns[:current_team])}>the team</span><span
-      :if={@conn.assigns[:current_team]}
-      class="font-semibold"
-    >"{@conn.assigns[:current_team].name}"</span>
-    has turned off email and password logins, so you can only sign in with your organization's Single Sign-On.
-    <span :if={@issue == :not_a_member}>
-      To access this team, you must be added as a team member first.
-    </span>
-    <span :if={@issue == :multiple_memberships}>
-      To access this team, you must leave all other teams first.
-    </span>
-    <span :if={@issue == :multiple_memberships_noforce}>
-      To sign in with SSO, you must leave all other teams first.
-    </span>
-    <span :if={@issue == :active_personal_team}>
-      To access this team, remove or transfer all sites under
-      <span class="font-semibold">"My Personal Sites"</span>
-      and cancel its subscription if active.
-    </span>
-    <span :if={@issue == :active_personal_team_noforce}>
-      To sign in with SSO, remove or transfer all sites under
-      <span class="font-semibold">"My Personal Sites"</span>
-      and cancel its subscription if active.
-    </span>
-  </p>
+<.auth_container>
+  <div class="flex flex-col items-center gap-y-4 text-center text-base text-gray-500 dark:text-gray-400 text-pretty">
+    <p>
+      The owner of
+      <span :if={is_nil(@conn.assigns[:current_team])}>the team</span><span
+        :if={@conn.assigns[:current_team]}
+        class="font-semibold"
+      >"{@conn.assigns[:current_team].name}"</span>
+      has turned off email and password logins, so you can only sign in with your organization's Single Sign-On.
+      <span :if={@issue == :not_a_member}>
+        To access this team, you must be added as a team member first.
+      </span>
+      <span :if={@issue == :multiple_memberships}>
+        To access this team, you must leave all other teams first.
+      </span>
+      <span :if={@issue == :multiple_memberships_noforce}>
+        To sign in with SSO, you must leave all other teams first.
+      </span>
+      <span :if={@issue == :active_personal_team}>
+        To access this team, remove or transfer all sites under
+        <span class="font-semibold">"My Personal Sites"</span>
+        and cancel its subscription if active.
+      </span>
+      <span :if={@issue == :active_personal_team_noforce}>
+        To sign in with SSO, remove or transfer all sites under
+        <span class="font-semibold">"My Personal Sites"</span>
+        and cancel its subscription if active.
+      </span>
+    </p>
 
-  <p :if={!@conn.assigns[:current_user]}>
-    <.styled_link href={Routes.auth_path(@conn, :login_form, prefer: "manual")}>
-      Sign in with email and password
-    </.styled_link>
-    to resolve the issue.
-  </p>
-</div>
+    <p :if={!@conn.assigns[:current_user]}>
+      <.styled_link href={Routes.auth_path(@conn, :login_form, prefer: "manual")}>
+        Sign in with email and password
+      </.styled_link>
+      to resolve the issue.
+    </p>
+  </div>
+</.auth_container>

--- a/extra/lib/plausible_web/templates/sso/provision_notice.html.heex
+++ b/extra/lib/plausible_web/templates/sso/provision_notice.html.heex
@@ -1,15 +1,17 @@
-<div class="w-full max-w-md mx-auto mt-6 pb-16 px-4 flex flex-col items-center gap-y-4 text-center text-base text-gray-500 dark:text-gray-400 text-pretty">
-  <p>
-    The owner of
-    <span :if={is_nil(@conn.assigns[:current_team])}>the team</span><span
-      :if={@conn.assigns[:current_team]}
-      class="font-semibold"
-    >"{@conn.assigns[:current_team].name}"</span>
-    has turned off email and password logins, so you can only sign in with your organization's Single Sign-On.
-  </p>
-  <p>
-    To access this team,
-    <.styled_link href={Routes.auth_path(@conn, :logout)}>sign out</.styled_link>
-    and sign in with SSO.
-  </p>
-</div>
+<.auth_container>
+  <div class="flex flex-col items-center gap-y-4 text-center text-base text-gray-500 dark:text-gray-400 text-pretty">
+    <p>
+      The owner of
+      <span :if={is_nil(@conn.assigns[:current_team])}>the team</span><span
+        :if={@conn.assigns[:current_team]}
+        class="font-semibold"
+      >"{@conn.assigns[:current_team].name}"</span>
+      has turned off email and password logins, so you can only sign in with your organization's Single Sign-On.
+    </p>
+    <p>
+      To access this team,
+      <.styled_link href={Routes.auth_path(@conn, :logout)}>sign out</.styled_link>
+      and sign in with SSO.
+    </p>
+  </div>
+</.auth_container>

--- a/extra/lib/plausible_web/templates/sso/provision_notice.html.heex
+++ b/extra/lib/plausible_web/templates/sso/provision_notice.html.heex
@@ -1,17 +1,15 @@
-<.focus_box>
-  <:title>
-    Single Sign-On enforcement
-  </:title>
-  <:subtitle>
-    The owner of <span :if={is_nil(@conn.assigns[:current_team])}>the team</span>
-    <span :if={@conn.assigns[:current_team]}>"{@conn.assigns[:current_team].name}"</span>
-    has turned off regular email and password logins.
-    To keep things secure and simple, you can only sign in using your organization's
-    Single Sign-On (SSO) system.
-  </:subtitle>
-
-  <p class="text-sm">
-    To access this team, you must first <.styled_link href="/logout">log out</.styled_link>
-    and log in as SSO user.
+<div class="w-full max-w-md mx-auto mt-6 pb-16 px-4 flex flex-col items-center gap-y-4 text-center text-base text-gray-500 dark:text-gray-400 text-pretty">
+  <p>
+    The owner of
+    <span :if={is_nil(@conn.assigns[:current_team])}>the team</span><span
+      :if={@conn.assigns[:current_team]}
+      class="font-semibold"
+    >"{@conn.assigns[:current_team].name}"</span>
+    has turned off email and password logins, so you can only sign in with your organization's Single Sign-On.
   </p>
-</.focus_box>
+  <p>
+    To access this team,
+    <.styled_link href={Routes.auth_path(@conn, :logout)}>sign out</.styled_link>
+    and sign in with SSO.
+  </p>
+</div>

--- a/lib/plausible/auth/user.ex
+++ b/lib/plausible/auth/user.ex
@@ -79,9 +79,10 @@ defmodule Plausible.Auth.User do
   def new(attrs \\ %{}) do
     %Plausible.Auth.User{}
     |> cast(attrs, @required)
-    |> validate_required(@required)
+    |> validate_required(:name, message: "Please enter your name")
+    |> validate_required(:email, message: "Please enter your email")
+    |> validate_required(:password, message: "Please enter a password")
     |> validate_password_length()
-    |> validate_confirmation(:password, required: true)
     |> validate_password_strength()
     |> hash_password()
     |> set_email_verification_status()

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -54,6 +54,17 @@ defmodule PlausibleWeb.Components.Generic do
     "md" => "btn-md"
   }
 
+  attr(:class, :string, default: "")
+  slot(:inner_block, required: true)
+
+  def auth_container(assigns) do
+    ~H"""
+    <div class={["w-full max-w-md mx-auto mt-10 pb-16 px-4", @class]}>
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
   attr(:type, :string, default: "button")
   attr(:theme, :string, default: "primary")
   attr(:size, :string, default: "md")

--- a/lib/plausible_web/components/layout.ex
+++ b/lib/plausible_web/components/layout.ex
@@ -3,6 +3,28 @@ defmodule PlausibleWeb.Components.Layout do
 
   use Phoenix.Component
 
+  attr :class, :string, default: "w-24 sm:w-30"
+
+  def logo(assigns) do
+    ~H"""
+    <img
+      src={logo_url("logo_dark.svg")}
+      class={[@class, "hidden dark:inline"]}
+      alt="Plausible logo"
+      loading="lazy"
+    />
+    <img
+      src={logo_url("logo_light.svg")}
+      class={[@class, "inline dark:hidden"]}
+      alt="Plausible logo"
+      loading="lazy"
+    />
+    """
+  end
+
+  defp logo_url(filename),
+    do: PlausibleWeb.Router.Helpers.static_path(PlausibleWeb.Endpoint, logo_path(filename))
+
   def favicon(assigns) do
     ~H"""
     <link

--- a/lib/plausible_web/components/two_factor.ex
+++ b/lib/plausible_web/components/two_factor.ex
@@ -25,51 +25,28 @@ defmodule PlausibleWeb.Components.TwoFactor do
   attr :field, :any, required: true
   attr :class, :string, default: ""
   attr :show_button?, :boolean, default: true
+  attr :autofocus?, :boolean, default: false
 
   def verify_2fa_input(assigns) do
-    input_class =
-      "font-mono tracking-[0.5em] w-36 pl-5 font-medium shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block border-gray-300 dark:border-gray-500 dark:text-gray-200 dark:bg-gray-900 rounded-l-md"
-
-    input_class =
-      if assigns.show_button? do
-        input_class
-      else
-        [input_class, "rounded-r-md"]
-      end
-
-    assigns = assign(assigns, :input_class, input_class)
     assigns = assign(assigns, :field, assigns[:form][assigns[:field]])
 
     ~H"""
-    <div class={[@class, "flex items-center"]}>
-      <input
-        type="text"
-        name={@field.name}
-        value={@field.value}
-        autocomplete="off"
-        class={@input_class}
-        oninput={
-          if @show_button? do
-            "this.value=this.value.replace(/[^0-9]/g, ''); if (this.value.length >= 6) document.getElementById('#{@id}').focus()"
-          else
-            "this.value=this.value.replace(/[^0-9]/g, '');"
-          end
-        }
-        onclick="this.select();"
+    <div class={[@class, "flex flex-col gap-y-6 items-center"]}>
+      <.otp_input
+        field={@field}
+        length={6}
         oninvalid={@show_button? && "document.getElementById('#{@id}').disabled = false"}
-        maxlength="6"
-        placeholder="••••••"
-        required="required"
+        autofocus={@autofocus? && "autofocus"}
       />
       <.button
         :if={@show_button?}
         type="submit"
         id={@id}
         mt?={false}
-        class="rounded-l-none [&>span.label-enabled]:block [&>span.label-disabled]:hidden [&[disabled]>span.label-enabled]:hidden [&[disabled]>span.label-disabled]:block"
+        class="w-full [&>span.label-enabled]:block [&>span.label-disabled]:hidden [&[disabled]>span.label-enabled]:hidden [&[disabled]>span.label-disabled]:block"
       >
         <span class="label-enabled pointer-events-none">
-          Verify &rarr;
+          Verify
         </span>
 
         <span class="label-disabled">

--- a/lib/plausible_web/components/two_factor.ex
+++ b/lib/plausible_web/components/two_factor.ex
@@ -26,18 +26,24 @@ defmodule PlausibleWeb.Components.TwoFactor do
   attr :class, :string, default: ""
   attr :show_button?, :boolean, default: true
   attr :autofocus?, :boolean, default: false
+  attr :error, :string, default: nil
 
   def verify_2fa_input(assigns) do
     assigns = assign(assigns, :field, assigns[:form][assigns[:field]])
 
     ~H"""
     <div class={[@class, "flex flex-col gap-y-6 items-center"]}>
-      <.otp_input
-        field={@field}
-        length={6}
-        oninvalid={@show_button? && "document.getElementById('#{@id}').disabled = false"}
-        autofocus={@autofocus? && "autofocus"}
-      />
+      <div class="flex flex-col gap-y-2 w-full">
+        <.otp_input
+          field={@field}
+          length={6}
+          oninvalid={@show_button? && "document.getElementById('#{@id}').disabled = false"}
+          autofocus={@autofocus? && "autofocus"}
+        />
+        <p :if={@error} class="text-xs text-red-500 text-center">
+          {@error}
+        </p>
+      </div>
       <.button
         :if={@show_button?}
         type="submit"

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -325,7 +325,7 @@ defmodule PlausibleWeb.AuthController do
       |> UserAuth.log_in_user(user, redirect_path)
     else
       {:error, :wrong_password} ->
-        Auth.log_failed_login_attempt("Incorrect password for #{email}")
+        Auth.log_failed_login_attempt("wrong password for #{email}")
 
         conn
         |> put_flash(:login_error, "Incorrect email or password. Please try again.")
@@ -508,9 +508,7 @@ defmodule PlausibleWeb.AuthController do
         {:error, :invalid_code} ->
           Auth.log_failed_login_attempt("wrong 2FA verification code provided for #{user.email}")
 
-          conn
-          |> put_flash(:error, "The provided code is invalid. Please try again")
-          |> render_verify_2fa()
+          render_verify_2fa(conn, "The provided code is invalid. Please try again")
 
         {:error, :not_enabled} ->
           UserAuth.log_in_user(conn, user, params["return_to"])
@@ -541,9 +539,10 @@ defmodule PlausibleWeb.AuthController do
         {:error, :invalid_code} ->
           Auth.log_failed_login_attempt("wrong 2FA recovery code provided for #{user.email}")
 
-          conn
-          |> put_flash(:error, "The provided recovery code is invalid. Please try another one")
-          |> render_verify_2fa_recovery_code()
+          render_verify_2fa_recovery_code(
+            conn,
+            "The provided recovery code is invalid. Please try another one"
+          )
 
         {:error, :not_enabled} ->
           UserAuth.log_in_user(conn, user)
@@ -551,16 +550,18 @@ defmodule PlausibleWeb.AuthController do
     end
   end
 
-  defp render_verify_2fa(conn) do
+  defp render_verify_2fa(conn, error \\ nil) do
     render_auth_page(conn, "verify_2fa.html",
+      error: error,
       heading: "Enter your 2FA code",
       subtitle: "Open your authenticator app and enter the 6-digit code.",
       remember_2fa_days: TwoFactor.Session.remember_2fa_days()
     )
   end
 
-  defp render_verify_2fa_recovery_code(conn) do
+  defp render_verify_2fa_recovery_code(conn, error \\ nil) do
     render_auth_page(conn, "verify_2fa_recovery_code.html",
+      error: error,
       heading: "Use a recovery code",
       subtitle: "Enter one of your saved recovery codes to sign in."
     )

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -64,15 +64,21 @@ defmodule PlausibleWeb.AuthController do
     user = conn.assigns.current_user
     flow = params["flow"] || PlausibleWeb.Flows.register()
     team_identifier = params["team_identifier"]
+    has_email_code? = Plausible.Users.has_email_code?(user)
+    has_any_memberships? = Plausible.Teams.Users.has_sites?(user)
 
-    render(conn, "activate.html",
+    render_auth_page(conn, "activate.html",
       error: nil,
-      has_email_code?: Plausible.Users.has_email_code?(user),
-      has_any_memberships?: Plausible.Teams.Users.has_sites?(user),
+      has_email_code?: has_email_code?,
+      has_any_memberships?: has_any_memberships?,
+      heading: activate_heading(has_email_code?),
       form_submit_url: "/activate?flow=#{flow}",
       team_identifier: team_identifier
     )
   end
+
+  defp activate_heading(true), do: "Check your email"
+  defp activate_heading(false), do: "Activate your account"
 
   def activate(conn, %{"code" => code}) do
     user = conn.assigns[:current_user]
@@ -116,19 +122,23 @@ defmodule PlausibleWeb.AuthController do
         end
 
       {:error, :incorrect} ->
-        render(conn, "activate.html",
-          error: "Incorrect activation code",
+        render_auth_page(conn, "activate.html",
+          error: "That code didn't work. Please try again.",
           has_email_code?: true,
           has_any_memberships?: has_any_memberships?,
-          form_submit_url: "/activate?flow=#{flow}"
+          heading: activate_heading(true),
+          form_submit_url: "/activate?flow=#{flow}",
+          team_identifier: team_identifier
         )
 
       {:error, :expired} ->
-        render(conn, "activate.html",
-          error: "Code is expired, please request another one",
+        render_auth_page(conn, "activate.html",
+          error: "The code has expired. Please request another one.",
           has_email_code?: false,
           has_any_memberships?: has_any_memberships?,
-          form_submit_url: "/activate?flow=#{flow}"
+          heading: activate_heading(false),
+          form_submit_url: "/activate?flow=#{flow}",
+          team_identifier: team_identifier
         )
     end
   end
@@ -152,11 +162,11 @@ defmodule PlausibleWeb.AuthController do
   end
 
   def password_reset_request_form(conn, _) do
-    render(conn, "password_reset_request_form.html")
+    render_password_reset_request_form(conn)
   end
 
   def password_reset_request(conn, %{"email" => ""}) do
-    render(conn, "password_reset_request_form.html", error: "Please enter an email address")
+    render_password_reset_request_form(conn, error: "Please enter an email address")
   end
 
   def password_reset_request(conn, %{"email" => email} = params) do
@@ -172,38 +182,62 @@ defmodule PlausibleWeb.AuthController do
             "Password reset e-mail sent. In dev environment GET /sent-emails for details."
           )
 
-          render(conn, "password_reset_request_success.html", email: email)
+          render_auth_page(conn, "password_reset_request_success.html",
+            heading: "Check your email",
+            email: email
+          )
 
         {:error, _} ->
-          render(conn, "password_reset_request_success.html", email: email)
+          render_auth_page(conn, "password_reset_request_success.html",
+            heading: "Check your email",
+            email: email
+          )
       end
     else
-      render(conn, "password_reset_request_form.html",
-        error: "Please complete the captcha to reset your password"
+      render_password_reset_request_form(conn,
+        captcha_error: "Please complete the captcha to reset your password"
       )
     end
+  end
+
+  defp render_password_reset_request_form(conn, extra_assigns \\ []) do
+    render_auth_page(
+      conn,
+      "password_reset_request_form.html",
+      Keyword.merge(
+        [
+          heading: "Reset your password",
+          subtitle: "Enter your email to receive a password reset link."
+        ],
+        extra_assigns
+      )
+    )
   end
 
   def password_reset_form(conn, params) do
     case Auth.Token.verify_password_reset(params["token"]) do
       {:ok, %{email: email}} ->
-        render(conn, "password_reset_form.html",
+        render_auth_page(conn, "password_reset_form.html",
           connect_live_socket: true,
+          heading: "Reset your password",
+          subtitle: "Choose a new password for your account",
           email: email
         )
 
       {:error, :expired} ->
-        render_error(
-          conn,
-          401,
-          "Your token has expired. Please request another password reset link."
+        conn
+        |> put_status(401)
+        |> render_auth_page("password_reset_error.html",
+          heading: "Password reset link expired",
+          subtitle: "Request a new one to reset your password."
         )
 
       {:error, _} ->
-        render_error(
-          conn,
-          401,
-          "Your token is invalid. Please request another password reset link."
+        conn
+        |> put_status(401)
+        |> render_auth_page("password_reset_error.html",
+          heading: "Password reset link invalid",
+          subtitle: "Request a new one to reset your password."
         )
     end
   end
@@ -212,7 +246,7 @@ defmodule PlausibleWeb.AuthController do
     conn
     |> UserAuth.log_out_user()
     |> put_flash(:login_title, "Password updated successfully")
-    |> put_flash(:login_instructions, "Please log in with your new credentials")
+    |> put_flash(:login_instructions, "Please sign in with your new credentials")
     |> redirect(to: Routes.auth_path(conn, :login_form))
   end
 
@@ -226,13 +260,20 @@ defmodule PlausibleWeb.AuthController do
           redirect(conn, to: Routes.sso_path(conn, :login_form, return_to: params["return_to"]))
 
         _ ->
-          render(conn, "login_form.html")
+          render_login_form(conn)
       end
     end
   else
     def login_form(conn, _params) do
-      render(conn, "login_form.html")
+      render_login_form(conn)
     end
+  end
+
+  defp render_login_form(conn) do
+    heading = Phoenix.Flash.get(conn.assigns.flash, :login_title) || "Sign in to your account"
+    subtitle = Phoenix.Flash.get(conn.assigns.flash, :login_instructions)
+
+    render_auth_page(conn, "login_form.html", heading: heading, subtitle: subtitle)
   end
 
   def login(conn, %{"user" => params}) do
@@ -277,19 +318,19 @@ defmodule PlausibleWeb.AuthController do
       |> UserAuth.log_in_user(user, redirect_path)
     else
       {:error, :wrong_password} ->
-        Auth.log_failed_login_attempt("wrong password for #{email}")
+        Auth.log_failed_login_attempt("Incorrect password for #{email}")
 
         conn
-        |> put_flash(:login_error, "Wrong email or password. Please try again.")
-        |> render("login_form.html")
+        |> put_flash(:login_error, "Incorrect email or password. Please try again.")
+        |> render_login_form()
 
       {:error, :user_not_found} ->
         Auth.log_failed_login_attempt("user not found for #{email}")
         Plausible.Auth.Password.dummy_calculation()
 
         conn
-        |> put_flash(:login_error, "Wrong email or password. Please try again.")
-        |> render("login_form.html")
+        |> put_flash(:login_error, "Incorrect email or password. Please try again.")
+        |> render_login_form()
 
       {:error, {:rate_limit, _}} ->
         Auth.log_failed_login_attempt("too many login attempts for #{email}")
@@ -439,9 +480,7 @@ defmodule PlausibleWeb.AuthController do
     case TwoFactor.Session.get_2fa_user(conn) do
       {:ok, user} ->
         if Auth.TOTP.enabled?(user) do
-          render(conn, "verify_2fa.html",
-            remember_2fa_days: TwoFactor.Session.remember_2fa_days()
-          )
+          render_verify_2fa(conn)
         else
           redirect_to_login(conn)
         end
@@ -464,9 +503,7 @@ defmodule PlausibleWeb.AuthController do
 
           conn
           |> put_flash(:error, "The provided code is invalid. Please try again")
-          |> render("verify_2fa.html",
-            remember_2fa_days: TwoFactor.Session.remember_2fa_days()
-          )
+          |> render_verify_2fa()
 
         {:error, :not_enabled} ->
           UserAuth.log_in_user(conn, user, params["return_to"])
@@ -478,7 +515,7 @@ defmodule PlausibleWeb.AuthController do
     case TwoFactor.Session.get_2fa_user(conn) do
       {:ok, user} ->
         if Auth.TOTP.enabled?(user) do
-          render(conn, "verify_2fa_recovery_code.html")
+          render_verify_2fa_recovery_code(conn)
         else
           redirect_to_login(conn)
         end
@@ -499,12 +536,27 @@ defmodule PlausibleWeb.AuthController do
 
           conn
           |> put_flash(:error, "The provided recovery code is invalid. Please try another one")
-          |> render("verify_2fa_recovery_code.html")
+          |> render_verify_2fa_recovery_code()
 
         {:error, :not_enabled} ->
           UserAuth.log_in_user(conn, user)
       end
     end
+  end
+
+  defp render_verify_2fa(conn) do
+    render_auth_page(conn, "verify_2fa.html",
+      heading: "Enter your 2FA code",
+      subtitle: "Open your authenticator app and enter the 6-digit code.",
+      remember_2fa_days: TwoFactor.Session.remember_2fa_days()
+    )
+  end
+
+  defp render_verify_2fa_recovery_code(conn) do
+    render_auth_page(conn, "verify_2fa_recovery_code.html",
+      heading: "Use a recovery code",
+      subtitle: "Enter one of your saved recovery codes to sign in."
+    )
   end
 
   defp get_2fa_user_limited(conn) do

--- a/lib/plausible_web/controllers/auth_controller.ex
+++ b/lib/plausible_web/controllers/auth_controller.ex
@@ -88,10 +88,17 @@ defmodule PlausibleWeb.AuthController do
       do_activate(conn, user, code)
     else
       {:error, {:rate_limit, _}} ->
-        render_error(
-          conn,
-          429,
-          "Too many activation attempts. Wait a few minutes before trying again."
+        has_any_memberships? = Plausible.Teams.Users.has_sites?(user, include_pending?: false)
+        flow = conn.params["flow"]
+        team_identifier = conn.params["team_identifier"]
+
+        render_auth_page(conn, "activate.html",
+          error: "Too many attempts. Please wait a few minutes before trying again.",
+          has_email_code?: true,
+          has_any_memberships?: has_any_memberships?,
+          heading: activate_heading(true),
+          form_submit_url: "/activate?flow=#{flow}",
+          team_identifier: team_identifier
         )
     end
   end

--- a/lib/plausible_web/controllers/helpers.ex
+++ b/lib/plausible_web/controllers/helpers.ex
@@ -1,4 +1,6 @@
 defmodule PlausibleWeb.ControllerHelpers do
+  @moduledoc false
+
   import Plug.Conn
   import Phoenix.Controller
 

--- a/lib/plausible_web/controllers/helpers.ex
+++ b/lib/plausible_web/controllers/helpers.ex
@@ -21,6 +21,17 @@ defmodule PlausibleWeb.ControllerHelpers do
   defp error_layout,
     do: Application.get_env(:plausible, PlausibleWeb.Endpoint)[:render_errors][:layout]
 
+  @auth_layout_assigns [
+    layout: {PlausibleWeb.LayoutView, :auth},
+    hide_header?: true,
+    hide_footer?: true,
+    disable_global_notices?: true
+  ]
+
+  def render_auth_page(conn, template, extra_assigns \\ []) do
+    render(conn, template, Keyword.merge(@auth_layout_assigns, extra_assigns))
+  end
+
   def debug_metadata(conn) do
     %{
       request_method: conn.method,

--- a/lib/plausible_web/flows.ex
+++ b/lib/plausible_web/flows.ex
@@ -15,8 +15,6 @@ defmodule PlausibleWeb.Flows do
       "Verify installation"
     ],
     register: [
-      "Register",
-      "Activate account",
       "Add site info",
       "Install Plausible",
       "Verify installation"

--- a/lib/plausible_web/live/auth_layout_context.ex
+++ b/lib/plausible_web/live/auth_layout_context.ex
@@ -1,7 +1,16 @@
 defmodule PlausibleWeb.Live.AuthLayoutContext do
   @moduledoc false
 
+  import Phoenix.Component
+
   def on_mount(_arg, _params, _session, socket) do
+    socket =
+      assign(socket,
+        hide_header?: true,
+        hide_footer?: true,
+        disable_global_notices?: true
+      )
+
     {:cont, socket, layout: {PlausibleWeb.LayoutView, :auth}}
   end
 end

--- a/lib/plausible_web/live/auth_layout_context.ex
+++ b/lib/plausible_web/live/auth_layout_context.ex
@@ -1,0 +1,7 @@
+defmodule PlausibleWeb.Live.AuthLayoutContext do
+  @moduledoc false
+
+  def on_mount(_arg, _params, _session, socket) do
+    {:cont, socket, layout: {PlausibleWeb.LayoutView, :auth}}
+  end
+end

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -318,18 +318,13 @@ defmodule PlausibleWeb.Live.Components.Form do
   attr(:field, Phoenix.HTML.FormField, required: true)
   attr(:length, :integer, default: 6)
 
-  attr(:autosubmit?, :boolean, default: false)
-
   attr(:rest, :global, include: ~w(autofocus oninvalid))
 
   def otp_input(assigns) do
     oninput_js =
       "this.value=this.value.replace(/[^0-9]/g, '');" <>
-        if assigns.autosubmit? do
-          " if (this.value.length >= #{assigns.length}) this.form.requestSubmit();"
-        else
-          ""
-        end
+        " if (this.value.length >= #{assigns.length})" <>
+        " this.form.querySelector('button[type=submit]').focus()"
 
     input_class = [
       @default_input_class,

--- a/lib/plausible_web/live/components/form.ex
+++ b/lib/plausible_web/live/components/form.ex
@@ -44,8 +44,9 @@ defmodule PlausibleWeb.Live.Components.Form do
   attr(:multiple, :boolean, default: false, doc: "the multiple flag for select inputs")
 
   attr(:rest, :global,
-    include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
-         multiple pattern placeholder readonly required rows size step x-model)
+    include:
+      ~w(accept autocomplete autofocus capture cols disabled form list max maxlength min minlength
+         multiple pattern placeholder readonly required rows size step x-bind:type x-model)
   )
 
   attr(:class, :any, default: @default_input_class)
@@ -54,6 +55,7 @@ defmodule PlausibleWeb.Live.Components.Form do
   attr(:max_one_error, :boolean, default: false)
   slot(:help_content)
   slot(:inner_block)
+  slot(:trailing)
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
@@ -193,14 +195,17 @@ defmodule PlausibleWeb.Live.Components.Form do
       <p :if={@help_text} class="text-gray-500 dark:text-gray-400 mb-2 text-sm">
         {@help_text}
       </p>
-      <input
-        type={@type}
-        name={@name}
-        id={@id}
-        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-        class={[@class, @width, assigns[:rest][:disabled] && "text-gray-500 dark:text-gray-400"]}
-        {@rest}
-      />
+      <div class="relative">
+        <input
+          type={@type}
+          name={@name}
+          id={@id}
+          value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+          class={[@class, @width, assigns[:rest][:disabled] && "text-gray-500 dark:text-gray-400"]}
+          {@rest}
+        />
+        {render_slot(@trailing)}
+      </div>
       {render_slot(@inner_block)}
       <.error :for={msg <- @errors}>
         {msg}
@@ -252,8 +257,114 @@ defmodule PlausibleWeb.Live.Components.Form do
     """
   end
 
+  @doc """
+  Renders a password input with a show/hide reveal toggle.
+  """
   attr(:id, :any, default: nil)
   attr(:label, :string, default: nil)
+  attr(:mt?, :boolean, default: true)
+  attr(:autocomplete, :string, default: "current-password")
+
+  attr(:field, Phoenix.HTML.FormField, required: true)
+
+  attr(:rest, :global,
+    include:
+      ~w(autocomplete autofocus disabled form maxlength minlength placeholder readonly required size)
+  )
+
+  slot(:inner_block)
+
+  def password_field(assigns) do
+    assigns = assign(assigns, :class, [@default_input_class, "pr-10"])
+
+    ~H"""
+    <div x-data="{ showPassword: false }">
+      <.input
+        type="password"
+        x-bind:type="showPassword ? 'text' : 'password'"
+        field={@field}
+        label={@label}
+        id={@id}
+        autocomplete={@autocomplete}
+        mt?={@mt?}
+        class={@class}
+        {@rest}
+      >
+        <:trailing>
+          <button
+            type="button"
+            @click="showPassword = !showPassword"
+            tabindex="-1"
+            aria-label="Toggle password visibility"
+            class="absolute inset-y-0 right-2 flex items-center text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300 transition-colors duration-150"
+          >
+            <span x-show="!showPassword">
+              <Heroicons.eye class="size-4" />
+            </span>
+            <span x-show="showPassword" x-cloak>
+              <Heroicons.eye_slash class="size-4" />
+            </span>
+          </button>
+        </:trailing>
+        {render_slot(@inner_block)}
+      </.input>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a one-time-code input (activation code, 2FA code, etc.).
+  """
+  attr(:field, Phoenix.HTML.FormField, required: true)
+  attr(:length, :integer, default: 6)
+
+  attr(:autosubmit?, :boolean, default: false)
+
+  attr(:rest, :global, include: ~w(autofocus oninvalid))
+
+  def otp_input(assigns) do
+    oninput_js =
+      "this.value=this.value.replace(/[^0-9]/g, '');" <>
+        if assigns.autosubmit? do
+          " if (this.value.length >= #{assigns.length}) this.form.requestSubmit();"
+        else
+          ""
+        end
+
+    input_class = [
+      @default_input_class,
+      "font-mono tracking-[0.5em] font-medium text-center w-full"
+    ]
+
+    assigns =
+      assigns
+      |> assign(:input_class, input_class)
+      |> assign(:placeholder, String.duplicate("•", assigns.length))
+      |> assign(:oninput_js, oninput_js)
+
+    ~H"""
+    <input
+      type="text"
+      id={@field.id}
+      name={@field.name}
+      value={@field.value}
+      class={@input_class}
+      inputmode="numeric"
+      autocomplete="one-time-code"
+      pattern="[0-9]*"
+      maxlength={@length}
+      placeholder={@placeholder}
+      required
+      onclick="this.select();"
+      oninput={@oninput_js}
+      {@rest}
+    />
+    """
+  end
+
+  attr(:id, :any, default: nil)
+  attr(:label, :string, default: nil)
+  attr(:mt?, :boolean, default: true)
 
   attr(:field, Phoenix.HTML.FormField,
     doc: "a form field struct retrieved from the form, for example: @form[:password]",
@@ -263,7 +374,8 @@ defmodule PlausibleWeb.Live.Components.Form do
   attr(:strength, :any)
 
   attr(:rest, :global,
-    include: ~w(autocomplete disabled form maxlength minlength readonly required size)
+    include:
+      ~w(autocomplete autofocus disabled form maxlength minlength placeholder readonly required size)
   )
 
   def password_input_with_strength(%{field: field} = assigns) do
@@ -294,9 +406,16 @@ defmodule PlausibleWeb.Live.Components.Form do
       )
 
     ~H"""
-    <.input field={@field} type="password" autocomplete="new-password" label={@label} id={@id} {@rest}>
+    <.password_field
+      field={@field}
+      autocomplete="new-password"
+      label={@label}
+      id={@id}
+      mt?={@mt?}
+      {@rest}
+    >
       <.strength_meter :if={@show_meter?} {@strength} />
-    </.input>
+    </.password_field>
     """
   end
 
@@ -305,6 +424,7 @@ defmodule PlausibleWeb.Live.Components.Form do
   attr(:class, :any)
   attr(:ok_class, :any)
   attr(:error_class, :any)
+  attr(:hide_when_used?, :boolean, default: false)
 
   attr(:field, Phoenix.HTML.FormField,
     doc: "a form field struct retrieved from the form, for example: @form[:password]",
@@ -314,9 +434,11 @@ defmodule PlausibleWeb.Live.Components.Form do
   def password_length_hint(%{field: field} = assigns) do
     {strength_errors, _} = pop_strength_errors(field.errors)
 
-    ok_class = assigns[:ok_class] || "text-gray-500"
-    error_class = assigns[:error_class] || "text-red-500"
-    class = assigns[:class] || ["text-xs", "mt-1"]
+    hidden? = assigns.hide_when_used? and Phoenix.Component.used_input?(field)
+
+    ok_class = assigns[:ok_class] || "text-gray-500 dark:text-gray-400"
+    error_class = assigns[:error_class] || "text-red-500 dark:text-red-400"
+    class = assigns[:class] || ["text-xs"]
 
     color =
       if :length in strength_errors do
@@ -327,10 +449,13 @@ defmodule PlausibleWeb.Live.Components.Form do
 
     final_class = [color | class]
 
-    assigns = assign(assigns, :class, final_class)
+    assigns =
+      assigns
+      |> assign(:class, final_class)
+      |> assign(:hidden?, hidden?)
 
     ~H"""
-    <p class={@class}>Min {@minimum} characters</p>
+    <p :if={not @hidden?} class={@class}>At least {@minimum} characters</p>
     """
   end
 
@@ -357,14 +482,6 @@ defmodule PlausibleWeb.Live.Components.Form do
   attr(:suggestions, :list, default: [])
 
   def strength_meter(assigns) do
-    color =
-      cond do
-        assigns.score <= 1 -> ["bg-red-500", "dark:bg-red-500"]
-        assigns.score == 2 -> ["bg-red-300", "dark:bg-red-300"]
-        assigns.score == 3 -> ["bg-indigo-300", "dark:bg-indigo-300"]
-        assigns.score >= 4 -> ["bg-indigo-600", "dark:bg-indigo-500"]
-      end
-
     feedback =
       cond do
         assigns.warning != "" -> assigns.warning <> "."
@@ -372,23 +489,27 @@ defmodule PlausibleWeb.Live.Components.Form do
         true -> nil
       end
 
+    strength_label =
+      cond do
+        assigns.score == 3 -> "Good"
+        assigns.score >= 4 -> "Strong"
+        true -> nil
+      end
+
     assigns =
       assigns
-      |> assign(:color, color)
       |> assign(:feedback, feedback)
+      |> assign(:strength_label, strength_label)
 
     ~H"""
-    <div class="w-full bg-gray-200 rounded-full h-1.5 mb-2 mt-2 dark:bg-gray-700 mt-1">
-      <div
-        class={["h-1.5", "rounded-full"] ++ @color}
-        style={["width: " <> to_string(@score * 25) <> "%"]}
-      >
-      </div>
-    </div>
-    <p :if={@score <= 2} class="text-sm text-red-500">
-      Password is too weak
+    <p :if={@score <= 2} class="text-xs text-red-500 mt-2">
+      Password is too weak.
     </p>
-    <p :if={@feedback} class="text-xs text-gray-500">
+    <p :if={@strength_label} class="text-xs mt-2">
+      <span class="text-gray-500 dark:text-gray-400">Password strength:</span>
+      <span class="text-green-600 dark:text-green-500 font-medium">{@strength_label}</span>
+    </p>
+    <p :if={@feedback && @score <= 2} class="text-xs text-gray-500 dark:text-gray-400">
       {@feedback}
     </p>
     """
@@ -416,7 +537,7 @@ defmodule PlausibleWeb.Live.Components.Form do
 
   def error(assigns) do
     ~H"""
-    <p class="mt-1 flex gap-3 text-sm text-red-500 leading-4.5 text-pretty">
+    <p class="mt-1 flex gap-3 text-xs text-red-500 leading-4.5 text-pretty">
       {render_slot(@inner_block)}
     </p>
     """

--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -70,20 +70,20 @@ defmodule PlausibleWeb.Live.RegisterForm do
 
   def render(%{invitation_expired: true} = assigns) do
     ~H"""
-    <div class="w-full max-w-md mx-auto mt-10 pb-16 px-4 flex gap-3 justify-center">
+    <.auth_container class="flex gap-3 justify-center">
       <.button_link href="/register" mt?={false}>
         Start free trial
       </.button_link>
       <.button_link href="/login" theme="secondary" mt?={false}>
         Sign in
       </.button_link>
-    </div>
+    </.auth_container>
     """
   end
 
   def render(assigns) do
     ~H"""
-    <div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+    <.auth_container>
       <.form
         :let={f}
         for={@form}
@@ -176,7 +176,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
           </p>
         </div>
       </.form>
-    </div>
+    </.auth_container>
     """
   end
 

--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -25,7 +25,13 @@ defmodule PlausibleWeb.Live.RegisterForm do
 
     if socket.assigns.live_action == :register_from_invitation_form and
          socket.assigns.invitation == nil do
-      {:ok, assign(socket, invitation_expired: true)}
+      {:ok,
+       assign(socket,
+         invitation_expired: true,
+         heading: "Invitation no longer valid",
+         subtitle:
+           "This invitation has expired or was revoked. Ask your team admin to send you a new invitation."
+       )}
     else
       changeset =
         if invitation = socket.assigns.invitation do
@@ -34,71 +40,55 @@ defmodule PlausibleWeb.Live.RegisterForm do
           Auth.User.settings_changeset(%Auth.User{})
         end
 
+      {heading, subtitle} = heading_and_subtitle(socket.assigns.live_action)
+
       {:ok,
        assign(socket,
          form: to_form(changeset),
          captcha_error: nil,
          password_strength: Auth.User.password_strength(changeset),
          disable_submit: false,
-         trigger_submit: false
+         trigger_submit: false,
+         heading: heading,
+         subtitle: subtitle
        )}
+    end
+  end
+
+  defp heading_and_subtitle(:register_from_invitation_form) do
+    {"Create your account", "Accept your invitation to join your team."}
+  end
+
+  defp heading_and_subtitle(:register_form) do
+    if ce?() do
+      {"Create your #{Plausible.product_name()} account",
+       "Start tracking privacy-friendly analytics in minutes."}
+    else
+      {"Start your 30-day free trial", "No credit card required. Cancel anytime."}
     end
   end
 
   def render(%{invitation_expired: true} = assigns) do
     ~H"""
-    <div class="mx-auto mt-6 text-center dark:text-gray-300">
-      <h1 class="text-3xl font-black">{Plausible.product_name()}</h1>
-      <div class="text-xl font-medium">Lightweight and privacy-friendly web analytics</div>
-    </div>
-
-    <div class="w-full max-w-md mx-auto bg-white dark:bg-gray-800 shadow-md rounded-sm px-8 py-6 mb-4 mt-8">
-      <h2 class="text-xl font-black dark:text-gray-100">Invitation expired</h2>
-
-      <p class="mt-4">
-        Your invitation has expired or been revoked. Please request fresh one or you can
-        <.styled_link href={Routes.auth_path(@socket, :register_form)}>sign up</.styled_link>
-        for a 30-day unlimited free trial without an invitation.
-      </p>
+    <div class="w-full max-w-md mx-auto mt-10 pb-16 px-4 flex gap-3 justify-center">
+      <.button_link href="/register" mt?={false}>
+        Start free trial
+      </.button_link>
+      <.button_link href="/login" theme="secondary" mt?={false}>
+        Sign in
+      </.button_link>
     </div>
     """
   end
 
   def render(assigns) do
     ~H"""
-    <div class="mx-auto text-center dark:text-gray-300">
-      <h1 class="text-3xl font-black">
-        <%= if ce?() or @live_action == :register_from_invitation_form do %>
-          Register your {Plausible.product_name()} account
-        <% else %>
-          Register your 30-day free trial
-        <% end %>
-      </h1>
-      <div class="text-xl font-medium mt-2">
-        Set up privacy-friendly analytics with just a few clicks
-      </div>
-    </div>
-
-    <PlausibleWeb.Components.FlowProgress.render
-      :if={@live_action == :register_form}
-      flow={PlausibleWeb.Flows.register()}
-      current_step="Register"
-    />
-    <PlausibleWeb.Components.FlowProgress.render
-      :if={@live_action == :register_from_invitation_form}
-      flow={PlausibleWeb.Flows.invitation()}
-      current_step="Register"
-    />
-
-    <.focus_box>
-      <:title>
-        Enter your details
-      </:title>
-
+    <div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
       <.form
         :let={f}
         for={@form}
         id="register-form"
+        class="flex flex-col gap-y-6"
         action={Routes.auth_path(@socket, :login)}
         phx-hook="Metrics"
         phx-change="validate"
@@ -121,43 +111,26 @@ defmodule PlausibleWeb.Live.RegisterForm do
           <.email_input field={f[:email]} for_invitation={false} />
         <% end %>
 
-        <div class="my-4">
-          <div class="flex justify-between">
-            <label for={f[:password].id} class="block font-medium text-gray-700 dark:text-gray-300">
-              Password
-            </label>
-            <.password_length_hint minimum={12} field={f[:password]} />
-          </div>
-          <div class="mt-1">
+        <div class="flex flex-col gap-y-2">
+          <label
+            for={f[:password].id}
+            class="text-sm font-semibold text-gray-800 dark:text-gray-200"
+          >
+            Password
+          </label>
+          <div>
             <.password_input_with_strength
               field={f[:password]}
               strength={@password_strength}
               phx-debounce={200}
-              class="dark:bg-gray-900 shadow-xs focus:ring-indigo-500 focus:border-indigo-500 block w-full border-gray-300 dark:border-gray-500 rounded-md dark:text-gray-300"
+              mt?={false}
             />
           </div>
-        </div>
-
-        <div class="my-4">
-          <label
-            for={f[:password_confirmation].id}
-            class="block font-medium text-gray-700 dark:text-gray-300"
-          >
-            Confirm password
-          </label>
-          <div class="mt-1">
-            <.input
-              type="password"
-              autocomplete="new-password"
-              field={f[:password_confirmation]}
-              phx-debounce={200}
-              class="dark:bg-gray-900 shadow-xs focus:ring-indigo-500 focus:border-indigo-500 block w-full border-gray-300 dark:border-gray-500 rounded-md dark:text-gray-300"
-            />
-          </div>
+          <.password_length_hint minimum={12} field={f[:password]} hide_when_used?={true} />
         </div>
 
         <%= if PlausibleWeb.Captcha.enabled?() do %>
-          <div class="mt-4">
+          <div>
             <div
               phx-update="ignore"
               id="hcaptcha-placeholder"
@@ -165,11 +138,14 @@ defmodule PlausibleWeb.Live.RegisterForm do
               data-sitekey={PlausibleWeb.Captcha.sitekey()}
             >
             </div>
-            <%= if @captcha_error do %>
-              <div class="text-red-500 text-xs italic mt-3" x-data x-init="hcaptcha.reset()">
-                {@captcha_error}
-              </div>
-            <% end %>
+            <p
+              :if={@captcha_error}
+              class="text-xs text-red-500 mt-2"
+              x-data
+              x-init="hcaptcha.reset()"
+            >
+              {@captcha_error}
+            </p>
             <script
               phx-update="ignore"
               id="hcaptcha-script"
@@ -181,39 +157,42 @@ defmodule PlausibleWeb.Live.RegisterForm do
           </div>
         <% end %>
 
-        <% submit_text =
-          if ce?() or @invitation do
-            "Create my account"
-          else
-            "Start my free trial"
-          end %>
-        <.button id="register" disabled={@disable_submit} type="submit" class="mt-4 w-full">
-          {submit_text}
-        </.button>
+        <div class="flex flex-col gap-y-4">
+          <% submit_text =
+            if ce?() or @invitation do
+              "Create my account"
+            else
+              "Start my free trial"
+            end %>
+          <.button id="register" disabled={@disable_submit} type="submit" class="w-full" mt?={false}>
+            {submit_text}
+          </.button>
 
-        <p class="text-center text-gray-600 dark:text-gray-500 mt-4">
-          Already have an account?
-          <.styled_link href="/login">
-            Log in
-          </.styled_link>
-        </p>
+          <p class="text-sm text-center text-gray-500 dark:text-gray-400">
+            Already have an account?
+            <.styled_link href="/login">
+              Sign in
+            </.styled_link>
+          </p>
+        </div>
       </.form>
-    </.focus_box>
+    </div>
     """
   end
 
   defp name_input(assigns) do
     ~H"""
-    <div class="my-4">
-      <label for={@field.id} class="block font-medium text-gray-700 dark:text-gray-300">
+    <div class="flex flex-col gap-y-2">
+      <label for={@field.id} class="text-sm font-semibold text-gray-800 dark:text-gray-200">
         Full name
       </label>
-      <div class="mt-1">
+      <div>
         <.input
           field={@field}
           placeholder="Jane Doe"
           phx-debounce={200}
-          class="dark:bg-gray-900 shadow-xs focus:ring-indigo-500 focus:border-indigo-500 block w-full border-gray-300 dark:border-gray-500 rounded-md dark:text-gray-300"
+          mt?={false}
+          autofocus="autofocus"
         />
       </div>
     </div>
@@ -221,46 +200,27 @@ defmodule PlausibleWeb.Live.RegisterForm do
   end
 
   defp email_input(assigns) do
-    email_classes = ~w(
-      dark:bg-gray-900
-      shadow-sm
-      focus:ring-indigo-500
-      focus:border-indigo-500
-      block
-      w-full
-      border-gray-300
-      dark:border-gray-500
-      rounded-md
-      dark:text-gray-300
-    )
-
-    {email_readonly, email_extra_classes} =
+    email_readonly =
       if assigns[:for_invitation] do
-        {[readonly: "readonly"], ["bg-gray-100"]}
+        [readonly: "readonly"]
       else
-        {[], []}
+        []
       end
 
-    assigns =
-      assigns
-      |> assign(:email_readonly, email_readonly)
-      |> assign(:email_classes, email_classes ++ email_extra_classes)
+    assigns = assign(assigns, :email_readonly, email_readonly)
 
     ~H"""
-    <div class="my-4">
-      <div class="flex justify-between">
-        <label for={@field.id} class="block font-medium text-gray-700 dark:text-gray-300">
-          Email
-        </label>
-        <p class="text-xs text-gray-500 mt-1">No spam, guaranteed.</p>
-      </div>
-      <div class="mt-1">
+    <div class="flex flex-col gap-y-2">
+      <label for={@field.id} class="text-sm font-semibold text-gray-800 dark:text-gray-200">
+        Email
+      </label>
+      <div>
         <.input
           type="email"
           field={@field}
           placeholder="example@email.com"
           phx-debounce={200}
-          class={@email_classes}
+          mt?={false}
           {@email_readonly}
         />
       </div>

--- a/lib/plausible_web/live/reset_password_form.ex
+++ b/lib/plausible_web/live/reset_password_form.ex
@@ -33,33 +33,37 @@ defmodule PlausibleWeb.Live.ResetPasswordForm do
       phx-change="validate"
       phx-submit="set"
       phx-trigger-action={@trigger_submit}
-      class="bg-white dark:bg-gray-800 max-w-md w-full mx-auto shadow-md rounded-sm px-8 py-6 mt-8"
+      class="flex flex-col gap-y-6"
     >
       <input name="_csrf_token" type="hidden" value={Plug.CSRFProtection.get_csrf_token()} />
-      <h2 class="text-xl font-black dark:text-gray-100">
-        Reset your password
-      </h2>
-      <div class="my-4">
-        <.password_length_hint
-          minimum={12}
-          field={f[:password]}
-          class={["text-sm", "mt-1", "mb-2"]}
-          ok_class="text-gray-600 dark:text-gray-600"
-          error_class="text-red-600 dark:text-red-500"
-        />
-        <.password_input_with_strength
-          field={f[:password]}
-          strength={@password_strength}
-          phx-debounce={200}
-          class="transition bg-gray-100 dark:bg-gray-900 outline-hidden appearance-none border border-transparent rounded-xs w-full p-2 text-gray-700 dark:text-gray-300 leading-normal focus:outline-hidden focus:bg-white dark:focus:bg-gray-800 focus:border-gray-300 dark:focus:border-gray-500"
-        />
+
+      <div class="flex flex-col gap-y-2">
+        <label
+          for={f[:password].id}
+          class="text-sm font-semibold text-gray-800 dark:text-gray-200"
+        >
+          New password
+        </label>
+        <div>
+          <.password_input_with_strength
+            field={f[:password]}
+            strength={@password_strength}
+            phx-debounce={200}
+            mt?={false}
+          />
+        </div>
+        <.password_length_hint minimum={12} field={f[:password]} hide_when_used?={true} />
       </div>
-      <.button id="set" type="submit" class="mt-4 w-full">
-        Set password →
-      </.button>
-      <p class="text-center text-gray-500 text-xs mt-4">
-        Don't have an account? <.styled_link href="/register">Register</.styled_link> instead.
-      </p>
+
+      <div class="flex flex-col gap-y-4">
+        <.button id="set" type="submit" class="w-full" mt?={false}>
+          Update password
+        </.button>
+
+        <p class="text-sm text-center text-gray-500 dark:text-gray-400">
+          <.styled_link href="/login">Back to sign in</.styled_link>
+        </p>
+      </div>
     </.form>
     """
   end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -419,23 +419,32 @@ defmodule PlausibleWeb.Router do
   scope "/", PlausibleWeb do
     pipe_through [:browser, :csrf]
 
-    scope alias: Live, assigns: %{connect_live_socket: true} do
+    scope alias: Live,
+          assigns: %{
+            connect_live_socket: true,
+            hide_header?: true,
+            hide_footer?: true,
+            disable_global_notices?: true
+          } do
       pipe_through [PlausibleWeb.RequireLoggedOutPlug, :app_layout]
 
-      scope assigns: %{disable_registration_for: [:invite_only, true]} do
-        pipe_through PlausibleWeb.Plugs.MaybeDisableRegistration
+      live_session :auth, on_mount: PlausibleWeb.Live.AuthLayoutContext do
+        scope assigns: %{disable_registration_for: [:invite_only, true]} do
+          pipe_through PlausibleWeb.Plugs.MaybeDisableRegistration
 
-        live "/register", RegisterForm, :register_form, as: :auth
-      end
+          live "/register", RegisterForm, :register_form, as: :auth
+        end
 
-      scope assigns: %{
-              disable_registration_for: true,
-              dogfood_page_path: "/register/invitation/:invitation_id"
-            } do
-        pipe_through PlausibleWeb.Plugs.MaybeDisableRegistration
+        scope assigns: %{
+                disable_registration_for: true,
+                dogfood_page_path: "/register/invitation/:invitation_id"
+              } do
+          pipe_through PlausibleWeb.Plugs.MaybeDisableRegistration
 
-        live "/register/invitation/:invitation_id", RegisterForm, :register_from_invitation_form,
-          as: :auth
+          live "/register/invitation/:invitation_id",
+               RegisterForm,
+               :register_from_invitation_form, as: :auth
+        end
       end
     end
 

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -419,13 +419,7 @@ defmodule PlausibleWeb.Router do
   scope "/", PlausibleWeb do
     pipe_through [:browser, :csrf]
 
-    scope alias: Live,
-          assigns: %{
-            connect_live_socket: true,
-            hide_header?: true,
-            hide_footer?: true,
-            disable_global_notices?: true
-          } do
+    scope alias: Live, assigns: %{connect_live_socket: true} do
       pipe_through [PlausibleWeb.RequireLoggedOutPlug, :app_layout]
 
       live_session :auth, on_mount: PlausibleWeb.Live.AuthLayoutContext do

--- a/lib/plausible_web/templates/auth/activate.html.heex
+++ b/lib/plausible_web/templates/auth/activate.html.heex
@@ -8,7 +8,7 @@
   <% end %>
 </p>
 
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+<.auth_container>
   <%= if @has_email_code? do %>
     <.form
       :let={f}
@@ -78,4 +78,4 @@
       <% end %>
     </p>
   <% end %>
-</div>
+</.auth_container>

--- a/lib/plausible_web/templates/auth/activate.html.heex
+++ b/lib/plausible_web/templates/auth/activate.html.heex
@@ -1,107 +1,81 @@
-<PlausibleWeb.Components.FlowProgress.render
-  flow={@conn.params["flow"]}
-  current_step="Activate account"
-/>
+<p class="max-w-md mx-auto mt-2 px-4 text-base text-gray-500 dark:text-gray-400 text-center text-pretty">
+  <%= if @has_email_code? do %>
+    We've sent an email with your code to: <br />
+    <span class="font-semibold">{@conn.assigns[:current_user].email}</span>
+  <% else %>
+    We'll send a 4-digit activation code to: <br />
+    <span class="font-semibold">{@conn.assigns[:current_user].email}</span>
+  <% end %>
+</p>
 
-<.focus_box>
-  <:title>
-    <%= if @has_email_code? do %>
-      <%= if @has_any_memberships? do %>
-        Verify your email address
-      <% else %>
-        Activate your account
-      <% end %>
-    <% else %>
-      Activate your account
-    <% end %>
-  </:title>
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+  <%= if @has_email_code? do %>
+    <.form
+      :let={f}
+      for={@conn}
+      action={@form_submit_url}
+      class="flex flex-col gap-y-6"
+    >
+      <input type="hidden" name="team_identifier" value={@team_identifier} />
 
-  <:subtitle :if={@has_email_code?}>
-    <p class="break-all">
-      Please enter the 4-digit code we sent to <b>{@conn.assigns[:current_user].email}</b>
-    </p>
-  </:subtitle>
+      <div class="flex flex-col gap-y-2">
+        <.otp_input field={f[:code]} length={4} autosubmit? autofocus="autofocus" />
+        <p :if={@error} class="text-xs text-red-500 text-center">
+          {@error}
+        </p>
+      </div>
 
-  <:subtitle :if={!@has_email_code?}>
-    <p class="break-all">
-      A 4-digit activation code will be sent to <b>{@conn.assigns[:current_user].email}</b>
-    </p>
-  </:subtitle>
-
-  <div :if={@has_email_code?}>
-    <.form :let={f} for={@conn} action={@form_submit_url}>
-      <.input type="hidden" field={f[:team_identifier]} />
-      <.input
-        field={f[:code]}
-        class="tracking-widest font-medium shadow-xs focus:ring-indigo-500 focus:border-indigo-500 block w-36 px-8 border-gray-300 dark:border-gray-500 rounded-md dark:text-gray-200 dark:bg-gray-900 text-center"
-        oninput="this.value=this.value.replace(/[^0-9]/g, ''); if (this.value.length >= 4) document.getElementById('submit').focus()"
-        onclick="this.select();"
-        maxlength="4"
-        placeholder="••••"
-        style="letter-spacing: 10px;"
-        required={true}
-      />
-      <.button id="submit" type="submit" class="w-full mt-8">
-        Activate
+      <.button type="submit" class="w-full" mt?={false}>
+        Activate account
       </.button>
     </.form>
-  </div>
 
-  <.error>{@error}</.error>
-
-  <div :if={!@has_email_code?}>
-    <.button_link method="post" class="w-full" href="/activate/request-code">
-      Request activation code
-    </.button_link>
-  </div>
-
-  <:footer :if={@has_email_code?}>
-    <b>Didn't receive an email?</b>
-
-    <.focus_list>
-      <:item>
-        Check your spam folder
-      </:item>
-      <:item>
-        <.styled_link href="/activate/request-code" method="post">
-          Send a new code
-        </.styled_link>
-        to {@conn.assigns[:current_user].email}
-      </:item>
-      <:item :if={ee?()}>
-        <.styled_link href="https://plausible.io/contact" new_tab={true}>
-          Contact us
-        </.styled_link>
-        if the problem persists
-      </:item>
-      <:item :if={ce?()}>
-        Ask on our
-        <.styled_link href="https://github.com/plausible/analytics/discussions" new_tab={true}>
-          community-supported forum
-        </.styled_link>
-      </:item>
-    </.focus_list>
-
-    <b>Entered the wrong email address?</b>
-
-    <.focus_list>
-      <:item :if={@has_any_memberships?}>
-        <.styled_link method="post" href={Routes.settings_path(@conn, :cancel_update_email)}>
-          Change email back to
-        </.styled_link>
-        {@conn.assigns[:current_user].previous_email}
-      </:item>
-
-      <:item :if={not @has_any_memberships?}>
+    <div class="mt-6 flex flex-col gap-y-2 text-sm text-gray-500 dark:text-gray-400 text-center">
+      <p>
+        Didn't receive it?
+        <.styled_link href="/activate/request-code" method="post">Resend code</.styled_link>
+        or
+        <%= if @has_any_memberships? do %>
+          <.styled_link method="post" href={Routes.settings_path(@conn, :cancel_update_email)}>
+            use my previous email
+          </.styled_link>
+        <% else %>
+          <.styled_link method="delete" href="/me?redirect=/register">change email</.styled_link>
+        <% end %>
+      </p>
+      <p :if={ee?()}>
+        Need help?
+        <.styled_link href="https://plausible.io/contact" new_tab={true}>Contact us</.styled_link>
+      </p>
+      <p :if={ce?()}>
+        Need help? Ask on our
         <.styled_link
-          method="delete"
-          href="/me?redirect=/register"
-          data-confim="Deleting your account cannot be reversed. Are you sure?"
+          href="https://github.com/plausible/analytics/discussions"
+          new_tab={true}
         >
-          Delete this account
+          community forum
         </.styled_link>
-        and start over
-      </:item>
-    </.focus_list>
-  </:footer>
-</.focus_box>
+      </p>
+    </div>
+  <% else %>
+    <div class="flex flex-col gap-y-2">
+      <.button_link method="post" class="w-full" href="/activate/request-code">
+        Send activation code
+      </.button_link>
+      <p :if={@error} class="text-xs text-red-500 text-center">
+        {@error}
+      </p>
+    </div>
+
+    <p class="mt-6 text-sm text-gray-500 dark:text-gray-400 text-center">
+      Wrong email?
+      <%= if @has_any_memberships? do %>
+        <.styled_link method="post" href={Routes.settings_path(@conn, :cancel_update_email)}>
+          use my previous email
+        </.styled_link>
+      <% else %>
+        <.styled_link method="delete" href="/me?redirect=/register">change email</.styled_link>
+      <% end %>
+    </p>
+  <% end %>
+</div>

--- a/lib/plausible_web/templates/auth/activate.html.heex
+++ b/lib/plausible_web/templates/auth/activate.html.heex
@@ -19,7 +19,7 @@
       <input type="hidden" name="team_identifier" value={@team_identifier} />
 
       <div class="flex flex-col gap-y-2">
-        <.otp_input field={f[:code]} length={4} autosubmit? autofocus="autofocus" />
+        <.otp_input field={f[:code]} length={4} autofocus="autofocus" />
         <p :if={@error} class="text-xs text-red-500 text-center">
           {@error}
         </p>

--- a/lib/plausible_web/templates/auth/login_form.html.heex
+++ b/lib/plausible_web/templates/auth/login_form.html.heex
@@ -53,23 +53,21 @@
           New here? <.styled_link href="/register">Create your account</.styled_link>
         </p>
 
-        <%= if ee?() do %>
-          <%= on_ee do %>
-            <div class="flex items-center justify-center gap-x-1 text-sm text-gray-500 dark:text-gray-400">
-              <Heroicons.lock_closed class="size-3.5" />
-              <span>
-                Continue with
-                <.styled_link href={
-                  Routes.sso_path(@conn, :login_form,
-                    return_to: @conn.params["return_to"],
-                    prefer: "manual"
-                  )
-                }>
-                  SSO
-                </.styled_link>
-              </span>
-            </div>
-          <% end %>
+        <%= on_ee do %>
+          <div class="flex items-center justify-center gap-x-1 text-sm text-gray-500 dark:text-gray-400">
+            <Heroicons.lock_closed class="size-3.5" />
+            <span>
+              Continue with
+              <.styled_link href={
+                Routes.sso_path(@conn, :login_form,
+                  return_to: @conn.params["return_to"],
+                  prefer: "manual"
+                )
+              }>
+                SSO
+              </.styled_link>
+            </span>
+          </div>
         <% end %>
       </div>
     </div>

--- a/lib/plausible_web/templates/auth/login_form.html.heex
+++ b/lib/plausible_web/templates/auth/login_form.html.heex
@@ -1,4 +1,4 @@
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+<.auth_container>
   <.form :let={f} for={@conn} action="/login" class="flex flex-col gap-y-6">
     <div class="flex flex-col gap-y-2">
       <label for={f[:email].id} class="text-sm font-semibold text-gray-800 dark:text-gray-200">
@@ -74,4 +74,4 @@
       </div>
     </div>
   </.form>
-</div>
+</.auth_container>

--- a/lib/plausible_web/templates/auth/login_form.html.heex
+++ b/lib/plausible_web/templates/auth/login_form.html.heex
@@ -1,75 +1,77 @@
-<.focus_box>
-  <:title>
-    {Phoenix.Flash.get(@flash, :login_title) || "Enter your account credentials"}
-  </:title>
-  <:subtitle>
-    <%= if Phoenix.Flash.get(@flash, :login_instructions) do %>
-      <p class="text-gray-500 mt-1 mb-2">
-        {Phoenix.Flash.get(@flash, :login_instructions)}
-      </p>
-    <% end %>
-  </:subtitle>
-  <.form :let={f} for={@conn} action="/login">
-    <div class="my-4 mt-8">
-      <.input
-        type="email"
-        autocomplete="username"
-        placeholder="user@example.com"
-        field={f[:email]}
-        label="Email"
-      />
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+  <.form :let={f} for={@conn} action="/login" class="flex flex-col gap-y-6">
+    <div class="flex flex-col gap-y-2">
+      <label for={f[:email].id} class="text-sm font-semibold text-gray-800 dark:text-gray-200">
+        Email
+      </label>
+      <div>
+        <.input
+          type="email"
+          autocomplete="username"
+          placeholder="example@email.com"
+          field={f[:email]}
+          mt?={false}
+          autofocus="autofocus"
+        />
+      </div>
     </div>
-    <div class="my-4">
-      <.input
-        type="password"
-        autocomplete="current-password"
+
+    <div class="relative flex flex-col gap-y-2">
+      <label for="current-password" class="text-sm font-semibold text-gray-800 dark:text-gray-200">
+        Password
+      </label>
+      <.password_field
         id="current-password"
+        autocomplete="current-password"
         field={f[:password]}
-        label="Password"
+        mt?={false}
       />
+      <.styled_link href="/password/request-reset" class="text-sm absolute top-0 right-0">
+        Forgot password?
+      </.styled_link>
+      <p
+        :if={login_error = Phoenix.Flash.get(@flash, :login_error)}
+        class="text-xs text-red-500"
+      >
+        {login_error}
+      </p>
     </div>
 
-    <%= if login_error = Phoenix.Flash.get(@flash, :login_error) do %>
-      <div class="text-red-500 mt-4">{login_error}</div>
-    <% end %>
+    <input type="hidden" name="return_to" value={@conn.params["return_to"]} />
 
-    <.input type="hidden" field={f[:return_to]} />
+    <div class="flex flex-col gap-y-6">
+      <.button class="w-full" type="submit">Sign in</.button>
 
-    <.button class="w-full" type="submit">Log in</.button>
-  </.form>
+      <div class="flex flex-col gap-y-2">
+        <p
+          :if={
+            Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) ==
+              false
+          }
+          class="text-sm text-center text-gray-500 dark:text-gray-400"
+        >
+          New here? <.styled_link href="/register">Create your account</.styled_link>
+        </p>
 
-  <:footer>
-    <.focus_list>
-      <:item :if={
-        Keyword.fetch!(Application.get_env(:plausible, :selfhost), :disable_registration) == false
-      }>
-        Don't have an account?
-        <.styled_link href="/register">
-          Register
-        </.styled_link>
-        instead.
-      </:item>
-      <:item :if={ee?()}>
-        <%= on_ee do %>
-          Have a Single Sign-on account?
-          <.styled_link href={
-            Routes.sso_path(@conn, :login_form,
-              return_to: @conn.params["return_to"],
-              prefer: "manual"
-            )
-          }>
-            Sign in here
-          </.styled_link>
-          instead.
+        <%= if ee?() do %>
+          <%= on_ee do %>
+            <div class="flex items-center justify-center gap-x-1 text-sm text-gray-500 dark:text-gray-400">
+              <Heroicons.lock_closed class="size-3.5" />
+              <span>
+                Continue with
+                <.styled_link href={
+                  Routes.sso_path(@conn, :login_form,
+                    return_to: @conn.params["return_to"],
+                    prefer: "manual"
+                  )
+                }>
+                  SSO
+                </.styled_link>
+              </span>
+            </div>
+          <% end %>
         <% end %>
-      </:item>
-      <:item>
-        Forgot password?
-        <.styled_link href="/password/request-reset">
-          Click here
-        </.styled_link>
-        to reset it.
-      </:item>
-    </.focus_list>
-  </:footer>
-</.focus_box>
+      </div>
+    </div>
+  </.form>
+</div>

--- a/lib/plausible_web/templates/auth/password_reset_error.html.heex
+++ b/lib/plausible_web/templates/auth/password_reset_error.html.heex
@@ -1,0 +1,5 @@
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4 flex justify-center">
+  <.button_link href="/password/request-reset" mt?={false}>
+    Send new reset link
+  </.button_link>
+</div>

--- a/lib/plausible_web/templates/auth/password_reset_error.html.heex
+++ b/lib/plausible_web/templates/auth/password_reset_error.html.heex
@@ -1,5 +1,5 @@
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4 flex justify-center">
+<.auth_container class="flex justify-center">
   <.button_link href="/password/request-reset" mt?={false}>
     Send new reset link
   </.button_link>
-</div>
+</.auth_container>

--- a/lib/plausible_web/templates/auth/password_reset_form.html.heex
+++ b/lib/plausible_web/templates/auth/password_reset_form.html.heex
@@ -1,4 +1,6 @@
-{live_render(@conn, PlausibleWeb.Live.ResetPasswordForm,
-  container: {:div, class: "contents"},
-  session: %{"email" => @email}
-)}
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+  {live_render(@conn, PlausibleWeb.Live.ResetPasswordForm,
+    container: {:div, class: "contents"},
+    session: %{"email" => @email}
+  )}
+</div>

--- a/lib/plausible_web/templates/auth/password_reset_form.html.heex
+++ b/lib/plausible_web/templates/auth/password_reset_form.html.heex
@@ -1,6 +1,6 @@
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+<.auth_container>
   {live_render(@conn, PlausibleWeb.Live.ResetPasswordForm,
     container: {:div, class: "contents"},
     session: %{"email" => @email}
   )}
-</div>
+</.auth_container>

--- a/lib/plausible_web/templates/auth/password_reset_request_form.html.heex
+++ b/lib/plausible_web/templates/auth/password_reset_request_form.html.heex
@@ -1,4 +1,4 @@
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+<.auth_container>
   <.form
     :let={f}
     for={@conn}
@@ -43,4 +43,4 @@
       </p>
     </div>
   </.form>
-</div>
+</.auth_container>

--- a/lib/plausible_web/templates/auth/password_reset_request_form.html.heex
+++ b/lib/plausible_web/templates/auth/password_reset_request_form.html.heex
@@ -1,31 +1,46 @@
-<.focus_box>
-  <:title>
-    Reset your password
-  </:title>
-
-  <:subtitle>
-    Enter your email so we can send a password reset link
-  </:subtitle>
-
-  <.form :let={f} for={@conn} action={Routes.auth_path(@conn, :password_reset_request)}>
-    <div class="my-4 mt-8">
-      <.input type="email" field={f[:email]} placeholder="user@example.com" />
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+  <.form
+    :let={f}
+    for={@conn}
+    action={Routes.auth_path(@conn, :password_reset_request)}
+    class="flex flex-col gap-y-6"
+  >
+    <div class="flex flex-col gap-y-2">
+      <label for={f[:email].id} class="text-sm font-semibold text-gray-800 dark:text-gray-200">
+        Email
+      </label>
+      <div>
+        <.input
+          type="email"
+          autocomplete="username"
+          placeholder="example@email.com"
+          field={f[:email]}
+          mt?={false}
+          autofocus="autofocus"
+        />
+      </div>
+      <p :if={@conn.assigns[:error]} class="text-xs text-red-500">
+        {@conn.assigns[:error]}
+      </p>
     </div>
-    <%= if @conn.assigns[:error] do %>
-      <div class="text-red-500 my-2">{@conn.assigns[:error]}</div>
-    <% end %>
 
     <%= if PlausibleWeb.Captcha.enabled?() do %>
-      <div class="mt-4">
+      <div>
         <div class="h-captcha" data-sitekey={PlausibleWeb.Captcha.sitekey()}></div>
-        <%= if assigns[:captcha_error] do %>
-          <div class="text-red-500 text-xs mt-3">{@captcha_error}</div>
-        <% end %>
+        <p :if={assigns[:captcha_error]} class="text-xs text-red-500 mt-2">
+          {@captcha_error}
+        </p>
         <script src="https://hcaptcha.com/1/api.js" async defer>
         </script>
       </div>
     <% end %>
 
-    <.button class="w-full" type="submit">Send reset link</.button>
+    <div class="flex flex-col gap-y-4">
+      <.button class="w-full" type="submit" mt?={false}>Send reset link</.button>
+
+      <p class="text-sm text-center text-gray-500 dark:text-gray-400">
+        <.styled_link href="/login">Back to sign in</.styled_link>
+      </p>
+    </div>
   </.form>
-</.focus_box>
+</div>

--- a/lib/plausible_web/templates/auth/password_reset_request_success.html.heex
+++ b/lib/plausible_web/templates/auth/password_reset_request_success.html.heex
@@ -2,7 +2,7 @@
   If an account exists for <span class="font-semibold">{@email}</span>, we've sent a password reset email.
 </p>
 
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4 border-t border-gray-200 dark:border-gray-700 pt-10">
+<.auth_container class="border-t border-gray-200 dark:border-gray-700 pt-10">
   <div class="flex flex-col gap-y-2 text-sm text-gray-500 dark:text-gray-400 text-center">
     <p class="font-semibold">
       Didn't receive the email?
@@ -24,4 +24,4 @@
   <p class="mt-10 text-sm text-center text-gray-500 dark:text-gray-400">
     <.styled_link href="/login">Back to sign in</.styled_link>
   </p>
-</div>
+</.auth_container>

--- a/lib/plausible_web/templates/auth/password_reset_request_success.html.heex
+++ b/lib/plausible_web/templates/auth/password_reset_request_success.html.heex
@@ -1,27 +1,27 @@
-<div class="bg-white dark:bg-gray-800 max-w-md w-full mx-auto shadow-md rounded-sm px-8 pt-6 pb-8 mb-4 mt-8">
-  <h2 class="text-xl font-black dark:text-gray-100">Success!</h2>
-  <div class="my-4 leading-tight dark:text-gray-100">
-    We've sent an email containing password reset instructions to <b>{@email}</b>
-    if it's registered in our system.
-  </div>
-  <div class="mt-8 text-sm dark:text-gray-100">
-    Didn't receive the email within a few minutes?
-  </div>
-  <div class="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-tight">
-    You might have used an email address that's not registered in our database. Please verify the email address associated with your Plausible account and attempt the password reset once more.
-  </div>
-  <div class="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-tight">
-    <span :if={ce?()}>
-      Certain that you're using the correct email address but still aren't receiving the password reset email? Please check your spam folder or ask on our <a
-        href="https://github.com/plausible/analytics/discussions"
-        class="text-indigo-500"
-      >community-supported forum</a>.
-    </span>
-    <span :if={ee?()}>
-      Certain that you're using the correct email address but still aren't receiving the password reset email? Please check your spam folder or <a
+<p class="max-w-md mx-auto mt-2 px-4 text-base text-gray-500 dark:text-gray-400 text-center">
+  If an account exists for <span class="font-semibold">{@email}</span>, we've sent a password reset email.
+</p>
+
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4 border-t border-gray-200 dark:border-gray-700 pt-10">
+  <div class="flex flex-col gap-y-2 text-sm text-gray-500 dark:text-gray-400 text-center">
+    <p class="font-semibold">
+      Didn't receive the email?
+    </p>
+    <p :if={ee?()}>
+      It may take a few minutes to arrive. Check your spam folder or try again with the email address associated with your account. Still no email? <.styled_link
         href="https://plausible.io/contact"
-        class="text-indigo-500"
-      >contact us</a>.
-    </span>
+        new_tab={true}
+      >Contact us</.styled_link>.
+    </p>
+    <p :if={ce?()}>
+      It may take a few minutes to arrive. Check your spam folder or try again with the email address associated with your account. Still no email? Ask on our <.styled_link
+        href="https://github.com/plausible/analytics/discussions"
+        new_tab={true}
+      >community forum</.styled_link>.
+    </p>
   </div>
+
+  <p class="mt-10 text-sm text-center text-gray-500 dark:text-gray-400">
+    <.styled_link href="/login">Back to sign in</.styled_link>
+  </p>
 </div>

--- a/lib/plausible_web/templates/auth/verify_2fa.html.heex
+++ b/lib/plausible_web/templates/auth/verify_2fa.html.heex
@@ -1,4 +1,4 @@
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+<.auth_container>
   <.form
     :let={f}
     action={Routes.auth_path(@conn, :verify_2fa, Map.take(@conn.query_params, ["return_to"]))}
@@ -41,4 +41,4 @@
       </.styled_link>
     </p>
   </div>
-</div>
+</.auth_container>

--- a/lib/plausible_web/templates/auth/verify_2fa.html.heex
+++ b/lib/plausible_web/templates/auth/verify_2fa.html.heex
@@ -11,6 +11,7 @@
       field={:code}
       class=""
       autofocus?={true}
+      error={@error}
     />
 
     <div class="flex justify-center items-center">

--- a/lib/plausible_web/templates/auth/verify_2fa.html.heex
+++ b/lib/plausible_web/templates/auth/verify_2fa.html.heex
@@ -1,49 +1,44 @@
-<.focus_box>
-  <:title>
-    Enter Your 2FA Code
-  </:title>
-
-  <:subtitle>
-    Enter the code from your authenticator application before it expires or wait for a new one.
-  </:subtitle>
-
-  <:footer>
-    <.focus_list>
-      <:item>
-        Can't access your authenticator app?
-        <.styled_link href={Routes.auth_path(@conn, :verify_2fa_recovery_code_form)}>
-          Use recovery code
-        </.styled_link>
-      </:item>
-      <:item :if={ee?()}>
-        Lost your recovery codes?
-        <.styled_link href="https://plausible.io/contact">
-          Contact us
-        </.styled_link>
-      </:item>
-    </.focus_list>
-  </:footer>
-
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
   <.form
     :let={f}
     action={Routes.auth_path(@conn, :verify_2fa, Map.take(@conn.query_params, ["return_to"]))}
     for={@conn.params}
+    class="flex flex-col gap-y-6"
     onsubmit="document.getElementById('verify-button').disabled = true"
   >
-    <div class="mt-2 text-gray-500 dark:text-gray-200 leading-tight">
-      <PlausibleWeb.Components.TwoFactor.verify_2fa_input form={f} field={:code} class="mt-6" />
+    <PlausibleWeb.Components.TwoFactor.verify_2fa_input
+      form={f}
+      field={:code}
+      class=""
+      autofocus?={true}
+    />
 
-      <div>
-        <.input
-          type="checkbox"
-          field={f[:remember_2fa]}
-          value="true"
-          label={"Trust this device for #{@remember_2fa_days} days"}
-          class="block h-5 w-5 rounded-sm dark:bg-gray-700 border-gray-300 text-indigo-600 focus:ring-indigo-600"
-        />
-      </div>
-
-      <.input type="hidden" field={f[:return_to]} />
+    <div class="flex justify-center items-center">
+      <.input
+        type="checkbox"
+        field={f[:remember_2fa]}
+        value="true"
+        label={"Remember this device for #{@remember_2fa_days} days"}
+        mt?={false}
+        class="block size-5 rounded-sm dark:bg-gray-700 border-gray-300 text-indigo-600 focus:ring-indigo-600"
+      />
     </div>
+
+    <.input type="hidden" field={f[:return_to]} mt?={false} />
   </.form>
-</.focus_box>
+
+  <div class="mt-6 flex flex-col gap-y-2 text-sm text-gray-500 dark:text-gray-400 text-center">
+    <p>
+      Can't access your authenticator app?
+      <.styled_link href={Routes.auth_path(@conn, :verify_2fa_recovery_code_form)}>
+        Use a recovery code
+      </.styled_link>
+    </p>
+    <p :if={ee?()}>
+      Need help?
+      <.styled_link href="https://plausible.io/contact">
+        Contact us
+      </.styled_link>
+    </p>
+  </div>
+</div>

--- a/lib/plausible_web/templates/auth/verify_2fa_recovery_code.html.heex
+++ b/lib/plausible_web/templates/auth/verify_2fa_recovery_code.html.heex
@@ -1,4 +1,4 @@
-<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
+<.auth_container>
   <.form
     :let={f}
     for={@conn.params}
@@ -46,4 +46,4 @@
       </.styled_link>
     </p>
   </div>
-</div>
+</.auth_container>

--- a/lib/plausible_web/templates/auth/verify_2fa_recovery_code.html.heex
+++ b/lib/plausible_web/templates/auth/verify_2fa_recovery_code.html.heex
@@ -6,17 +6,22 @@
     class="flex flex-col gap-y-6"
     onsubmit="document.getElementById('use-code-button').disabled = true"
   >
-    <.input
-      type="text"
-      field={f[:recovery_code]}
-      autocomplete="off"
-      autofocus="autofocus"
-      maxlength="10"
-      oninvalid="document.getElementById('use-code-button').disabled = false"
-      required="required"
-      placeholder="Recovery code"
-      mt?={false}
-    />
+    <div class="flex flex-col gap-y-2">
+      <.input
+        type="text"
+        field={f[:recovery_code]}
+        autocomplete="off"
+        autofocus="autofocus"
+        maxlength="10"
+        oninvalid="document.getElementById('use-code-button').disabled = false"
+        required="required"
+        placeholder="Recovery code"
+        mt?={false}
+      />
+      <p :if={@error} class="text-xs text-red-500 text-center">
+        {@error}
+      </p>
+    </div>
 
     <.button
       id="use-code-button"

--- a/lib/plausible_web/templates/auth/verify_2fa_recovery_code.html.heex
+++ b/lib/plausible_web/templates/auth/verify_2fa_recovery_code.html.heex
@@ -1,57 +1,49 @@
-<.focus_box>
-  <:title>
-    Enter Recovery Code
-  </:title>
-
-  <:subtitle>
-    Can't access your authenticator application? Enter a recovery code instead.
-  </:subtitle>
-
-  <:footer>
-    Authenticator application working again?
-    <.styled_link href={Routes.auth_path(@conn, :verify_2fa)}>
-      Enter code
-    </.styled_link>
-    <%= if ee?() do %>
-      <br /> Lost your recovery codes?
-      <.styled_link href="https://plausible.io/contact">
-        Contact us
-      </.styled_link>
-    <% end %>
-  </:footer>
-
+<div class="w-full max-w-md mx-auto mt-10 pb-16 px-4">
   <.form
     :let={f}
     for={@conn.params}
     action={Routes.auth_path(@conn, :verify_2fa_recovery_code)}
+    class="flex flex-col gap-y-6"
     onsubmit="document.getElementById('use-code-button').disabled = true"
   >
-    <div class="mt-6">
-      <div>
-        <.input
-          type="text"
-          field={f[:recovery_code]}
-          autocomplete="off"
-          maxlength="10"
-          oninvalid="document.getElementById('use-code-button').disabled = false"
-          required="required"
-          placeholder="Enter recovery code"
-        />
-      </div>
-      <.button
-        id="use-code-button"
-        type="submit"
-        class="w-full mt-4 [&>span.label-enabled]:block [&>span.label-disabled]:hidden [&[disabled]>span.label-enabled]:hidden [&[disabled]>span.label-disabled]:block"
-      >
-        <span class="label-enabled pointer-events-none">
-          Use Code
-        </span>
+    <.input
+      type="text"
+      field={f[:recovery_code]}
+      autocomplete="off"
+      autofocus="autofocus"
+      maxlength="10"
+      oninvalid="document.getElementById('use-code-button').disabled = false"
+      required="required"
+      placeholder="Recovery code"
+      mt?={false}
+    />
 
-        <span class="label-disabled">
-          <.spinner class="inline-block h-5 w-5 mr-2 text-white dark:text-gray-400" />
-          Verifying...
-        </span>
-      </.button>
-    </div>
+    <.button
+      id="use-code-button"
+      type="submit"
+      mt?={false}
+      class="w-full [&>span.label-enabled]:block [&>span.label-disabled]:hidden [&[disabled]>span.label-enabled]:hidden [&[disabled]>span.label-disabled]:block"
+    >
+      <span class="label-enabled pointer-events-none">
+        Verify
+      </span>
+      <span class="label-disabled">
+        <.spinner class="inline-block h-5 w-5 mr-2 text-white dark:text-gray-400" /> Verifying...
+      </span>
+    </.button>
   </.form>
-</.focus_box>
+
+  <div class="mt-6 flex flex-col gap-y-2 text-sm text-gray-500 dark:text-gray-400 text-center">
+    <p>
+      <.styled_link href={Routes.auth_path(@conn, :verify_2fa)}>
+        Use authenticator app instead
+      </.styled_link>
+    </p>
+    <p :if={ee?()}>
+      Lost your recovery codes?
+      <.styled_link href="https://plausible.io/contact">
+        Contact us
+      </.styled_link>
+    </p>
+  </div>
+</div>

--- a/lib/plausible_web/templates/auth/verify_2fa_setup.html.heex
+++ b/lib/plausible_web/templates/auth/verify_2fa_setup.html.heex
@@ -31,6 +31,11 @@
     id="verify-2fa-form"
     onsubmit="document.getElementById('verify-button').disabled = true"
   >
-    <PlausibleWeb.Components.TwoFactor.verify_2fa_input form={f} field={:code} class="mt-6" />
+    <PlausibleWeb.Components.TwoFactor.verify_2fa_input
+      form={f}
+      field={:code}
+      class="mt-6"
+      autofocus?={true}
+    />
   </.form>
 </.focus_box>

--- a/lib/plausible_web/templates/layout/_header.html.heex
+++ b/lib/plausible_web/templates/layout/_header.html.heex
@@ -3,28 +3,7 @@
     <nav class="relative flex items-center justify-between sm:h-10 md:justify-center">
       <div class="flex items-center flex-1 md:absolute md:inset-y-0 md:left-0">
         <a href={home_dest(@conn)}>
-          <img
-            src={
-              PlausibleWeb.Router.Helpers.static_path(
-                @conn,
-                logo_path("logo_dark.svg")
-              )
-            }
-            class="w-30 hidden dark:inline"
-            alt="Plausible logo"
-            loading="lazy"
-          />
-          <img
-            src={
-              PlausibleWeb.Router.Helpers.static_path(
-                @conn,
-                logo_path("logo_light.svg")
-              )
-            }
-            class="w-30 inline dark:hidden"
-            alt="Plausible logo"
-            loading="lazy"
-          />
+          <Layout.logo />
         </a>
       </div>
       <div class="absolute inset-y-0 right-0 flex items-center justify-end">

--- a/lib/plausible_web/templates/layout/_notice.html.heex
+++ b/lib/plausible_web/templates/layout/_notice.html.heex
@@ -1,7 +1,3 @@
-<%= if assigns[:flash] do %>
-  {render("_flash.html", assigns)}
-<% end %>
-
 <div :if={assigns[:current_team]} class="flex flex-col gap-y-2">
   <Notice.active_grace_period
     :if={Plausible.Teams.GracePeriod.active?(@current_team)}

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -37,6 +37,10 @@
     ]}
     style={if assigns[:background], do: "background-color: #{assigns[:background]}"}
   >
+    <%= if !assigns[:embedded] && assigns[:flash] do %>
+      {render("_flash.html", assigns)}
+    <% end %>
+
     <%= if !assigns[:embedded] && !assigns[:hide_header?] do %>
       {render("_header.html", assigns)}
 

--- a/lib/plausible_web/templates/layout/auth.html.heex
+++ b/lib/plausible_web/templates/layout/auth.html.heex
@@ -1,0 +1,18 @@
+<div class="min-h-screen w-full bg-white dark:bg-gray-900">
+  <div class="flex justify-center pt-12 sm:pt-20">
+    <a href="/">
+      <Layout.logo />
+    </a>
+  </div>
+
+  <div class="max-w-md mx-auto mt-10 sm:mt-16 px-4 flex flex-col gap-y-2 text-center dark:text-gray-300">
+    <h1 class="text-lg sm:text-xl font-semibold">
+      {@heading}
+    </h1>
+    <p :if={assigns[:subtitle]} class="text-base text-gray-500 dark:text-gray-400 text-pretty">
+      {@subtitle}
+    </p>
+  </div>
+
+  {@inner_content}
+</div>

--- a/lib/plausible_web/templates/layout/base_error.html.heex
+++ b/lib/plausible_web/templates/layout/base_error.html.heex
@@ -11,28 +11,7 @@
   <body class="flex flex-col h-full bg-gray-100 dark:bg-gray-900">
     <div class="w-full my-8 text-center">
       <a href={home_dest(@conn)}>
-        <img
-          src={
-            PlausibleWeb.Router.Helpers.static_path(
-              @conn,
-              logo_path("logo_dark.svg")
-            )
-          }
-          class="w-44 hidden dark:inline"
-          alt="Plausible logo"
-          loading="lazy"
-        />
-        <img
-          src={
-            PlausibleWeb.Router.Helpers.static_path(
-              @conn,
-              logo_path("logo_light.svg")
-            )
-          }
-          class="w-44 inline dark:hidden"
-          alt="Plausible logo"
-          loading="lazy"
-        />
+        <Layout.logo />
       </a>
     </div>
 

--- a/lib/plausible_web/templates/settings/security.html.heex
+++ b/lib/plausible_web/templates/settings/security.html.heex
@@ -91,7 +91,7 @@
         width="w-1/2"
       />
 
-      <div :if={@totp_enabled?} class="mt-2">
+      <div :if={@totp_enabled?} class="mt-6">
         <.label for={f[:two_factor_code].id} class="mb-2">
           Verify with 2FA Code
         </.label>
@@ -99,6 +99,7 @@
           form={f}
           show_button?={false}
           field={:two_factor_code}
+          class="w-1/2"
         />
       </div>
 

--- a/lib/plausible_web/user_auth.ex
+++ b/lib/plausible_web/user_auth.ex
@@ -49,7 +49,10 @@ defmodule PlausibleWeb.UserAuth do
         {:error, :integration_not_found} ->
           conn
           |> log_out_user()
-          |> Phoenix.Controller.put_flash(:login_error, "Wrong email.")
+          |> Phoenix.Controller.put_flash(
+            :login_error,
+            "We couldn't find a Single Sign-On account for that email."
+          )
           |> Phoenix.Controller.redirect(
             to: Routes.sso_path(conn, :login_form, return_to: redirect_path)
           )

--- a/test/plausible_web/components/flow_progress_test.exs
+++ b/test/plausible_web/components/flow_progress_test.exs
@@ -27,11 +27,11 @@ defmodule PlausibleWeb.Components.FlowProgressTest do
     rendered =
       render_component(&FlowProgress.render/1,
         flow: PlausibleWeb.Flows.register(),
-        current_step: "Register"
+        current_step: "Add site info"
       )
 
     assert text_of_element(rendered, "#flow-progress") ==
-             "1 Register 2 Activate account 3 Add site info 4 Install Plausible 5 Verify installation"
+             "1 Add site info 2 Install Plausible 3 Verify installation"
   end
 
   test "invitation" do

--- a/test/plausible_web/controllers/admin_auth_controller_test.exs
+++ b/test/plausible_web/controllers/admin_auth_controller_test.exs
@@ -17,7 +17,7 @@ defmodule PlausibleWeb.AdminAuthControllerTest do
 
       # "first launch" takes precedence
       conn = get(conn, "/register")
-      assert html_response(conn, 200) =~ "Enter your details"
+      assert html_response(conn, 200) =~ "Create your Plausible CE account"
     end
   end
 

--- a/test/plausible_web/controllers/auth_controller/logs_test.exs
+++ b/test/plausible_web/controllers/auth_controller/logs_test.exs
@@ -26,7 +26,7 @@ defmodule PlausibleWeb.AuthController.LogsTest do
           post(conn, "/login", email: user.email, password: "wrong")
         end)
 
-      assert logs =~ "[warning] [login] wrong password for #{user.email}"
+      assert logs =~ "[warning] [login] Incorrect password for #{user.email}"
     end
 
     test "logs on too many login attempts" do

--- a/test/plausible_web/controllers/auth_controller/logs_test.exs
+++ b/test/plausible_web/controllers/auth_controller/logs_test.exs
@@ -26,7 +26,7 @@ defmodule PlausibleWeb.AuthController.LogsTest do
           post(conn, "/login", email: user.email, password: "wrong")
         end)
 
-      assert logs =~ "[warning] [login] Incorrect password for #{user.email}"
+      assert logs =~ "[warning] [login] wrong password for #{user.email}"
     end
 
     test "logs on too many login attempts" do

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -486,13 +486,15 @@ defmodule PlausibleWeb.AuthControllerTest do
             end)
 
             conn = post(conn, "/activate", %{code: "1111"})
+            body = html_response(conn, 200)
 
-            {conn.status == 429, conn}
+            {body =~ "Too many attempts", conn}
           end,
           500
         )
 
-      assert html_response(response, 429) =~ "Too many activation attempts"
+      assert html_response(response, 200) =~
+               "Too many attempts. Please wait a few minutes before trying again."
     end
   end
 

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -19,7 +19,13 @@ defmodule PlausibleWeb.AuthControllerTest do
     test "shows the register form", %{conn: conn} do
       conn = get(conn, "/register")
 
-      assert html_response(conn, 200) =~ "Enter your details"
+      html = html_response(conn, 200)
+
+      if ee?() do
+        assert html =~ "Start your 30-day free trial"
+      else
+        assert html =~ "Create your #{Plausible.product_name()} account"
+      end
     end
   end
 
@@ -103,7 +109,7 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       conn = get(conn, "/register/invitation/#{invitation.invitation_id}")
 
-      assert html_response(conn, 200) =~ "Enter your details"
+      assert html_response(conn, 200) =~ "Accept your invitation to join your team."
     end
   end
 
@@ -287,7 +293,7 @@ defmodule PlausibleWeb.AuthControllerTest do
     test "if user does not have a code: prompts user to request activation code", %{conn: conn} do
       conn = get(conn, "/activate")
 
-      assert html_response(conn, 200) =~ "Request activation code"
+      assert html_response(conn, 200) =~ "Send activation code"
     end
 
     test "if user does have a code: prompts user to enter the activation code from their email",
@@ -296,7 +302,7 @@ defmodule PlausibleWeb.AuthControllerTest do
         post(conn, "/activate/request-code")
         |> get("/activate")
 
-      assert html_response(conn, 200) =~ "Please enter the 4-digit code we sent to"
+      assert html_response(conn, 200) =~ "We've sent an email with your code to:"
     end
 
     test "passes team identifier in form data", %{conn: conn, user: user} do
@@ -372,7 +378,8 @@ defmodule PlausibleWeb.AuthControllerTest do
     test "with wrong pin - reloads the form with error", %{conn: conn} do
       conn = post(conn, "/activate", %{code: "1234"})
 
-      assert html_response(conn, 200) =~ "Incorrect activation code"
+      assert html_response(conn, 200) =~
+               htmlize_quotes("That code didn't work. Please try again.")
     end
 
     test "with expired pin - reloads the form with error", %{conn: conn, user: user} do
@@ -385,7 +392,7 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       conn = post(conn, "/activate", %{code: verification.code})
 
-      assert html_response(conn, 200) =~ "Code is expired, please request another one"
+      assert html_response(conn, 200) =~ "The code has expired. Please request another one."
     end
 
     test "marks the user account as active", %{conn: conn, user: user} do
@@ -492,7 +499,7 @@ defmodule PlausibleWeb.AuthControllerTest do
   describe "GET /login_form" do
     test "shows the login form", %{conn: conn} do
       conn = get(conn, "/login")
-      assert html_response(conn, 200) =~ "Enter your account credentials"
+      assert html_response(conn, 200) =~ "Sign in to your account"
     end
 
     test "renders `return_to` query param as hidden input", %{conn: conn} do
@@ -517,7 +524,7 @@ defmodule PlausibleWeb.AuthControllerTest do
     test "keeps standard login form if preference manually overridden", %{conn: conn} do
       conn = PlausibleWeb.LoginPreference.set_sso(conn)
       conn = get(conn, "/login?prefer=manual")
-      assert html_response(conn, 200) =~ "Enter your account credentials"
+      assert html_response(conn, 200) =~ "Sign in to your account"
     end
   end
 
@@ -659,7 +666,7 @@ defmodule PlausibleWeb.AuthControllerTest do
         conn = post(conn, "/login", email: member.email, password: "password")
 
         assert get_session(conn, :user_token) == nil
-        assert html_response(conn, 200) =~ "Enter your account credentials"
+        assert html_response(conn, 200) =~ "Sign in to your account"
       end
 
       test "SSO user other than owner with personal team - renders login form again", %{
@@ -683,7 +690,7 @@ defmodule PlausibleWeb.AuthControllerTest do
         conn = post(conn, "/login", email: member.email, password: "password")
 
         assert get_session(conn, :user_token) == nil
-        assert html_response(conn, 200) =~ "Enter your account credentials"
+        assert html_response(conn, 200) =~ "Sign in to your account"
       end
     end
 
@@ -691,7 +698,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       conn = post(conn, "/login", email: "user@example.com", password: "password")
 
       assert get_session(conn, :user_token) == nil
-      assert html_response(conn, 200) =~ "Enter your account credentials"
+      assert html_response(conn, 200) =~ "Sign in to your account"
     end
 
     test "bad password - renders login form again", %{conn: conn} do
@@ -699,7 +706,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       conn = post(conn, "/login", email: user.email, password: "wrong")
 
       assert get_session(conn, :user_token) == nil
-      assert html_response(conn, 200) =~ "Enter your account credentials"
+      assert html_response(conn, 200) =~ "Sign in to your account"
     end
 
     test "limits login attempts to 5 per minute" do
@@ -758,7 +765,7 @@ defmodule PlausibleWeb.AuthControllerTest do
   describe "GET /password/request-reset" do
     test "renders the form", %{conn: conn} do
       conn = get(conn, "/password/request-reset")
-      assert html_response(conn, 200) =~ "Enter your email so we can send a password reset link"
+      assert html_response(conn, 200) =~ "Enter your email to receive a password reset link."
     end
   end
 
@@ -766,7 +773,7 @@ defmodule PlausibleWeb.AuthControllerTest do
     test "email is empty - renders form with error", %{conn: conn} do
       conn = post(conn, "/password/request-reset", %{email: ""})
 
-      assert html_response(conn, 200) =~ "Enter your email so we can send a password reset link"
+      assert html_response(conn, 200) =~ "Enter your email to receive a password reset link."
     end
 
     test "email is present and exists - sends password reset email", %{conn: conn} do
@@ -774,7 +781,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       user = insert(:user)
       conn = post(conn, "/password/request-reset", %{email: user.email})
 
-      assert html_response(conn, 200) =~ "Success!"
+      assert html_response(conn, 200) =~ "Check your email"
       assert_email_delivered_with(subject: "Plausible password reset")
     end
 
@@ -836,13 +843,13 @@ defmodule PlausibleWeb.AuthControllerTest do
     test "with invalid token - shows error page", %{conn: conn} do
       conn = get(conn, "/password/reset", %{token: "blabla"})
 
-      assert html_response(conn, 401) =~ "Your token is invalid"
+      assert html_response(conn, 401) =~ "Password reset link invalid"
     end
 
     test "without token - shows error page", %{conn: conn} do
       conn = get(conn, "/password/reset", %{})
 
-      assert html_response(conn, 401) =~ "Your token is invalid"
+      assert html_response(conn, 401) =~ "Password reset link invalid"
     end
   end
 

--- a/test/plausible_web/controllers/auth_controller_test.exs
+++ b/test/plausible_web/controllers/auth_controller_test.exs
@@ -1858,10 +1858,7 @@ defmodule PlausibleWeb.AuthControllerTest do
 
       conn = post(conn, Routes.auth_path(conn, :verify_2fa), %{code: "invalid"})
 
-      assert html_response(conn, 200)
-
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
-               "The provided code is invalid"
+      assert html_response(conn, 200) =~ "The provided code is invalid"
     end
 
     test "redirects to login when cookie not found", %{conn: conn} do
@@ -2020,10 +2017,7 @@ defmodule PlausibleWeb.AuthControllerTest do
       conn =
         post(conn, Routes.auth_path(conn, :verify_2fa_recovery_code), %{recovery_code: "invalid"})
 
-      assert html_response(conn, 200)
-
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
-               "The provided recovery code is invalid"
+      assert html_response(conn, 200) =~ "The provided recovery code is invalid"
     end
 
     test "redirects to login when cookie not found", %{conn: conn} do

--- a/test/plausible_web/controllers/sso_controller_sync_test.exs
+++ b/test/plausible_web/controllers/sso_controller_sync_test.exs
@@ -141,7 +141,8 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
-        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) == "Wrong email."
+        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
+                 "We couldn't find a Single Sign-On account for that email."
       end
     end
 
@@ -265,7 +266,8 @@ defmodule PlausibleWeb.SSOControllerSyncTest do
 
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
-        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) == "Wrong email"
+        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
+                 "We couldn't find a Single Sign-On account for that email."
       end
 
       test "redirects with error on mismatch of RelayState", %{

--- a/test/plausible_web/controllers/sso_controller_test.exs
+++ b/test/plausible_web/controllers/sso_controller_test.exs
@@ -59,7 +59,7 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Enter your Single Sign-On email"
+        assert html =~ "Sign in with SSO"
         assert element_exists?(html, "input[name=email]")
         assert text_of_attr(html, ~s|input[name="return_to"]|, "value") == nil
       end
@@ -77,7 +77,7 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Enter your Single Sign-On email"
+        assert html =~ "Sign in with SSO"
         assert text_of_attr(html, "input[name=email]", "value") == "user@example.com"
         assert html =~ ~s|document.getElementById("sso-login-form").submit()|
       end
@@ -96,13 +96,13 @@ defmodule PlausibleWeb.SSOControllerTest do
           |> init_session()
           |> fetch_session()
           |> fetch_flash()
-          |> put_flash(:login_error, "Wrong email.")
+          |> put_flash(:login_error, "We couldn't find a Single Sign-On account for that email.")
 
         conn = get(conn, Routes.sso_path(conn, :login_form, return_to: "/sites"))
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Wrong email."
+        assert html =~ htmlize_quotes("We couldn't find a Single Sign-On account for that email.")
         assert element_exists?(html, "input[name=email]")
         assert text_of_attr(html, "input[name=return_to]", "value") == "/sites"
       end
@@ -151,7 +151,8 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form)
 
-        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) == "Wrong email."
+        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
+                 "We couldn't find a Single Sign-On account for that email."
       end
 
       test "limits login attempts to 5 per minute", %{conn: conn} do
@@ -264,7 +265,8 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "/sites")
 
-        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) == "Wrong email."
+        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
+                 "We couldn't find a Single Sign-On account for that email."
       end
     end
 
@@ -304,10 +306,11 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Single Sign-On enforcement"
-        assert html =~ "To access this team, you must first"
-        assert html =~ "log out"
-        assert html =~ "and log in as SSO user"
+        assert html =~ "Single Sign-On required"
+        assert html =~ "has turned off email and password logins"
+        assert html =~ "To access this team,"
+        assert html =~ "sign out"
+        assert html =~ "and sign in with SSO"
       end
     end
 
@@ -317,8 +320,8 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Single Sign-On enforcement"
-        assert html =~ "To access this team, you must join as a team member first"
+        assert html =~ "Single Sign-On required"
+        assert html =~ "To access this team, you must be added as a team member first"
       end
 
       test "renders issue for multiple_memberships", %{conn: conn} do
@@ -326,8 +329,8 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Single Sign-On enforcement"
-        assert html =~ "To access this team, you must first leave all other teams"
+        assert html =~ "Single Sign-On required"
+        assert html =~ "To access this team, you must leave all other teams first"
       end
 
       test "renders issue for multiple_memberships_noforce", %{conn: conn} do
@@ -339,11 +342,11 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Single Sign-On enforcement"
-        assert html =~ "To log in as an SSO user, you must first leave all other teams"
+        assert html =~ "Single Sign-On required"
+        assert html =~ "To sign in with SSO, you must leave all other teams first"
 
-        assert html =~ "Log in"
-        assert html =~ "with your email and password"
+        assert html =~ "Sign in with email and password"
+        assert html =~ "to resolve the issue"
       end
 
       test "renders issue for active_personal_team", %{conn: conn} do
@@ -351,8 +354,10 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Single Sign-On enforcement"
-        assert html =~ "To access this team, you must either remove or transfer all sites"
+        assert html =~ "Single Sign-On required"
+        assert html =~ "To access this team, remove or transfer all sites under"
+        assert html =~ "My Personal Sites"
+        assert html =~ "cancel its subscription if active"
       end
 
       test "renders issue for active_personal_team_noforce", %{conn: conn} do
@@ -364,13 +369,13 @@ defmodule PlausibleWeb.SSOControllerTest do
 
         assert html = html_response(conn, 200)
 
-        assert html =~ "Single Sign-On enforcement"
+        assert html =~ "Single Sign-On required"
+        assert html =~ "To sign in with SSO, remove or transfer all sites under"
+        assert html =~ "My Personal Sites"
+        assert html =~ "cancel its subscription if active"
 
-        assert html =~
-                 "To log in as an SSO user, you must either remove or transfer all sites"
-
-        assert html =~ "Log in"
-        assert html =~ "with your email and password"
+        assert html =~ "Sign in with email and password"
+        assert html =~ "to resolve the issue"
       end
     end
 

--- a/test/plausible_web/live/components/form_test.exs
+++ b/test/plausible_web/live/components/form_test.exs
@@ -10,9 +10,9 @@ defmodule PlausibleWeb.Live.Components.FormTest do
       doc = render_password_input_with_strength("very-secret-and-very-long-123")
 
       assert element_exists?(doc, ~s/input#user_password[type="password"][name="user[password]"]/)
-      assert element_exists?(doc, ~s/div.rounded-full.bg-indigo-600/)
       refute element_exists?(doc, "label")
-      refute element_exists?(doc, "p")
+      assert text_of_element(doc, "p") =~ "Password strength:"
+      assert text_of_element(doc, "p") =~ "Strong"
     end
 
     test "renders with label when passed" do
@@ -30,7 +30,7 @@ defmodule PlausibleWeb.Live.Components.FormTest do
     test "renders weak password warning and hints when password too short" do
       doc = render_password_input_with_strength("too-short")
 
-      assert text_of_element(doc, "p:first-of-type") == "Password is too weak"
+      assert text_of_element(doc, "p:first-of-type") == "Password is too weak."
       assert text_of_element(doc, "p:last-of-type") != ""
     end
 
@@ -45,7 +45,7 @@ defmodule PlausibleWeb.Live.Components.FormTest do
         )
 
       assert warning_p = find(doc, "p")
-      assert text(warning_p) == "Password is too weak"
+      assert text(warning_p) == "Password is too weak."
     end
 
     test "renders too long password case gracefully" do
@@ -63,7 +63,7 @@ defmodule PlausibleWeb.Live.Components.FormTest do
 
       assert p_hint = find(doc, "p")
       assert text_of_attr(p_hint, "class") =~ "text-gray-500"
-      assert text(p_hint) == "Min 12 characters"
+      assert text(p_hint) == "At least 12 characters"
     end
 
     test "renders for too short password" do
@@ -71,7 +71,7 @@ defmodule PlausibleWeb.Live.Components.FormTest do
 
       assert p_hint = find(doc, "p")
       assert text_of_attr(p_hint, "class") =~ "text-red-500"
-      assert text(p_hint) == "Min 12 characters"
+      assert text(p_hint) == "At least 12 characters"
     end
 
     test "renders gracefully for too long password" do
@@ -80,52 +80,42 @@ defmodule PlausibleWeb.Live.Components.FormTest do
 
       assert p_hint = find(doc, "p")
       assert text_of_attr(p_hint, "class") =~ "text-gray-500"
-      assert text(p_hint) == "Min 12 characters"
+      assert text(p_hint) == "At least 12 characters"
     end
   end
 
   describe "strength_meter/1" do
     test "renders too weak level" do
       doc = render_component(&Form.strength_meter/1, score: 0, warning: "", suggestions: [])
-      meter = find(doc, "div.rounded-full")
 
-      assert text_of_attr(meter, "style") == "width: 0%"
-      assert p_warning = find(doc, "p")
-      assert text(p_warning) == "Password is too weak"
+      refute element_exists?(doc, "div.rounded-full")
+      assert text_of_element(doc, "p") == "Password is too weak."
     end
 
     test "renders very weak level" do
       doc = render_component(&Form.strength_meter/1, score: 1, warning: "", suggestions: [])
-      meter = find(doc, "div.rounded-full")
 
-      assert text_of_attr(meter, "style") == "width: 25%"
-      assert p_warning = find(doc, "p")
-      assert text(p_warning) == "Password is too weak"
+      assert text_of_element(doc, "p") == "Password is too weak."
     end
 
     test "renders somewhat weak level" do
       doc = render_component(&Form.strength_meter/1, score: 2, warning: "", suggestions: [])
-      meter = find(doc, "div.rounded-full")
 
-      assert text_of_attr(meter, "style") == "width: 50%"
-      assert p_warning = find(doc, "p")
-      assert text(p_warning) == "Password is too weak"
+      assert text_of_element(doc, "p") == "Password is too weak."
     end
 
     test "renders strong level" do
       doc = render_component(&Form.strength_meter/1, score: 3, warning: "", suggestions: [])
-      meter = find(doc, "div.rounded-full")
 
-      assert text_of_attr(meter, "style") == "width: 75%"
-      refute element_exists?(doc, "p")
+      assert text_of_element(doc, "p") =~ "Password strength:"
+      assert text_of_element(doc, "p") =~ "Good"
     end
 
     test "renders very strong level" do
       doc = render_component(&Form.strength_meter/1, score: 4, warning: "", suggestions: [])
-      meter = find(doc, "div.rounded-full")
 
-      assert text_of_attr(meter, "style") == "width: 100%"
-      refute element_exists?(doc, "p")
+      assert text_of_element(doc, "p") =~ "Password strength:"
+      assert text_of_element(doc, "p") =~ "Strong"
     end
 
     test "renders hints paragraph when warning hint is present" do

--- a/test/plausible_web/live/register_form_test.exs
+++ b/test/plausible_web/live/register_form_test.exs
@@ -28,11 +28,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
                ~s|input#register-form_password[type="password"][name="user[password]"]|
              )
 
-      assert element_exists?(
-               html,
-               ~s|input#register-form_password_confirmation[type="password"][name="user[password_confirmation]"]|
-             )
-
       assert element_exists?(html, ~s|button[type="submit"]|)
     end
 
@@ -58,7 +53,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       type_into_input(lv, "user[name]", "Mary Sue")
       type_into_input(lv, "user[email]", "mary.sue@plausible.test")
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
-      type_into_input(lv, "user[password_confirmation]", "very-long-and-very-secret-123")
 
       html = lv |> element("form") |> render_submit()
 
@@ -71,8 +65,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
                action_input,
                name_input,
                email_input,
-               password_input,
-               password_confirmation_input | _
+               password_input | _
              ] = find(html, "input") |> Enum.into([])
 
       assert String.length(text_of_attr(csrf_input, "value")) > 0
@@ -80,7 +73,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert text_of_attr(name_input, "value") == "Mary Sue"
       assert text_of_attr(email_input, "value") == "mary.sue@plausible.test"
       assert text_of_attr(password_input, "value") == "very-long-and-very-secret-123"
-      assert text_of_attr(password_confirmation_input, "value") == "very-long-and-very-secret-123"
 
       assert %{
                name: "Mary Sue",
@@ -91,22 +83,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert String.length(password_hash) > 0
     end
 
-    test "renders only one error on empty password confirmation", %{conn: conn} do
-      mock_captcha_success()
-
-      lv = get_liveview(conn, "/register")
-
-      type_into_input(lv, "user[name]", "Mary Sue")
-      type_into_input(lv, "user[email]", "mary.sue@plausible.test")
-      type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
-      type_into_input(lv, "user[password_confirmation]", "")
-
-      html = lv |> element("form") |> render_submit()
-
-      assert html =~ "does not match confirmation"
-      refute html =~ "can't be blank"
-    end
-
     test "renders error on failed captcha", %{conn: conn} do
       mock_captcha_failure()
 
@@ -115,7 +91,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       type_into_input(lv, "user[name]", "Mary Sue")
       type_into_input(lv, "user[email]", "mary.sue@plausible.test")
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
-      type_into_input(lv, "user[password_confirmation]", "very-long-and-very-secret-123")
 
       html = lv |> element("form") |> render_submit()
 
@@ -153,7 +128,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       type_into_input(lv, "user[name]", "Mary Sue")
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
-      type_into_input(lv, "user[password_confirmation]", "very-long-and-very-secret-123")
 
       html = lv |> element("form") |> render_submit()
 
@@ -166,8 +140,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
                action_input,
                email_input,
                name_input,
-               password_input,
-               password_confirmation_input | _
+               password_input | _
              ] = find(html, "input") |> Enum.into([])
 
       assert String.length(text_of_attr(csrf_input, "value")) > 0
@@ -175,7 +148,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert text_of_attr(name_input, "value") == "Mary Sue"
       assert text_of_attr(email_input, "value") == "user@email.co"
       assert text_of_attr(password_input, "value") == "very-long-and-very-secret-123"
-      assert text_of_attr(password_confirmation_input, "value") == "very-long-and-very-secret-123"
 
       assert user =
                %{
@@ -201,7 +173,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       type_into_input(lv, "user[name]", "Mary Sue")
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
-      type_into_input(lv, "user[password_confirmation]", "very-long-and-very-secret-123")
 
       html = lv |> element("form") |> render_submit()
 
@@ -215,8 +186,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
                team_input,
                email_input,
                name_input,
-               password_input,
-               password_confirmation_input | _
+               password_input | _
              ] = find(html, "input") |> Enum.into([])
 
       assert String.length(text_of_attr(csrf_input, "value")) > 0
@@ -225,7 +195,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert text_of_attr(name_input, "value") == "Mary Sue"
       assert text_of_attr(email_input, "value") == "team-user@email.co"
       assert text_of_attr(password_input, "value") == "very-long-and-very-secret-123"
-      assert text_of_attr(password_confirmation_input, "value") == "very-long-and-very-secret-123"
     end
 
     test "preserves trial_expiry_date when invitation role is :owner", %{
@@ -241,7 +210,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       type_into_input(lv, "user[name]", "Mary Sue")
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
-      type_into_input(lv, "user[password_confirmation]", "very-long-and-very-secret-123")
 
       _html = lv |> element("form") |> render_submit()
 
@@ -261,7 +229,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       type_into_input(lv, "user[name]", "Mary Sue")
       type_into_input(lv, "user[email]", "mary.sue@plausible.test")
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
-      type_into_input(lv, "user[password_confirmation]", "very-long-and-very-secret-123")
 
       html = lv |> element("form") |> render_submit()
 
@@ -283,7 +250,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       html = render(lv)
 
-      assert html =~ "Your invitation has expired or been revoked"
+      assert html =~ "This invitation has expired or was revoked"
     end
 
     test "renders error on failed captcha", %{conn: conn, guest_invitation: guest_invitation} do
@@ -293,7 +260,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       type_into_input(lv, "user[name]", "Mary Sue")
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
-      type_into_input(lv, "user[password_confirmation]", "very-long-and-very-secret-123")
 
       html = lv |> element("form") |> render_submit()
 

--- a/test/plausible_web/user_auth_test.exs
+++ b/test/plausible_web/user_auth_test.exs
@@ -146,7 +146,8 @@ defmodule PlausibleWeb.UserAuthTest do
 
         assert redirected_to(conn, 302) == Routes.sso_path(conn, :login_form, return_to: "")
 
-        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) == "Wrong email."
+        assert Phoenix.Flash.get(conn.assigns.flash, :login_error) ==
+                 "We couldn't find a Single Sign-On account for that email."
 
         assert conn.private[:plug_session_info] == :renew
         refute get_session(conn, :user_token)


### PR DESCRIPTION
### Changes

- Create new auth layout context that looks visually cleaner, and hides the header and footer
- Transform all auth pages to use the new context. This includes:
  - Login page
  - Signup page
  - Password reset page
  - Password reset request page
  - Password reset request success page
  - Password reset error page
  - Activate account page
  - Verify 2FA page
  - Verify 2FA recovery code page
  - SSO login page
  - SSO provision notice page
  - SSO provision issue page
  - Invitation expired page
- Tighten copy across auth pages to be more consistent and concise
- Remove password conformation field from signup page
- Extract password field to a new component with visibility toggle
- Extract Plausible logo to a new component
- Ensure first field on any page is in focus

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated

### Dark mode
- [x] The UI has been tested both in dark and light mode
