### PR TITLE
Validate `page` param in Stats API breakdown endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 - Always compare against the same time range in comparisons with "Today"
 - Added vertical indicator line to graph to make it easier to see what's hovered / selected
 
+### Fixed
+
+- Stats API `/api/v1/stats/breakdown` now returns a `400` error for an invalid `page` parameter instead of crashing with a `500`
+
 ### Removed
 
 - Removed the standalone team switcher page; team switching is now done from the topbar dropdown only

--- a/lib/plausible_web/controllers/api/external_stats_controller.ex
+++ b/lib/plausible_web/controllers/api/external_stats_controller.ex
@@ -40,9 +40,8 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
          :ok <- validate_filters(site, query.filters),
          {:ok, metrics} <- parse_and_validate_metrics(params, query),
          {:ok, limit} <- validate_or_default_limit(params),
+         {:ok, page} <- validate_or_default_page(params),
          :ok <- ensure_custom_props_access(site, query) do
-      page = String.to_integer(Map.get(params, "page", "1"))
-
       %{results: results, meta: meta} =
         Legacy.Breakdown.breakdown(site, query, metrics, {limit, page})
 
@@ -87,6 +86,18 @@ defmodule PlausibleWeb.Api.ExternalStatsController do
 
   @default_breakdown_limit 100
   defp validate_or_default_limit(_), do: {:ok, @default_breakdown_limit}
+
+  defp validate_or_default_page(%{"page" => page}) do
+    case Integer.parse(page) do
+      {page, ""} when page > 0 ->
+        {:ok, page}
+
+      _ ->
+        {:error, "Please provide page as a number greater than 0."}
+    end
+  end
+
+  defp validate_or_default_page(_), do: {:ok, 1}
 
   defp parse_and_validate_metrics(params, query) do
     metrics =

--- a/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/breakdown_test.exs
@@ -2492,6 +2492,41 @@ defmodule PlausibleWeb.Api.ExternalStatsController.BreakdownTest do
       assert json_response(conn, 400) == %{"error" => @invalid_limit_message}
     end
 
+    @invalid_page_message "Please provide page as a number greater than 0."
+
+    test "returns error with non-integer page", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "property" => "event:page",
+          "page" => "bad_page"
+        })
+
+      assert json_response(conn, 400) == %{"error" => @invalid_page_message}
+    end
+
+    test "returns error with negative integer page", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "property" => "event:page",
+          "page" => -1
+        })
+
+      assert json_response(conn, 400) == %{"error" => @invalid_page_message}
+    end
+
+    test "returns error with zero page", %{conn: conn, site: site} do
+      conn =
+        get(conn, "/api/v1/stats/breakdown", %{
+          "site_id" => site.domain,
+          "property" => "event:page",
+          "page" => 0
+        })
+
+      assert json_response(conn, 400) == %{"error" => @invalid_page_message}
+    end
+
     test "can paginate results", %{conn: conn, site: site} do
       populate_stats(site, [
         build(:pageview, pathname: "/a", timestamp: ~N[2021-01-01 00:00:00]),


### PR DESCRIPTION
## Changes

The public Stats API `GET /api/v1/stats/breakdown` endpoint passed the `page` query parameter straight into `String.to_integer/1`, which raises `ArgumentError` on any non-numeric input — resulting in a **500 Internal Server Error**.

This PR validates `page` the same way the sibling `limit` parameter is already validated (`validate_or_default_limit/1`): invalid or non-positive values now return a clean **400** with a descriptive message.

```elixir
defp validate_or_default_page(%{"page" => page}) do
  case Integer.parse(page) do
    {page, ""} when page > 0 -> {:ok, page}
    _ -> {:error, "Please provide page as a number greater than 0."}
  end
end

defp validate_or_default_page(_), do: {:ok, 1}
```

## Tests

Added tests to `breakdown_test.exs` covering non-integer, negative, and zero `page` values (mirroring the existing `limit` validation tests).

## Notes

- Behavior for valid `page` values (including the default of `1` when omitted) is unchanged.
- CHANGELOG updated under a new **Fixed** section.

Fixes #6500