### PR TITLE
Fix Sentry filtering to properly catch noise from DB driver

### DIFF
--- a/lib/sentry_filter.ex
+++ b/lib/sentry_filter.ex
@@ -25,6 +25,15 @@ defmodule Plausible.SentryFilter do
 
   def before_send(
         %{
+          exception: [%{type: "Mint.TransportError"}],
+          original_exception: %{reason: reason}
+        } = event
+      ) do
+    %{event | fingerprint: ["mint_transport", reason]}
+  end
+
+  def before_send(
+        %{
           exception: [%{type: "Finch.TransportError"}],
           original_exception: %{reason: reason}
         } = event
@@ -35,7 +44,7 @@ defmodule Plausible.SentryFilter do
   def before_send(
         %{source: :logger, message: %{formatted: "Ch.Connection (#PID<" <> rest}} = event
       ) do
-    if String.ends_with?(rest, ")) disconnected: ** (Finch.HTTPError) the connection is closed") do
+    if String.ends_with?(rest, ")) disconnected: ** (Mint.HTTPError) the connection is closed") do
       false
     else
       event


### PR DESCRIPTION
Noise started appearing in Sentry dashboard again because I was overeager with switching to Finch wrapped errors where plain Mint is used still (CH DB driver).