### PR TITLE
Track installation method with form `onsubmit` instead of classes

### DIFF
--- a/assets/js/liveview/live_socket.js
+++ b/assets/js/liveview/live_socket.js
@@ -17,14 +17,6 @@ let csrfToken = document.querySelector("meta[name='csrf-token']")
 let websocketUrl = document.querySelector("meta[name='websocket-url']")
 if (csrfToken && websocketUrl) {
   let Hooks = { Modal, Dropdown }
-  Hooks.Metrics = {
-    mounted() {
-      this.handleEvent('send-metrics', ({ event_name }) => {
-        window.plausible(event_name)
-        this.pushEvent('send-metrics-after', { event_name })
-      })
-    }
-  }
   let Uploaders = {}
   Uploaders.S3 = function (entries, onViewError) {
     entries.forEach((entry) => {

--- a/lib/plausible_web/live/installation.ex
+++ b/lib/plausible_web/live/installation.ex
@@ -152,7 +152,12 @@ defmodule PlausibleWeb.Live.Installation do
             />
           <% end %>
 
-          <.form for={@tracker_script_configuration_form.result} phx-submit="submit" class="mt-4">
+          <.form
+            for={@tracker_script_configuration_form.result}
+            phx-submit="submit"
+            class="mt-4"
+            onsubmit={install_method_event(@installation_type.result, recommended_installation_type)}
+          >
             <.input
               type="hidden"
               field={@tracker_script_configuration_form.result[:installation_type]}
@@ -179,13 +184,7 @@ defmodule PlausibleWeb.Live.Installation do
 
             <.button
               type="submit"
-              class={
-                "w-full mt-8 " <>
-                  install_method_event_classes(
-                    @installation_type.result,
-                    recommended_installation_type
-                  )
-              }
+              class="w-full mt-8"
             >
               {verify_cta(@installation_type.result)}
             </.button>
@@ -211,22 +210,27 @@ defmodule PlausibleWeb.Live.Installation do
   defp verify_cta("gtm"), do: "Verify Tag Manager installation"
   defp verify_cta("npm"), do: "Verify NPM installation"
 
-  defp install_method_event_classes(installation_type, recommended) do
-    method = installation_method_label(installation_type)
-    match = if installation_type == recommended, do: "true", else: "false"
+  on_ee do
+    defp install_method_event(installation_type, recommended) do
+      method = installation_method_label(installation_type)
+      match = if installation_type == recommended, do: "true", else: "false"
 
-    Enum.join(
-      [
-        "plausible-event-name=Site+installation+method",
-        "plausible-event-method=#{method}",
-        "plausible-event-recommended_match=#{match}"
-      ],
-      " "
-    )
+      opts =
+        Jason.encode!(%{
+          "props" => %{
+            "method" => method,
+            "recommended_match" => match
+          }
+        })
+
+      "window.plausible('Site installation method', #{opts})"
+    end
+
+    defp installation_method_label("manual"), do: "script"
+    defp installation_method_label(other), do: other
+  else
+    defp install_method_event(_, _), do: ""
   end
-
-  defp installation_method_label("manual"), do: "script"
-  defp installation_method_label(other), do: other
 
   on_ee do
     defp detect_recommended_installation_type(flow, site) do

--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -90,6 +90,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
         id="register-form"
         class="flex flex-col gap-y-6"
         action={Routes.auth_path(@socket, :login)}
+        onsubmit={form_submit_event(@invitation)}
         phx-hook="Metrics"
         phx-change="validate"
         phx-submit="register"
@@ -178,6 +179,14 @@ defmodule PlausibleWeb.Live.RegisterForm do
       </.form>
     </.auth_container>
     """
+  end
+
+  on_ee do
+    defp form_submit_event(invitation) do
+      "window.plausible('Signup#{if invitation, do: " via invitation"}')"
+    end
+  else
+    defp form_submit_event(_), do: ""
   end
 
   defp name_input(assigns) do
@@ -275,10 +284,6 @@ defmodule PlausibleWeb.Live.RegisterForm do
     end
   end
 
-  def handle_event("send-metrics-after", _params, socket) do
-    {:noreply, assign(socket, trigger_submit: true)}
-  end
-
   defp add_user(socket, user, opts \\ []) do
     result =
       Repo.transaction(fn ->
@@ -289,12 +294,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
       {:ok, _user} ->
         socket = assign(socket, disable_submit: true)
 
-        on_ee do
-          event_name = "Signup#{if socket.assigns.invitation, do: " via invitation"}"
-          {:noreply, push_event(socket, "send-metrics", %{event_name: event_name})}
-        else
-          {:noreply, assign(socket, trigger_submit: true)}
-        end
+        {:noreply, assign(socket, trigger_submit: true)}
 
       {:error, changeset} ->
         {:noreply,

--- a/test/plausible_web/live/register_form_test.exs
+++ b/test/plausible_web/live/register_form_test.exs
@@ -56,10 +56,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       html = lv |> element("form") |> render_submit()
 
-      on_ee do
-        assert_push_event(lv, "send-metrics", %{event_name: "Signup"})
-      end
-
       assert [
                csrf_input,
                action_input,
@@ -98,16 +94,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       refute Repo.one(User)
     end
-
-    test "pushing send-metrics-after event submits the form", %{conn: conn} do
-      lv = get_liveview(conn, "/register")
-
-      refute render(lv) =~ ~s|phx-trigger-action=""|
-
-      render_hook(lv, "send-metrics-after", %{event_name: "Signup", params: %{}})
-
-      assert render(lv) =~ ~s|phx-trigger-action=""|
-    end
   end
 
   describe "/register/invitation/:invitation_id" do
@@ -130,10 +116,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
 
       html = lv |> element("form") |> render_submit()
-
-      on_ee do
-        assert_push_event(lv, "send-metrics", %{event_name: "Signup via invitation"})
-      end
 
       assert [
                csrf_input,
@@ -175,10 +157,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
 
       html = lv |> element("form") |> render_submit()
-
-      on_ee do
-        assert_push_event(lv, "send-metrics", %{event_name: "Signup via invitation"})
-      end
 
       assert [
                csrf_input,
@@ -266,19 +244,6 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert html =~ "Please complete the captcha to register"
 
       refute Repo.get_by(User, email: "user@email.co")
-    end
-
-    test "pushing send-metrics-after event submits the form", %{
-      conn: conn,
-      guest_invitation: guest_invitation
-    } do
-      lv = get_liveview(conn, "/register/invitation/#{guest_invitation.invitation_id}")
-
-      refute render(lv) =~ ~s|phx-trigger-action=""|
-
-      render_hook(lv, "send-metrics-after", %{event_name: "Signup via invitation", params: %{}})
-
-      assert render(lv) =~ ~s|phx-trigger-action=""|
     end
   end
 


### PR DESCRIPTION
### Changes

This PR implements alternative approach to tracking form submission event in LV proposed in https://github.com/plausible/analytics/pull/6509#discussion_r3586935725. The event is triggered across Firefox, Vivaldi and Safari on MacOS and Safari on iOS. In all cases the sent event is registered in the network tab.


