### PR TITLE
Fix wrong asserts in exploration test filtered by Firefox scenario

### DIFF
--- a/e2e/tests/dashboard/exploration.spec.ts
+++ b/e2e/tests/dashboard/exploration.spec.ts
@@ -1143,7 +1143,7 @@ test('change filters during a 3-step journey', async ({ page, request }) => {
 
     await expect(
       firstColumn.getByTestId('exploration-row').getByTestId('metric-value')
-    ).toHaveText(['2'])
+    ).toHaveText(['1'])
 
     await expect(
       secondColumn.getByTestId('exploration-row').getByTestId('metric-label')
@@ -1151,7 +1151,7 @@ test('change filters during a 3-step journey', async ({ page, request }) => {
 
     await expect(
       secondColumn.getByTestId('exploration-row').getByTestId('metric-value')
-    ).toHaveText(['2'])
+    ).toHaveText(['1'])
 
     await expect(
       thirdColumn.getByTestId('exploration-row').getByTestId('metric-label')


### PR DESCRIPTION
### Changes

The asserts were wrong for one test step. I've verified that there's indeed one visitor from Firefox in that step. They passed in some cases because the test runs fast enough to evaluate on the column's previous values, which aren't cleared up instantly on clicking the filter.