### PR TITLE
Fix sample rate calculator estimated traffic logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ All notable changes to this project will be documented in this file.
 - Fixed main graph being clipped when the browser's root font size is smaller than the default 16px
 - Fixed issue with users with billing role not being able to create personal segments
 - Fixed period arrow keys hijacking custom-range calendar
-- Fixed sample rate calculator overestimating traffic when the queried date range starts before the site's stats begin
 
 ## v3.2.0 - 2026-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
 - Fixed main graph being clipped when the browser's root font size is smaller than the default 16px
 - Fixed issue with users with billing role not being able to create personal segments
 - Fixed period arrow keys hijacking custom-range calendar
+- Fixed sample rate calculator overestimating traffic when the queried date range starts before the site's stats begin
 
 ## v3.2.0 - 2026-01-16
 

--- a/extra/lib/plausible/stats/sampling.ex
+++ b/extra/lib/plausible/stats/sampling.ex
@@ -1,9 +1,24 @@
 defmodule Plausible.Stats.Sampling do
   @moduledoc """
-  Sampling related functions
+  This module contains the logic to calculate the sample fraction to use for a particular query.
+
+  To do so, it
+  1) estimates how much traffic the site has per day
+  2) how many days of traffic does the query cover
+  3) calculates the fraction so as not to scan more than 10M events
+
+  ### Example calculation
+  traffic = 3M / day
+  query covers = 14 days
+  events in query = 3M / day * 14 days = 42M
+
+  10M = 42M * fraction
+  ->
+  fraction = 10M / 42M
+  fraction = 0.24
   """
+
   @default_sample_threshold 10_000_000
-  @sampling_window_days 30
 
   import Ecto.Query
 
@@ -70,19 +85,7 @@ defmodule Plausible.Stats.Sampling do
     do: :no_sampling
 
   def fractional_sample_rate(traffic_30_day, query) do
-    date_range = Query.date_range(query)
-    stats_start = query.site_native_stats_start_at
-
-    # A site's traffic before their stats begin date isn't queried,
-    # so it shouldn't figure in the traffic estimation
-    start_of_range_with_stats =
-      if stats_start && Date.before?(date_range.first, stats_start) do
-        stats_start
-      else
-        date_range.first
-      end
-
-    duration = Date.diff(date_range.last, start_of_range_with_stats)
+    duration = queried_duration_days(query)
 
     estimated_traffic = estimate_traffic(traffic_30_day, duration, query)
 
@@ -101,25 +104,42 @@ defmodule Plausible.Stats.Sampling do
     end
   end
 
+  @doc """
+  Number of days of stats the query's range covers, clamped to the site's native stats
+  begin date (traffic before that isn't queried, so it shouldn't figure in the
+  traffic estimation).
+  """
+  def queried_duration_days(%Query{} = query) do
+    {first, last} = Plausible.Stats.Time.utc_boundaries(query)
+    days_in_range(first, last)
+  end
+
   defp min_sample_rate(), do: 0.013
 
-  defp estimate_traffic(traffic_30_day, duration, query) do
-    daily_traffic = traffic_30_day / days_of_traffic_in_window(query)
+  defp estimate_traffic(traffic_30_day, duration, %Query{} = query) do
+    daily_traffic =
+      traffic_30_day / days_of_traffic_in_30d_window(query.now, query.site_native_stats_start_at)
 
     estimate_by_filters(daily_traffic * duration, query.filters)
   end
 
-  defp days_of_traffic_in_window(%Query{
-         now: %DateTime{} = now,
-         site_native_stats_start_at: %NaiveDateTime{} = at
-       }) do
-    now
-    |> Date.diff(at)
-    |> min(@sampling_window_days)
-    |> max(1)
+  defp days_of_traffic_in_30d_window(now, native_stats_start_at) do
+    days_from_stats_start = days_in_range(native_stats_start_at, DateTime.to_naive(now))
+
+    cond do
+      days_from_stats_start <= 1 -> 1
+      days_from_stats_start <= 30 -> days_from_stats_start
+      true -> 30
+    end
   end
 
