### PR TITLE
Fix period arrow keys hijacking custom-range calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 - Fixed issue with timestamps being rendered incorrectly in segment menus and modals for some timezones
 - Fixed main graph being clipped when the browser's root font size is smaller than the default 16px
 - Fixed issue with users with billing role not being able to create personal segments
+- Fixed period arrow keys hijacking custom-range calendar
 
 ## v3.2.0 - 2026-01-16
 

--- a/assets/js/dashboard/keybinding.tsx
+++ b/assets/js/dashboard/keybinding.tsx
@@ -113,11 +113,13 @@ export function Keybind(opts: KeybindOptions) {
 export function NavigateKeybind({
   keyboardKey,
   type,
-  navigateProps
+  navigateProps,
+  shouldAlsoIgnoreWhen = []
 }: {
   keyboardKey: string
   type: KeyboardEventType
   navigateProps: AppNavigationTarget
+  shouldAlsoIgnoreWhen?: Array<(event: KeyboardEvent) => boolean>
 }) {
   const navigate = useAppNavigate()
   const handler = useCallback(() => {
@@ -129,7 +131,7 @@ export function NavigateKeybind({
       keyboardKey={keyboardKey}
       type={type}
       handler={handler}
-      shouldIgnoreWhen={[isModifierPressed, isTyping]}
+      shouldIgnoreWhen={[isModifierPressed, isTyping, ...shouldAlsoIgnoreWhen]}
       targetRef="document"
     />
   )

--- a/assets/js/dashboard/nav-menu/query-periods/dashboard-dates.test.tsx
+++ b/assets/js/dashboard/nav-menu/query-periods/dashboard-dates.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TestContextProviders } from '../../../../test-utils/app-context-providers'
 import { stringifySearch } from '../../util/url-search-params'
@@ -171,9 +171,7 @@ test('arrow keys shift the period when the custom-range calendar is closed, but 
   expect(screen.getByText('July 2024')).toBeVisible()
 
   await userEvent.keyboard('c')
-  await waitFor(() =>
-    expect(document.querySelector('.flatpickr-calendar')).not.toBeNull()
-  )
+  expect(document.querySelector('.flatpickr-calendar')).not.toBeNull()
 
   await userEvent.keyboard('{ArrowLeft}')
   await userEvent.keyboard('{ArrowLeft}')

--- a/assets/js/dashboard/nav-menu/query-periods/dashboard-dates.test.tsx
+++ b/assets/js/dashboard/nav-menu/query-periods/dashboard-dates.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TestContextProviders } from '../../../../test-utils/app-context-providers'
 import { stringifySearch } from '../../util/url-search-params'
@@ -149,6 +149,38 @@ test.each([
     expect(localStorage.getItem(periodStorageKey)).toBe(dashboardPeriod)
   }
 )
+
+test('arrow keys shift the period when the custom-range calendar is closed, but not while it is open', async () => {
+  const localDomain = 'no-arrow-hijack.test'
+  const startUrl = `${getRouterBasepath({ domain: localDomain, shared: false })}${stringifySearch({ period: 'month', date: '2024-08-15' })}`
+
+  render(<DashboardPeriodPicker />, {
+    wrapper: (props) => (
+      <TestContextProviders
+        siteOptions={{ domain: localDomain, statsBegin: '2020-01-01' }}
+        routerProps={{ initialEntries: [startUrl] }}
+        {...props}
+      />
+    )
+  })
+
+  expect(screen.getByText('August 2024')).toBeVisible()
+  expect(document.querySelector('.flatpickr-calendar')).toBeNull()
+
+  await userEvent.keyboard('{ArrowLeft}')
+  expect(screen.getByText('July 2024')).toBeVisible()
+
+  await userEvent.keyboard('c')
+  await waitFor(() =>
+    expect(document.querySelector('.flatpickr-calendar')).not.toBeNull()
+  )
+
+  await userEvent.keyboard('{ArrowLeft}')
+  await userEvent.keyboard('{ArrowLeft}')
+
+  expect(screen.getByText('July 2024')).toBeVisible()
+  expect(document.querySelector('.flatpickr-calendar')).not.toBeNull()
+})
 
 test('going back resets the stored dashboardState period to previous value', async () => {
   const BrowserBackButton = () => {

--- a/assets/js/dashboard/nav-menu/query-periods/date-range-calendar.tsx
+++ b/assets/js/dashboard/nav-menu/query-periods/date-range-calendar.tsx
@@ -2,6 +2,9 @@ import React, { useLayoutEffect, useRef } from 'react'
 import DatePicker from 'react-flatpickr'
 import { CustomLocale } from 'flatpickr/dist/types/locale'
 
+export const isDateRangeCalendarOpen = (): boolean =>
+  !!document.querySelector('.flatpickr-calendar')
+
 const calendarLocale: Partial<CustomLocale> = {
   weekdays: {
     shorthand: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],

--- a/assets/js/dashboard/nav-menu/query-periods/move-period-arrows.tsx
+++ b/assets/js/dashboard/nav-menu/query-periods/move-period-arrows.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import {
   shiftDashboardPeriod,
   getDateForShiftedPeriod
@@ -6,11 +6,15 @@ import {
 import classNames from 'classnames'
 import { useDashboardStateContext } from '../../dashboard-state-context'
 import { useSiteContext } from '../../site-context'
-import { NavigateKeybind } from '../../keybinding'
-import { AppNavigationLink } from '../../navigation/use-app-navigate'
+import { isModifierPressed, isTyping, Keybind } from '../../keybinding'
+import {
+  AppNavigationLink,
+  useAppNavigate
+} from '../../navigation/use-app-navigate'
 import { DashboardPeriod } from '../../dashboard-time-periods'
 import { useMatch } from 'react-router-dom'
 import { rootRoute } from '../../router'
+import { isDateRangeCalendarOpen } from './date-range-calendar'
 
 const ArrowKeybind = ({
   keyboardKey
@@ -19,6 +23,7 @@ const ArrowKeybind = ({
 }) => {
   const site = useSiteContext()
   const { dashboardState } = useDashboardStateContext()
+  const navigate = useAppNavigate()
 
   const search = useMemo(
     () =>
@@ -31,11 +36,22 @@ const ArrowKeybind = ({
     [site, dashboardState, keyboardKey]
   )
 
+  const handler = useCallback(() => {
+    navigate({ search })
+  }, [navigate, search])
+
   return (
-    <NavigateKeybind
+    <Keybind
       type="keydown"
       keyboardKey={keyboardKey}
-      navigateProps={{ search }}
+      handler={handler}
+      shouldIgnoreWhen={[
+        isModifierPressed,
+        isTyping,
+        // Don't hijack arrow keys flatpickr uses for its own day-cell navigation.
+        isDateRangeCalendarOpen
+      ]}
+      targetRef="document"
     />
   )
 }

--- a/assets/js/dashboard/nav-menu/query-periods/move-period-arrows.tsx
+++ b/assets/js/dashboard/nav-menu/query-periods/move-period-arrows.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import {
   shiftDashboardPeriod,
   getDateForShiftedPeriod
@@ -6,11 +6,8 @@ import {
 import classNames from 'classnames'
 import { useDashboardStateContext } from '../../dashboard-state-context'
 import { useSiteContext } from '../../site-context'
-import { isModifierPressed, isTyping, Keybind } from '../../keybinding'
-import {
-  AppNavigationLink,
-  useAppNavigate
-} from '../../navigation/use-app-navigate'
+import { NavigateKeybind } from '../../keybinding'
+import { AppNavigationLink } from '../../navigation/use-app-navigate'
 import { DashboardPeriod } from '../../dashboard-time-periods'
 import { useMatch } from 'react-router-dom'
 import { rootRoute } from '../../router'
@@ -23,7 +20,6 @@ const ArrowKeybind = ({
 }) => {
   const site = useSiteContext()
   const { dashboardState } = useDashboardStateContext()
-  const navigate = useAppNavigate()
 
   const search = useMemo(
     () =>
@@ -36,22 +32,13 @@ const ArrowKeybind = ({
     [site, dashboardState, keyboardKey]
   )
 
-  const handler = useCallback(() => {
-    navigate({ search })
-  }, [navigate, search])
-
   return (
-    <Keybind
+    <NavigateKeybind
       type="keydown"
       keyboardKey={keyboardKey}
-      handler={handler}
-      shouldIgnoreWhen={[
-        isModifierPressed,
-        isTyping,
-        // Don't hijack arrow keys flatpickr uses for its own day-cell navigation.
-        isDateRangeCalendarOpen
-      ]}
-      targetRef="document"
+      navigateProps={{ search }}
+      // Don't hijack arrow keys flatpickr uses for its own day-cell navigation.
+      shouldAlsoIgnoreWhen={[isDateRangeCalendarOpen]}
     />
   )
 }


### PR DESCRIPTION
### Changes
- On periods with `< >` controls (Today, Month to Date, Last Month, Year to Date, specific day/month/year), the document-level ArrowLeft/ArrowRight listener kept firing while the calendar popover was open, silently shifting the period and closing the calendar.
- Suppress that listener whenever a flatpickr calendar is mounted, via a new `isDateRangeCalendarOpen` predicate on `Keybind.shouldIgnoreWhen`.
- Added a regression test covering both directions: arrows still shift the period when the calendar is closed, and no longer do so while it's open.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
