### PR TITLE
Combo box: prevent races between async suggestions and options rewrite

### DIFF
--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -54,7 +54,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
       else
         socket
       end
-      |> assign_suggestions(assigns[:suggestions])
+      |> assign_suggestions(assigns)
 
     {:ok, socket}
   end
@@ -364,24 +364,28 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
     end)
   end
 
-  defp assign_suggestions(socket, nil = _suggestions_from_update) do
+  defp assign_suggestions(socket, %{suggestions: _}), do: socket
+
+  defp assign_suggestions(socket, %{async_result?: true}) do
     if socket.assigns[:searching?] do
-      # A search is already in progress (or was completed) for a non-empty
-      # query - an unrelated update (e.g. the initial async options prefetch)
-      # must not race with the plain options list update.
+      # A background suggest_fun task delivered a result for a different key
+      # (namely, the initial options prefetch) - since the user has already
+      # searched, this stale result must not clobber the up-to-date suggestions.
       socket
     else
-      suggestions =
-        socket.assigns
-        |> Map.get(:options, [])
-        |> Enum.take(suggestions_limit(socket.assigns))
-
-      assign(socket, suggestions: suggestions)
+      fill_suggestions_from_options(socket)
     end
   end
 
-  defp assign_suggestions(socket, _suggestions_from_update) do
-    socket
+  defp assign_suggestions(socket, _assigns), do: fill_suggestions_from_options(socket)
+
+  defp fill_suggestions_from_options(socket) do
+    suggestions =
+      socket.assigns
+      |> Map.get(:options, [])
+      |> Enum.take(suggestions_limit(socket.assigns))
+
+    assign(socket, suggestions: suggestions)
   end
 
   defp select_default(socket) do
@@ -412,7 +416,8 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
           __MODULE__,
           Keyword.new([
             {:id, id},
-            {key_to_update, result}
+            {key_to_update, result},
+            {:async_result?, true}
           ])
         )
       end)

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -325,7 +325,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
       end
       |> Enum.take(suggestions_limit(socket.assigns))
 
-    {:noreply, assign(socket, %{suggestions: suggestions, searching?: input_len > 0})}
+    {:noreply, assign(socket, %{suggestions: suggestions})}
   end
 
   defp do_select(socket, submit_value, display_value) do
@@ -365,19 +365,12 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
   end
 
   defp assign_suggestions(socket, nil = _suggestions_from_update) do
-    if socket.assigns[:searching?] do
-      # A search is already in progress (or was completed) for a non-empty
-      # query - an unrelated update (e.g. the initial async options prefetch)
-      # must not race with the plain options list update.
-      socket
-    else
-      suggestions =
-        socket.assigns
-        |> Map.get(:options, [])
-        |> Enum.take(suggestions_limit(socket.assigns))
+    suggestions =
+      socket.assigns
+      |> Map.get(:options, [])
+      |> Enum.take(suggestions_limit(socket.assigns))
 
-      assign(socket, suggestions: suggestions)
-    end
+    assign(socket, suggestions: suggestions)
   end
 
   defp assign_suggestions(socket, _suggestions_from_update) do

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -325,7 +325,7 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
       end
       |> Enum.take(suggestions_limit(socket.assigns))
 
-    {:noreply, assign(socket, %{suggestions: suggestions})}
+    {:noreply, assign(socket, %{suggestions: suggestions, searching?: input_len > 0})}
   end
 
   defp do_select(socket, submit_value, display_value) do
@@ -365,12 +365,19 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
   end
 
   defp assign_suggestions(socket, nil = _suggestions_from_update) do
-    suggestions =
-      socket.assigns
-      |> Map.get(:options, [])
-      |> Enum.take(suggestions_limit(socket.assigns))
+    if socket.assigns[:searching?] do
+      # A search is already in progress (or was completed) for a non-empty
+      # query - an unrelated update (e.g. the initial async options prefetch)
+      # must not race with the plain options list update.
+      socket
+    else
+      suggestions =
+        socket.assigns
+        |> Map.get(:options, [])
+        |> Enum.take(suggestions_limit(socket.assigns))
 
-    assign(socket, suggestions: suggestions)
+      assign(socket, suggestions: suggestions)
+    end
   end
 
   defp assign_suggestions(socket, _suggestions_from_update) do

--- a/lib/plausible_web/live/components/combo_box.ex
+++ b/lib/plausible_web/live/components/combo_box.ex
@@ -366,16 +366,11 @@ defmodule PlausibleWeb.Live.Components.ComboBox do
 
   defp assign_suggestions(socket, %{suggestions: _}), do: socket
 
-  defp assign_suggestions(socket, %{async_result?: true}) do
-    if socket.assigns[:searching?] do
-      # A background suggest_fun task delivered a result for a different key
-      # (namely, the initial options prefetch) - since the user has already
-      # searched, this stale result must not clobber the up-to-date suggestions.
-      socket
-    else
-      fill_suggestions_from_options(socket)
-    end
-  end
+  # A background suggest_fun task delivered a result for a different key
+  # (namely, the initial options prefetch) - since the user has already
+  # searched, this stale result must not clobber the up-to-date suggestions.
+  defp assign_suggestions(%{assigns: %{searching?: true}} = socket, %{async_result?: true}),
+    do: socket
 
   defp assign_suggestions(socket, _assigns), do: fill_suggestions_from_options(socket)
 

--- a/test/plausible_web/live/components/combo_box_test.exs
+++ b/test/plausible_web/live/components/combo_box_test.exs
@@ -319,12 +319,12 @@ defmodule PlausibleWeb.Live.Components.ComboBoxTest do
 
       defmodule SampleSuggest do
         def suggest("", []) do
-          :timer.sleep(500)
+          :timer.sleep(600)
           [{1, "One"}, {2, "Two"}, {3, "Three"}]
         end
 
         def suggest("Echo me", _options) do
-          :timer.sleep(500)
+          :timer.sleep(510)
           [{1, "Echo me"}]
         end
       end


### PR DESCRIPTION
This PR addresses flaky combobox test mostly appearing in CI env.


The problem was essentially two async `suggest_fun` were executed - on connect and on search. In tests, both sleep 500ms - which means they finish nearly simultaneously giving no guarantees about `send_update` message handling order. This change makes sure if search is in progress or made, the initial prefetch suggestions update will be ignored.

Because we still have to support cases like messaging existing comboboxes to update their options (funnel step suggestions are shrinked via a broadcast, once one is picked) recognizing async function execution result is necessary.


To repro, revert the actual fix and run `mix test test/plausible_web/live/components/combo_box_test.exs --include slow --seed 1` - should exceed 60s timeout.