-  defp days_of_traffic_in_window(%Query{}), do: @sampling_window_days
+  @seconds_per_day 86_400
+  # Whole days spanned by the inclusive range [first, last]. Rounds the real
+  # elapsed time so a range ending at 23:59:59 counts its final day in full,
+  # rather than diffing the date parts (which undercounts by one).
+  defp days_in_range(first, last) do
+    round(NaiveDateTime.diff(last, first, :second) / @seconds_per_day)
+  end
 
   @filter_traffic_multiplier 1 / 4.0
   @max_filters 2

--- a/extra/lib/plausible/stats/sampling.ex
+++ b/extra/lib/plausible/stats/sampling.ex
@@ -70,7 +70,18 @@ defmodule Plausible.Stats.Sampling do
 
   def fractional_sample_rate(traffic_30_day, query) do
     date_range = Query.date_range(query)
-    duration = Date.diff(date_range.last, date_range.first)
+    stats_start = query.site_native_stats_start_at
+
+    # A site's traffic before their stats begin date isn't queried,
+    # so it shouldn't figure in the traffic estimation
+    start_of_range_with_stats =
+      if stats_start && Date.before?(date_range.first, stats_start) do
+        stats_start
+      else
+        date_range.first
+      end
+
+    duration = Date.diff(date_range.last, start_of_range_with_stats)
 
     estimated_traffic = estimate_traffic(traffic_30_day, duration, query)
 

--- a/extra/lib/plausible/stats/sampling.ex
+++ b/extra/lib/plausible/stats/sampling.ex
@@ -3,6 +3,7 @@ defmodule Plausible.Stats.Sampling do
   Sampling related functions
   """
   @default_sample_threshold 10_000_000
+  @sampling_window_days 30
 
   import Ecto.Query
 
@@ -103,10 +104,22 @@ defmodule Plausible.Stats.Sampling do
   defp min_sample_rate(), do: 0.013
 
   defp estimate_traffic(traffic_30_day, duration, query) do
-    duration_adjusted_traffic = traffic_30_day / 30.0 * duration
+    daily_traffic = traffic_30_day / days_of_traffic_in_window(query)
 
-    estimate_by_filters(duration_adjusted_traffic, query.filters)
+    estimate_by_filters(daily_traffic * duration, query.filters)
   end
+
+  defp days_of_traffic_in_window(%Query{
+         now: %DateTime{} = now,
+         site_native_stats_start_at: %NaiveDateTime{} = at
+       }) do
+    now
+    |> Date.diff(at)
+    |> min(@sampling_window_days)
+    |> max(1)
+  end
+
+  defp days_of_traffic_in_window(%Query{}), do: @sampling_window_days
 
   @filter_traffic_multiplier 1 / 4.0
   @max_filters 2

--- a/extra/lib/plausible/stats/sampling_cache.ex
+++ b/extra/lib/plausible/stats/sampling_cache.ex
@@ -1,6 +1,6 @@
 defmodule Plausible.Stats.SamplingCache do
   @moduledoc """
