### PR TITLE
Fix manual lock grace period bug

### DIFF
--- a/lib/plausible/teams/grace_period.ex
+++ b/lib/plausible/teams/grace_period.ex
@@ -85,8 +85,8 @@ defmodule Plausible.Teams.GracePeriod do
     Date.diff(end_date, Date.utc_today()) >= 0
   end
 
-  def active?(%{grace_period: %__MODULE__{manual_lock: true}}) do
-    true
+  def active?(%{grace_period: %__MODULE__{manual_lock: true}} = team) do
+    manual_lock_active?(team)
   end
 
   def active?(_team), do: false

--- a/lib/plausible/teams/grace_period.ex
+++ b/lib/plausible/teams/grace_period.ex
@@ -81,12 +81,12 @@ defmodule Plausible.Teams.GracePeriod do
   """
   def active?(team)
 
-  def active?(%{grace_period: %__MODULE__{end_date: %Date{} = end_date}}) do
-    Date.diff(end_date, Date.utc_today()) >= 0
-  end
-
   def active?(%{grace_period: %__MODULE__{manual_lock: true}} = team) do
     manual_lock_active?(team)
+  end
+
+  def active?(%{grace_period: %__MODULE__{end_date: %Date{} = end_date}}) do
+    Date.diff(end_date, Date.utc_today()) >= 0
   end
 
   def active?(_team), do: false

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -1244,6 +1244,16 @@ defmodule Plausible.Billing.QuotaTest do
                :grace_period_active
     end
 
+    @some_usage %{
+      monthly_pageviews: %{
+        current_cycle: %{total: 5000},
+        last_cycle: %{total: 15_000},
+        penultimate_cycle: %{total: 14_000}
+      },
+      sites: 3,
+      team_members: 2
+    }
+
     test "returns :manual_lock_grace_period_active when manual lock is active" do
       user = new_user() |> subscribe_to_enterprise_plan(monthly_pageview_limit: 10_000)
       team = team_of(user)
@@ -1256,18 +1266,24 @@ defmodule Plausible.Billing.QuotaTest do
 
       team = %{team | grace_period: manual_lock_grace_period}
 
-      usage = %{
-        monthly_pageviews: %{
-          current_cycle: %{total: 5000},
-          last_cycle: %{total: 15_000},
-          penultimate_cycle: %{total: 14_000}
-        },
-        sites: 3,
-        team_members: 2
+      assert Plausible.Billing.Quota.usage_notification_type(team, @some_usage) ==
+               :manual_lock_grace_period_active
+    end
+
+    test "returns :dashboard_locked when manual lock grace_period has been manually locked" do
+      user = new_user() |> subscribe_to_enterprise_plan(monthly_pageview_limit: 10_000)
+      team = team_of(user)
+
+      manual_lock_grace_period = %Plausible.Teams.GracePeriod{
+        end_date: nil,
+        is_over: true,
+        manual_lock: true
       }
 
-      assert Plausible.Billing.Quota.usage_notification_type(team, usage) ==
-               :manual_lock_grace_period_active
+      team = %{team | grace_period: manual_lock_grace_period}
+
+      assert Plausible.Billing.Quota.usage_notification_type(team, @some_usage) ==
+               :dashboard_locked
     end
 
     test "returns :trial_ended when trial expired and no subscription" do

--- a/test/plausible/billing/site_locker_test.exs
+++ b/test/plausible/billing/site_locker_test.exs
@@ -85,6 +85,51 @@ defmodule Plausible.Billing.SiteLockerTest do
       refute Repo.reload!(site.team).locked
     end
 
+    test "keeps a manually locked enterprise customer locked while over limits, unlocks once usage drops within limits" do
+      user = new_user() |> subscribe_to_enterprise_plan(monthly_pageview_limit: 10_000)
+      team = team_of(user)
+      site = new_site(owner: user)
+
+      # The usage check worker flags the account for manual locking
+      # (see Plausible.Workers.CheckUsage.check_enterprise_subscriber/2)
+      team = Plausible.Teams.start_manual_lock_grace_period(team)
+      refute Repo.reload!(team).locked
+
+      # Customer support locks the team from the CS panel
+      # (see PlausibleWeb.Live.CustomerSupport.Team.lock_team/1)
+      team = Plausible.Teams.end_grace_period(team)
+      SiteLocker.set_lock_status_for(team, true)
+      team = Repo.reload!(team)
+
+      assert team.locked
+      assert team.grace_period.manual_lock
+      assert team.grace_period.is_over
+
+      over_limits_usage_stub = monthly_pageview_usage_stub(15_000, 15_000)
+
+      # while usage is still over the limit, the daily LockSites run keeps
+      # the team locked and leaves the grace period in place
+      assert SiteLocker.update_for(team, usage_mod: over_limits_usage_stub) ==
+               {:locked, :grace_period_ended_already}
+
+      team = Repo.reload!(team)
+      assert team.locked
+      assert Repo.reload!(site.team).locked
+      assert team.grace_period.manual_lock
+      assert team.grace_period.is_over
+
+      within_limits_usage_stub = monthly_pageview_usage_stub(5_000, 5_000)
+
+      # once usage drops within limits, the next run unlocks the team and
+      # removes the grace period
+      assert SiteLocker.update_for(team, usage_mod: within_limits_usage_stub) == :unlocked
+
+      team = Repo.reload!(team)
+      refute team.locked
+      refute Repo.reload!(site.team).locked
+      refute team.grace_period
+    end
+
     test "locks user who cancelled subscription and the cancelled subscription has expired" do
       user =
         new_user(trial_expiry_date: Date.shift(Date.utc_today(), day: -1))

--- a/test/plausible/teams/grace_period_test.exs
+++ b/test/plausible/teams/grace_period_test.exs
@@ -1,15 +1,16 @@
 defmodule Plausible.Teams.GracePeriodTest do
   use Plausible.DataCase, async: true
 
-  test "active?/1 returns false when grace period cannot be telled" do
+  test "active?/1 returns false when grace period is nil" do
     without_grace_period =
       new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: nil])
       |> team_of()
 
     refute Plausible.Teams.GracePeriod.active?(without_grace_period)
+  end
 
-    without_team = nil
-    refute Plausible.Teams.GracePeriod.active?(without_team)
+  test "active?/1 returns false when team is nil" do
+    refute Plausible.Teams.GracePeriod.active?(nil)
   end
 
   test "active?/1 returns false when grace period is expired" do
@@ -42,15 +43,29 @@ defmodule Plausible.Teams.GracePeriodTest do
     assert Plausible.Teams.GracePeriod.active?(team)
   end
 
-  test "expired?/1 returns false when grace period cannot be telled" do
+  test "active?/1 returns false for a manual lock grace period with is_over = true" do
+    grace_period = %Plausible.Teams.GracePeriod{
+      manual_lock: true,
+      is_over: true
+    }
+
+    team =
+      new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: grace_period])
+      |> team_of()
+
+    refute Plausible.Teams.GracePeriod.active?(team)
+  end
+
+  test "expired?/1 returns false when grace period is nil" do
     without_grace_period =
       new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: nil])
       |> team_of()
 
     refute Plausible.Teams.GracePeriod.expired?(without_grace_period)
+  end
 
-    without_team = nil
-    refute Plausible.Teams.GracePeriod.expired?(without_team)
+  test "expired?/1 returns false when team is nil" do
+    refute Plausible.Teams.GracePeriod.expired?(nil)
   end
 
   test "expired?/1 returns true when grace period is expired" do
@@ -58,6 +73,19 @@ defmodule Plausible.Teams.GracePeriodTest do
 
     grace_period = %Plausible.Teams.GracePeriod{
       end_date: yesterday,
+      is_over: true
+    }
+
+    team =
+      new_user(trial_expiry_date: Date.utc_today(), team: [grace_period: grace_period])
+      |> team_of()
+
+    assert Plausible.Teams.GracePeriod.expired?(team)
+  end
+
+  test "expired?/1 returns true when manual lock grace period is manually terminated" do
+    grace_period = %Plausible.Teams.GracePeriod{
+      manual_lock: true,
       is_over: true
     }
 


### PR DESCRIPTION
### Changes

The bug is caused by `Plausible.GracePeriod.active?/1` unconditionally returning `true` for any `manual_lock` grace_period. It should return `false` when the manual lock grace period has been terminated manually via CS.

The bug is pretty tricky, so I'll do my best explaining what happens under the hood:

* An enterprise customer has not upgraded in time and our customer support decides to hit the "Lock" button on their team
* This action: 1) locks the team instantly and 2) sets their (manual lock) `grace_period.is_over = true`
* At the next UTC midnight, `site_locker.ex` runs -- checks every team and ends up calling `Plausible.Teams.Billing.check_needs_to_upgrade/2`
* ❗️`check_needs_to_upgrade` ends up returning `:no_upgrade_needed` because the `Teams.GracePeriod.expired?(team)` cond branch wrongly returns `false`
* `site_locker.ex` unlocks the site but keeps the grace period in place  

At this point, we're already in a messed up state because on one hand, the team is unlocked, but on the other, it has a manually terminated grace period. Now we get to rendering `usage_notification` for the team in the team settings billing section:

* `usage_notification_type` tries to find the type of the notification to render
* From these three cond branches (see screenshot below), we incorrectly end up in the third one because:
  * the team is not locked (as mentioned above)
  * `Teams.GracePeriod.expired?(team)` returns false (also mentioned above)
  * `manual_lock_active?` returns false as well -- this is correct because `is_over` being `true` means it's not active
  * Finally, `GracePeriod.active?` returns true (the root bug)

<img width="666" height="167" alt="image" src="https://github.com/user-attachments/assets/310acd39-7dc0-40d2-bf88-afe885aff0de" />

* the `usage_notification` component then tries to render "days left" but no case clause matches `nil` -- a `manual_lock` grace period has `end_date = nil`

Expected behaviour:

* The manually locked team stays locked after site_locker runs (unless the usage has decreased enough to unlock)
* usage_notification renders `:dashboard_locked`

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
