### PR TITLE
Fix CTAs for grandfathered plans

### DIFF
--- a/assets/js/dashboard/annotations/annotations-modals.tsx
+++ b/assets/js/dashboard/annotations/annotations-modals.tsx
@@ -176,7 +176,7 @@ const AnnotationTypeSelector = ({
           siteOptionDisabledMessage === 'upgrade-subscription-yourself' ||
           siteOptionDisabledMessage === 'upgrade-subscription-reach-out' ? (
             <UpgradePill
-              plan="Growth"
+              plan="Upgrade needed"
               linked={
                 siteOptionDisabledMessage === 'upgrade-subscription-yourself'
               }
@@ -202,9 +202,9 @@ const AnnotationTypeDisabledMessage = ({
     case 'no-permissions':
       return "You don't have enough permissions to change note to this type"
     case 'upgrade-subscription-yourself':
-      return 'Upgrade to Growth to make notes visible to others.'
+      return 'Upgrade your plan to make notes visible to others.'
     case 'upgrade-subscription-reach-out':
-      return 'Ask a team owner to upgrade to Growth to make notes visible to others.'
+      return 'Ask a team owner to upgrade your plan to make notes visible to others.'
   }
 }
 

--- a/assets/js/dashboard/segments/segment-modals.tsx
+++ b/assets/js/dashboard/segments/segment-modals.tsx
@@ -312,7 +312,7 @@ const SegmentTypeSelector = ({
           siteOptionDisabledMessage === 'upgrade-subscription-yourself' ||
           siteOptionDisabledMessage === 'upgrade-subscription-reach-out' ? (
             <UpgradePill
-              plan="Growth"
+              plan="Upgrade needed"
               linked={
                 siteOptionDisabledMessage === 'upgrade-subscription-yourself'
               }
@@ -341,10 +341,10 @@ const SegmentTypeDisabledMessage = ({
       return "You don't have enough permissions to change segment to this type"
     }
     case 'upgrade-subscription-yourself': {
-      return 'Upgrade to Growth to share segments with others.'
+      return 'Upgrade your plan to share segments with others.'
     }
     case 'upgrade-subscription-reach-out': {
-      return 'Ask a team owner to upgrade to Growth to share segments with others.'
+      return 'Ask a team owner to upgrade your plan to share segments with others.'
     }
   }
 }


### PR DESCRIPTION
### Changes

Some users aren't on v5 generation plans, so the CTA is misleading. This is just a quick fix. The alternative to pass subscription plan related data from the BE to the FE seemed excessive. 

### Tests
- [x] This PR does not require tests

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