-  Cache storing estimation for events ingested by a site in the past month.
+  Cache storing estimation for events ingested by a site in the past 30 days.
 
   Used for sampling rate calculations in Plausible.Stats.Sampling.
   """

--- a/lib/plausible/sites.ex
+++ b/lib/plausible/sites.ex
@@ -378,7 +378,9 @@ defmodule Plausible.Sites do
   def stats_start_date(site)
 
   on_ee do
-    # for now, we're going to always update consolidated views
+    # for now, we're going to always update consolidated views,
+    # though Repo.update! runs the actual update query only when
+    # the value has changed
     def stats_start_date(%Site{consolidated: true} = site) do
       team = Repo.preload(site, :team).team
 

--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -5,6 +5,7 @@ defmodule Plausible.Stats.Time do
 
   alias Plausible.Stats.{Query, DateTimeRange}
 
+  @spec utc_boundaries(Query.t()) :: {NaiveDateTime.t(), NaiveDateTime.t()}
   def utc_boundaries(%Query{
         utc_time_range: time_range,
         site_native_stats_start_at: native_stats_start_at

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -1,13 +1,13 @@
 defmodule Plausible.Stats.SamplingTest do
-  use Plausible.DataCase, async: true
+  use Plausible.DataCase, async: false
 
   on_ee do
     import Plausible.Stats.Sampling, only: [fractional_sample_rate: 2]
     alias Plausible.Stats.{Query, DateTimeRange}
 
-    describe "&fractional_sample_rate/2" do
-      @threshold Plausible.Stats.Sampling.default_sample_threshold()
+    @threshold Plausible.Stats.Sampling.default_sample_threshold()
 
+    describe "&fractional_sample_rate/2 for date ranges of different lengths" do
       test "no traffic estimate" do
         assert fractional_sample_rate(nil, query(30)) == :no_sampling
       end
@@ -47,8 +47,7 @@ defmodule Plausible.Stats.SamplingTest do
       end
 
       test "short durations" do
-        assert fractional_sample_rate(@threshold * 15, query(1, unit: :hour)) ==
-                 :no_sampling
+        assert fractional_sample_rate(@threshold * 15, query(1, unit: :hour)) == :no_sampling
       end
 
       test "very low sampling rate" do
@@ -58,24 +57,56 @@ defmodule Plausible.Stats.SamplingTest do
       @filter ["is", "event:name", ["pageview"]]
       test "scales sampling rate according to query filters (when sampling adjustments are enabled)" do
         assert fractional_sample_rate(@threshold * 50, query(30, filters: [])) == 0.02
+        assert fractional_sample_rate(@threshold * 50, query(30, filters: [@filter])) == 0.08
 
-        assert fractional_sample_rate(@threshold * 50, query(30, filters: [@filter])) ==
-                 0.08
-
-        assert fractional_sample_rate(
-                 @threshold * 50,
-                 query(30, filters: [@filter, @filter])
-               ) == 0.32
+        assert fractional_sample_rate(@threshold * 50, query(30, filters: [@filter, @filter])) ==
+                 0.32
 
         assert fractional_sample_rate(
                  @threshold * 50,
                  query(30, filters: [@filter, @filter, @filter])
                ) == 0.32
 
-        assert fractional_sample_rate(
-                 @threshold * 10,
-                 query(30, filters: [@filter, @filter])
-               ) == :no_sampling
+        assert fractional_sample_rate(@threshold * 10, query(30, filters: [@filter, @filter])) ==
+                 :no_sampling
+      end
+    end
+
+    describe "&fractional_sample_rate/2 clamps the range to the site's stats start" do
+      test "a range with no known stats start uses the full requested range" do
+        # `site_native_stats_start_at` is only nil in tests / for sites without
+        # stats; nothing gets clamped, matching a stats start before the range.
+        without_start = range_query(~D[2025-01-01], ~D[2026-07-15], nil)
+        early_start = range_query(~D[2025-01-01], ~D[2026-07-15], ~N[1900-01-01 00:00:00])
+
+        assert fractional_sample_rate(@threshold, without_start) ==
+                 fractional_sample_rate(@threshold, early_start)
+      end
+
+      test "a range starting after stats begin is unaffected by the clamp" do
+        after_start = range_query(~D[2026-04-01], ~D[2026-07-15], ~N[2026-01-01 00:00:00])
+        no_start = range_query(~D[2026-04-01], ~D[2026-07-15], nil)
+
+        assert fractional_sample_rate(@threshold, after_start) ==
+                 fractional_sample_rate(@threshold, no_start)
+      end
+
+      test "a range starting before stats begin is treated as starting when stats begin" do
+        stats_start = ~N[2026-01-01 00:00:00]
+        range_end = ~D[2026-07-15]
+
+        from_stats_start =
+          fractional_sample_rate(@threshold, range_query(~D[2026-01-01], range_end, stats_start))
+
+        from_1970 =
+          fractional_sample_rate(@threshold, range_query(~D[1970-01-01], range_end, stats_start))
+
+        from_2025 =
+          fractional_sample_rate(@threshold, range_query(~D[2025-01-01], range_end, stats_start))
+
+        assert from_stats_start == 0.15
+        assert from_1970 == from_stats_start
+        assert from_2025 == from_stats_start
       end
     end
 
@@ -90,6 +121,18 @@ defmodule Plausible.Stats.SamplingTest do
         utc_time_range: DateTimeRange.new!(first, last),
         timezone: "UTC",
         filters: filters
+      }
+    end
+
+    defp range_query(first_date, last_date, native_stats_start_at) do
+      first = DateTime.new!(first_date, ~T[00:00:00], "Etc/UTC")
+      last = DateTime.new!(last_date, ~T[00:00:00], "Etc/UTC")
+
+      %Query{
+        utc_time_range: DateTimeRange.new!(first, last),
+        timezone: "UTC",
+        filters: [],
+        site_native_stats_start_at: native_stats_start_at
       }
     end
   end

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -110,6 +110,18 @@ defmodule Plausible.Stats.SamplingTest do
       end
     end
 
+    describe "&fractional_sample_rate/2 for sites with less than 30 days of stats" do
+      test "estimates traffic from the site's real daily rate, not a 30-day average" do
+        # Site started 3 days before "now" (2026-07-15) and has ingested 30M
+        # events since (10M/day). A query over the last 30 days is clamped to
+        # those 3 days, where all 30M events live - 3x the sampling threshold -
+        # so it must be sampled.
+        query = range_query(~D[2026-06-15], ~D[2026-07-15], ~N[2026-07-12 00:00:00])
+
+        assert fractional_sample_rate(30_000_000, query) == 0.33
+      end
+    end
+
     def query(duration, opts \\ []) do
       unit = Keyword.get(opts, :unit, :day)
       filters = Keyword.get(opts, :filters, [])
@@ -132,6 +144,7 @@ defmodule Plausible.Stats.SamplingTest do
         utc_time_range: DateTimeRange.new!(first, last),
         timezone: "UTC",
         filters: [],
+        now: last,
         site_native_stats_start_at: native_stats_start_at
       }
     end

--- a/test/plausible/stats/sampling_test.exs
+++ b/test/plausible/stats/sampling_test.exs
@@ -2,10 +2,37 @@ defmodule Plausible.Stats.SamplingTest do
   use Plausible.DataCase, async: false
 
   on_ee do
-    import Plausible.Stats.Sampling, only: [fractional_sample_rate: 2]
+    import Plausible.Stats.Sampling, only: [fractional_sample_rate: 2, queried_duration_days: 1]
     alias Plausible.Stats.{Query, DateTimeRange}
 
     @threshold Plausible.Stats.Sampling.default_sample_threshold()
+
+    describe "&queried_duration_days/1" do
+      test "handles 1 day range" do
+        query = range_query(~D[2026-07-20], ~D[2026-07-20], ~N[2000-01-01 00:00:00])
+
+        assert queried_duration_days(query) == 1
+      end
+
+      test "handles range in non-leap year" do
+        query = range_query(~D[2025-01-01], ~D[2025-12-31], ~N[2000-01-01 00:00:00])
+
+        assert queried_duration_days(query) == 365
+      end
+
+      test "handles range in leap year" do
+        query = range_query(~D[2024-01-01], ~D[2024-12-31], ~N[2000-01-01 00:00:00])
+
+        assert queried_duration_days(query) == 366
+      end
+
+      test "is clamped to the site's native stats start for a range extending beyond native stats start" do
+        query = range_query(~D[2026-07-01], ~D[2026-07-10], ~N[2026-07-08 00:00:00])
+
+        # Stats begin Jul 8, range ends Jul 10 -> Jul 8, 9, 10 = 3 days.
+        assert queried_duration_days(query) == 3
+      end
+    end
 
     describe "&fractional_sample_rate/2 for date ranges of different lengths" do
       test "no traffic estimate" do
@@ -72,25 +99,7 @@ defmodule Plausible.Stats.SamplingTest do
       end
     end
 
-    describe "&fractional_sample_rate/2 clamps the range to the site's stats start" do
-      test "a range with no known stats start uses the full requested range" do
-        # `site_native_stats_start_at` is only nil in tests / for sites without
-        # stats; nothing gets clamped, matching a stats start before the range.
-        without_start = range_query(~D[2025-01-01], ~D[2026-07-15], nil)
-        early_start = range_query(~D[2025-01-01], ~D[2026-07-15], ~N[1900-01-01 00:00:00])
-
-        assert fractional_sample_rate(@threshold, without_start) ==
-                 fractional_sample_rate(@threshold, early_start)
-      end
-
-      test "a range starting after stats begin is unaffected by the clamp" do
-        after_start = range_query(~D[2026-04-01], ~D[2026-07-15], ~N[2026-01-01 00:00:00])
-        no_start = range_query(~D[2026-04-01], ~D[2026-07-15], nil)
-
-        assert fractional_sample_rate(@threshold, after_start) ==
-                 fractional_sample_rate(@threshold, no_start)
-      end
-
+    describe "&fractional_sample_rate/2 clamping" do
       test "a range starting before stats begin is treated as starting when stats begin" do
         stats_start = ~N[2026-01-01 00:00:00]
         range_end = ~D[2026-07-15]
@@ -108,16 +117,9 @@ defmodule Plausible.Stats.SamplingTest do
         assert from_1970 == from_stats_start
         assert from_2025 == from_stats_start
       end
-    end
 
-    describe "&fractional_sample_rate/2 for sites with less than 30 days of stats" do
-      test "estimates traffic from the site's real daily rate, not a 30-day average" do
-        # Site started 3 days before "now" (2026-07-15) and has ingested 30M
-        # events since (10M/day). A query over the last 30 days is clamped to
-        # those 3 days, where all 30M events live - 3x the sampling threshold -
-        # so it must be sampled.
+      test "sample rate is correct if a site has ingested 30M events in the 3 days it has existed" do
         query = range_query(~D[2026-06-15], ~D[2026-07-15], ~N[2026-07-12 00:00:00])
-
         assert fractional_sample_rate(30_000_000, query) == 0.33
       end
     end
@@ -131,20 +133,22 @@ defmodule Plausible.Stats.SamplingTest do
 
       %Query{
         utc_time_range: DateTimeRange.new!(first, last),
-        timezone: "UTC",
-        filters: filters
+        timezone: "Etc/UTC",
+        filters: filters,
+        now: last,
+        # A stats start well before the range, so nothing gets clamped.
+        site_native_stats_start_at: ~N[2000-01-01 00:00:00]
       }
     end
 
     defp range_query(first_date, last_date, native_stats_start_at) do
-      first = DateTime.new!(first_date, ~T[00:00:00], "Etc/UTC")
-      last = DateTime.new!(last_date, ~T[00:00:00], "Etc/UTC")
+      utc_time_range = DateTimeRange.new!(first_date, last_date, "Etc/UTC")
 
       %Query{
-        utc_time_range: DateTimeRange.new!(first, last),
-        timezone: "UTC",
+        utc_time_range: utc_time_range,
+        timezone: "Etc/UTC",
         filters: [],
-        now: last,
+        now: utc_time_range.last,
         site_native_stats_start_at: native_stats_start_at
       }
     end


### PR DESCRIPTION
### Changes

This PR fixes how we estimate traffic to calculate the sample rate for the query. 

There were two issues. The first was noticed by a user, the second by me when I was fixing the first. 

## 1) Overestimating events to scan for longer queries

We were overestimating the events the query would scan when the query start date was significantly before site stats start date, e.g. date range is 1970 to 2026, but stats actually start on 2025. 

Previously, the calculator when run for this query would have estimated traffic to be 56 years worth of last month's average daily traffic.

Now, the calculator takes into account that stats start from 2025, so for this query, the estimated traffic is 1 years worth of last month's average daily traffic.

## 2) Underestimating events to scan for newer sites with high ingestion rate

We were underestimating the events the query would scan when the site's ingest counters have accumulated over less than 30 days. 

Previously, a query for a new site ingesting 10M events per day for 3 days would not have been sampled, but a query for an older site ingesting 10M events per day for the last 30 days would have been. Expected is that both are sampled with the same rate.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This doesn't make a CE-user facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
