### PR TITLE
Fix flaky breakdown test

### DIFF
--- a/assets/js/dashboard/components/drilldown-link.tsx
+++ b/assets/js/dashboard/components/drilldown-link.tsx
@@ -58,6 +58,7 @@ export function DrilldownLink({
 
     return (
       <AppNavigationLink
+        data-testid="dimension-value"
         title={`Add filter: ${title}`}
         className={classNames(className, 'group')}
         path={path}
@@ -76,7 +77,7 @@ export function DrilldownLink({
     )
   } else {
     return (
-      <span className={className}>
+      <span data-testid="dimension-value" className={className}>
         {icon}
         <span className={textClassName}>{children}</span>
       </span>

--- a/assets/js/dashboard/stats/pages/external-link.tsx
+++ b/assets/js/dashboard/stats/pages/external-link.tsx
@@ -15,7 +15,7 @@ export function DetailsExternalLink({
           target="_blank"
           rel="noreferrer"
           href={href}
-          aria-label="Open page in new tab"
+          aria-label="Open page in a new tab"
           className={isActive ? 'block' : 'hidden'}
         >
           <ExternalLinkIcon />
@@ -37,7 +37,7 @@ export function IndexExternalLink({
       target="_blank"
       rel="noreferrer"
       href={href}
-      aria-label="Open page in new tab"
+      aria-label="Open page in a new tab"
       className={
         isActive
           ? 'visible md:invisible md:group-hover/row:visible'

--- a/assets/js/dashboard/stats/pages/external-link.tsx
+++ b/assets/js/dashboard/stats/pages/external-link.tsx
@@ -15,6 +15,7 @@ export function DetailsExternalLink({
           target="_blank"
           rel="noreferrer"
           href={href}
+          aria-label="Open page in new tab"
           className={isActive ? 'block' : 'hidden'}
         >
           <ExternalLinkIcon />
@@ -36,6 +37,7 @@ export function IndexExternalLink({
       target="_blank"
       rel="noreferrer"
       href={href}
+      aria-label="Open page in new tab"
       className={
         isActive
           ? 'visible md:invisible md:group-hover/row:visible'

--- a/e2e/tests/test-utils.ts
+++ b/e2e/tests/test-utils.ts
@@ -43,10 +43,15 @@ export const expectHeaders = async (report: Locator, headers: HaveTextArg) =>
   expect(report.getByTestId('report-header')).toHaveText(headers)
 
 export const expectRows = async (report: Locator, labels: HaveTextArg) =>
-  expect(report.getByTestId('report-row').getByRole('link')).toHaveText(labels)
+  expect(
+    report.getByTestId('report-row').getByTestId('dimension-value')
+  ).toHaveText(labels)
 
 export const rowLink = (report: Locator, label: HasTextArg) =>
-  report.getByTestId('report-row').filter({ hasText: label }).getByRole('link')
+  report
+    .getByTestId('report-row')
+    .filter({ hasText: label })
+    .getByTestId('dimension-value')
 
 export const expectMetricValues = async (
   report: Locator,


### PR DESCRIPTION
### Changes

This flaky test was a bit tricky. The way we selected `getByRole(link)` within the rows caught the external link icon, producing the failure
```
    Locator: getByTestId('report-pages').getByTestId('report-row').getByRole('link')
    Timeout: 5000ms
    - Expected  - 0
    + Received  + 1

      Array [
        "blog.example.com/post",
        "docs.example.com/api",
    +   "",
      ]

    Call log:
      - Expect "toHaveText" with timeout 5000ms
      - waiting for getByTestId('report-pages').getByTestId('report-row').getByRole('link')
        14 × locator resolved to 3 elements


       at test-utils.ts:46
```

That didn't occur every time because the external link element appears only when the cursor hovers the row. 