### PR TITLE
Stop repeating annotation date in tooltip when unambiguous

### DIFF
--- a/assets/js/dashboard/annotations/annotation-list-items.tsx
+++ b/assets/js/dashboard/annotations/annotation-list-items.tsx
@@ -21,24 +21,28 @@ const VerticalBar = () => (
 )
 
 export const AnnotationItemRow = ({ children }: { children: ReactNode }) => (
-  <div className="group flex flex-row gap-x-2">
+  <div className="relative group flex flex-row gap-x-2">
     <VerticalBar />
     {children}
   </div>
 )
 
 export const AnnotationAuthorshipLine = ({
-  annotation
+  annotation,
+  showDateLabel
 }: {
   annotation: Annotation
+  showDateLabel: boolean
 }) => (
   <div className="flex items-baseline text-xs text-gray-300 pr-8">
     <span className="truncate min-w-0">
       {getAnnotationAuthorship(annotation)}
     </span>
-    <span className="whitespace-nowrap shrink-0">
-      {` • ${getAttributionDateLabel(annotation)}`}
-    </span>
+    {showDateLabel && (
+      <span className="whitespace-nowrap shrink-0">
+        &nbsp;{`• ${getAttributionDateLabel(annotation)}`}
+      </span>
+    )}
   </div>
 )
 

--- a/assets/js/dashboard/annotations/annotation-list-items.tsx
+++ b/assets/js/dashboard/annotations/annotation-list-items.tsx
@@ -34,7 +34,10 @@ export const AnnotationAuthorshipLine = ({
   annotation: Annotation
   showDateLabel: boolean
 }) => (
-  <div className="flex items-baseline text-xs text-gray-300 pr-8">
+  <div
+    data-testid="annotation-attribution"
+    className="flex items-baseline text-xs text-gray-300 pr-8"
+  >
     <span className="truncate min-w-0">
       {getAnnotationAuthorship(annotation)}
     </span>

--- a/assets/js/dashboard/annotations/annotations.test.ts
+++ b/assets/js/dashboard/annotations/annotations.test.ts
@@ -6,7 +6,8 @@ import {
   getAnnotationAuthorship,
   getAnnotationGranularity,
   getAnnotationTimeLabel,
-  groupAnnotationsByTimeLabel
+  groupAnnotationsByTimeLabel,
+  allAnnotationsAreFromThisExactDatetime
 } from './annotations'
 import { Interval } from '../stats/graph/intervals'
 import { Role, UserContextValue } from '../user-context'
@@ -293,5 +294,46 @@ describe(`${groupAnnotationsByTimeLabel.name}`, () => {
         Interval.day
       )
     ).toEqual({})
+  })
+})
+
+describe(`${allAnnotationsAreFromThisExactDatetime.name}`, () => {
+  it('returns true when every annotation shares the given datetime', () => {
+    expect(
+      allAnnotationsAreFromThisExactDatetime(
+        [
+          { datetime: '2025-02-26T10:30:00' },
+          { datetime: '2025-02-26T10:30:00' }
+        ],
+        '2025-02-26T10:30:00'
+      )
+    ).toBe(true)
+  })
+
+  it('returns true when every annotation shares the given date', () => {
+    expect(
+      allAnnotationsAreFromThisExactDatetime(
+        [{ datetime: '2026-07-20' }, { datetime: '2026-07-20' }],
+        '2026-07-20'
+      )
+    ).toBe(true)
+  })
+
+  it('returns false when some annotation has a different datetime', () => {
+    expect(
+      allAnnotationsAreFromThisExactDatetime(
+        [
+          { datetime: '2025-02-26T10:30:00' },
+          { datetime: '2025-02-26T10:31:00' }
+        ],
+        '2025-02-26T10:30:00'
+      )
+    ).toBe(false)
+  })
+
+  it('returns true when there are no annotations', () => {
+    expect(
+      allAnnotationsAreFromThisExactDatetime([], '2025-02-26T10:30:00')
+    ).toBe(true)
   })
 })

--- a/assets/js/dashboard/annotations/annotations.test.ts
+++ b/assets/js/dashboard/annotations/annotations.test.ts
@@ -5,8 +5,8 @@ import {
   canEditAnnotation,
   getAnnotationAuthorship,
   getAnnotationGranularity,
-  getAnnotationTimeLabel,
-  groupAnnotationsByTimeLabel,
+  getAnnotationDatetimeGroup,
+  groupAnnotationsByDatetime,
   allAnnotationsAreFromThisExactDatetime
 } from './annotations'
 import { Interval } from '../stats/graph/intervals'
@@ -200,7 +200,7 @@ describe(`${getAnnotationGranularity.name}`, () => {
   })
 })
 
-describe(`${getAnnotationTimeLabel.name}`, () => {
+describe(`${getAnnotationDatetimeGroup.name}`, () => {
   // 2025-02-26 is a Wednesday
   const dateAnnotation = {
     datetime: '2025-02-26',
@@ -216,7 +216,9 @@ describe(`${getAnnotationTimeLabel.name}`, () => {
   ])(
     `date-granularity annotation on ${dateAnnotation.datetime} bucketed to %s yields %s`,
     (interval, expected) => {
-      expect(getAnnotationTimeLabel(dateAnnotation, interval)).toBe(expected)
+      expect(getAnnotationDatetimeGroup(dateAnnotation, interval)).toBe(
+        expected
+      )
     }
   )
 
@@ -228,17 +230,19 @@ describe(`${getAnnotationTimeLabel.name}`, () => {
     [Interval.month, '2025-02-01'],
     [Interval.week, '2025-02-24'],
     [Interval.day, '2025-02-26'],
-    [Interval.hour, '2025-02-26 10:00:00'],
-    [Interval.minute, '2025-02-26 10:30:00']
+    [Interval.hour, '2025-02-26T10:00:00'],
+    [Interval.minute, '2025-02-26T10:30:00']
   ])(
     `minute granularity annotation with datetime ${minuteAnnotation.datetime} bucketed to %s yields %s`,
     (interval, expected) => {
-      expect(getAnnotationTimeLabel(minuteAnnotation, interval)).toBe(expected)
+      expect(getAnnotationDatetimeGroup(minuteAnnotation, interval)).toBe(
+        expected
+      )
     }
   )
 })
 
-describe(`${groupAnnotationsByTimeLabel.name}`, () => {
+describe(`${groupAnnotationsByDatetime.name}`, () => {
   const dateGranularity = AnnotationGranularity.date
   const annotations = [
     { id: 1, datetime: '2025-02-24 00:00:00', granularity: dateGranularity }, // Mon
@@ -247,7 +251,7 @@ describe(`${groupAnnotationsByTimeLabel.name}`, () => {
   ]
 
   it('groups annotations by day when the interval is day', () => {
-    const grouped = groupAnnotationsByTimeLabel(annotations, Interval.day)
+    const grouped = groupAnnotationsByDatetime(annotations, Interval.day)
 
     expect(Object.keys(grouped).sort()).toEqual([
       '2025-02-24',
@@ -260,7 +264,7 @@ describe(`${groupAnnotationsByTimeLabel.name}`, () => {
   })
 
   it('collapses annotations from the same week into one bucket', () => {
-    const grouped = groupAnnotationsByTimeLabel(annotations, Interval.week)
+    const grouped = groupAnnotationsByDatetime(annotations, Interval.week)
 
     expect(Object.keys(grouped).sort()).toEqual(['2025-02-24', '2025-03-03'])
     expect(grouped['2025-02-24']!.map((a) => a.id)).toEqual([1, 2])
@@ -268,7 +272,7 @@ describe(`${groupAnnotationsByTimeLabel.name}`, () => {
   })
 
   it('collapses annotations from the same month into one bucket', () => {
-    const grouped = groupAnnotationsByTimeLabel(annotations, Interval.month)
+    const grouped = groupAnnotationsByDatetime(annotations, Interval.month)
 
     expect(Object.keys(grouped).sort()).toEqual(['2025-02-01', '2025-03-01'])
     expect(grouped['2025-02-01']!.map((a) => a.id)).toEqual([1, 2])
@@ -282,14 +286,14 @@ describe(`${groupAnnotationsByTimeLabel.name}`, () => {
       { id: 12, datetime: '2025-02-26 10:00:00', granularity: dateGranularity }
     ]
 
-    const grouped = groupAnnotationsByTimeLabel(sameDay, Interval.day)
+    const grouped = groupAnnotationsByDatetime(sameDay, Interval.day)
 
     expect(grouped['2025-02-26']!.map((a) => a.id)).toEqual([10, 11, 12])
   })
 
   it('returns an empty object when there are no annotations', () => {
     expect(
-      groupAnnotationsByTimeLabel(
+      groupAnnotationsByDatetime(
         [] as { datetime: string; granularity: AnnotationGranularity }[],
         Interval.day
       )

--- a/assets/js/dashboard/annotations/annotations.ts
+++ b/assets/js/dashboard/annotations/annotations.ts
@@ -37,9 +37,9 @@ export type Annotation = {
   note: string
 
   id: number
-  /** datetime in site timezone, example 2025-02-26 10:00:00 */
+  /** datetime in site timezone, example 2025-02-26T10:00:00 */
   inserted_at: string
-  /** datetime in site timezone, example 2025-02-26 10:00:00 */
+  /** datetime in site timezone, example 2025-02-26T10:00:00 */
   updated_at: string
 } & AnnotationOwnership
 
@@ -139,7 +139,7 @@ export function canAddAnnotation({
   }
 }
 
-export const getAnnotationTimeLabel = (
+export const getAnnotationDatetimeGroup = (
   annotation: Pick<Annotation, 'datetime' | 'granularity'>,
   interval: Interval
 ): string => {
@@ -175,24 +175,24 @@ export const getAnnotationTimeLabel = (
         case Interval.hour: {
           const [dateYYYYMMDD, timeHHMMSS] = annotation.datetime.split('T')
           // floors time to hour
-          return `${dateYYYYMMDD} ${timeHHMMSS.substring(0, 'HH'.length)}:00:00`
+          return `${dateYYYYMMDD}T${timeHHMMSS.substring(0, 'HH'.length)}:00:00`
         }
         case Interval.minute:
-          return annotation.datetime.split('T').join(' ')
+          return annotation.datetime
       }
     }
   }
 }
 
-export const groupAnnotationsByTimeLabel = <
+export const groupAnnotationsByDatetime = <
   T extends Pick<Annotation, 'datetime' | 'granularity'>
 >(
   annotations: T[],
   interval: Interval
 ): Record<string, T[] | undefined> => {
   return annotations.reduce<Record<string, T[]>>((acc, annotation) => {
-    const timeLabel = getAnnotationTimeLabel(annotation, interval)
-    return { ...acc, [timeLabel]: [...(acc[timeLabel] ?? []), annotation] }
+    const label = getAnnotationDatetimeGroup(annotation, interval)
+    return { ...acc, [label]: [...(acc[label] ?? []), annotation] }
   }, {})
 }
 

--- a/assets/js/dashboard/annotations/annotations.ts
+++ b/assets/js/dashboard/annotations/annotations.ts
@@ -210,6 +210,11 @@ export const getAnnotationGranularity = (
   }
 }
 
+export const allAnnotationsAreFromThisExactDatetime = (
+  annotations: Pick<Annotation, 'datetime'>[],
+  datetime: string
+): boolean => annotations.every((a) => a.datetime === datetime)
+
 export const getApiFormattedPayload = ({
   granularity,
   datetime,

--- a/assets/js/dashboard/annotations/hover-annotations-list.tsx
+++ b/assets/js/dashboard/annotations/hover-annotations-list.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import { Annotation } from './annotations'
+import {
+  Annotation,
+  allAnnotationsAreFromThisExactDatetime
+} from './annotations'
 import {
   AnnotationAuthorshipLine,
   AnnotationItemRow,
@@ -10,20 +13,29 @@ import {
 const MAX_PREVIEW = 2
 
 export const HoverAnnotationsList = ({
+  annotationDatetime,
   annotations
 }: {
+  annotationDatetime: string
   annotations: Annotation[]
 }) => {
   const preview = annotations.slice(0, MAX_PREVIEW)
   const extra = annotations.length - MAX_PREVIEW
+  const showDateLabel = !allAnnotationsAreFromThisExactDatetime(
+    preview,
+    annotationDatetime
+  )
 
   return (
     <>
       <AnnotationsListContainer>
         {preview.map((annotation) => (
           <AnnotationItemRow key={annotation.id}>
-            <div className="relative flex flex-col gap-y-px w-full max-w-64">
-              <AnnotationAuthorshipLine annotation={annotation} />
+            <div className="flex flex-col gap-y-px w-full max-w-64">
+              <AnnotationAuthorshipLine
+                annotation={annotation}
+                showDateLabel={showDateLabel}
+              />
               <AnnotationNote note={annotation.note} clamp />
             </div>
           </AnnotationItemRow>

--- a/assets/js/dashboard/annotations/interactive-annotations-list.tsx
+++ b/assets/js/dashboard/annotations/interactive-annotations-list.tsx
@@ -1,5 +1,9 @@
 import React, { ReactNode } from 'react'
-import { Annotation, canEditAnnotation } from './annotations'
+import {
+  Annotation,
+  allAnnotationsAreFromThisExactDatetime,
+  canEditAnnotation
+} from './annotations'
 import {
   AnnotationAuthorshipLine,
   AnnotationItemRow,
@@ -17,10 +21,12 @@ const ScrollableArea = (props: { children: ReactNode }) => (
 )
 
 export const InteractiveAnnotationsList = ({
+  annotationDatetime,
   annotations,
   isTouchDevice,
   closeTooltip
 }: {
+  annotationDatetime: string
   annotations: Annotation[]
   isTouchDevice: boolean
   closeTooltip: () => void
@@ -31,6 +37,10 @@ export const InteractiveAnnotationsList = ({
     closeTooltip()
     setModal({ type: 'update-annotation', annotation })
   }
+  const showDateLabel = !allAnnotationsAreFromThisExactDatetime(
+    annotations,
+    annotationDatetime
+  )
 
   return (
     <ScrollableArea>
@@ -39,7 +49,10 @@ export const InteractiveAnnotationsList = ({
           const editable = canEditAnnotation({ type: annotation.type, user })
           const content = (
             <>
-              <AnnotationAuthorshipLine annotation={annotation} />
+              <AnnotationAuthorshipLine
+                annotation={annotation}
+                showDateLabel={showDateLabel}
+              />
               <AnnotationNote note={annotation.note} />
               {editable && !isTouchDevice && (
                 <button
@@ -56,13 +69,13 @@ export const InteractiveAnnotationsList = ({
             <AnnotationItemRow key={annotation.id}>
               {editable && isTouchDevice ? (
                 <button
-                  className="relative flex flex-col gap-y-px w-full max-w-64 text-left focus:outline-none"
+                  className="flex flex-col gap-y-px w-full max-w-64 text-left focus:outline-none"
                   onClick={() => openEdit(annotation)}
                 >
                   {content}
                 </button>
               ) : (
-                <div className="relative flex flex-col gap-y-px w-full max-w-64">
+                <div className="flex flex-col gap-y-px w-full max-w-64">
                   {content}
                 </div>
               )}

--- a/assets/js/dashboard/stats/graph/main-graph-data.test.ts
+++ b/assets/js/dashboard/stats/graph/main-graph-data.test.ts
@@ -1,7 +1,8 @@
 import {
   getChangeInPercentagePoints,
   getRelativeChange,
-  getLineSegments
+  getLineSegments,
+  normalizeGraphTimeLabel
 } from './main-graph-data'
 
 describe(`${getChangeInPercentagePoints.name}`, () => {
@@ -107,5 +108,17 @@ describe(`${getLineSegments.name}`, () => {
     expect(getLineSegments([nc(), nc(), nc(), gap(), gap()])).toEqual([
       { startIndexInclusive: 0, stopIndexExclusive: 3, type: 'full' }
     ])
+  })
+})
+
+describe(`${normalizeGraphTimeLabel.name}`, () => {
+  it('replaces the space separator with "T" for datetime labels', () => {
+    expect(normalizeGraphTimeLabel('2026-10-10 10:00:15')).toBe(
+      '2026-10-10T10:00:15'
+    )
+  })
+
+  it('leaves date-only labels unchanged', () => {
+    expect(normalizeGraphTimeLabel('2026-10-10')).toBe('2026-10-10')
   })
 })

--- a/assets/js/dashboard/stats/graph/main-graph-data.ts
+++ b/assets/js/dashboard/stats/graph/main-graph-data.ts
@@ -213,3 +213,11 @@ type SeriesValue =
       isCurrent: boolean
       timeLabel: string
     }
+
+/**
+ * This function normalizes graph time labels in the format "2026-10-10 10:00:15"
+ * to the standard format "2026-10-10T10:00:15". Passes YYYY-MM-DD format date strings
+ * like "2026-01-01" through unchanged.
+ */
+export const normalizeGraphTimeLabel = (timeLabel: string) =>
+  timeLabel.split(' ').join('T')

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -399,10 +399,6 @@ export const MainGraph = ({
       ? selectedDatum.main.timeLabel
       : null
 
-  // graph time labels are space-separated ("YYYY-MM-DD HH:MM:SS"); normalize to the
-  // standard ISO form ("YYYY-MM-DDTHH:MM:SS") that annotation code works with, both
-  // for the `annotationsByTimeLabel` lookup (keyed by normalized labels) and for the
-  // datetime handed to the annotation components.
   const annotationDatetime =
     selectedDatum && selectedDatum.main.isDefined
       ? normalizeGraphTimeLabel(selectedDatum.main.timeLabel)

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -36,7 +36,8 @@ import {
   getRelativeChange,
   REVENUE_METRICS,
   getFirstAndLastTimeLabels,
-  MainGraphSeriesName
+  MainGraphSeriesName,
+  normalizeGraphTimeLabel
 } from './main-graph-data'
 import { Metric, getMetricLabel } from '../metrics'
 import { extractIntervalFromDimensions, Interval } from './intervals'
@@ -46,7 +47,7 @@ import {
   AnnotationType,
   canShowAddAnnotationButton,
   getAnnotationGranularity,
-  groupAnnotationsByTimeLabel
+  groupAnnotationsByDatetime
 } from '../../annotations/annotations'
 import { useUserContext } from '../../user-context'
 import { Button } from '../../components/button'
@@ -118,8 +119,8 @@ export const MainGraph = ({
   const interval = extractIntervalFromDimensions(data.query.dimensions)
   const isRealtime = data.extraContext.isRealtime
 
-  const annotationsByTimeLabel = useMemo(
-    () => groupAnnotationsByTimeLabel(annotations, interval),
+  const annotationsByDatetime = useMemo(
+    () => groupAnnotationsByDatetime(annotations, interval),
     [annotations, interval]
   )
 
@@ -304,13 +305,15 @@ export const MainGraph = ({
     () =>
       remappedData.map((datum) => {
         const annotationsOnDatum = datum.main.isDefined
-          ? (annotationsByTimeLabel[datum.main.timeLabel] ?? [])
+          ? (annotationsByDatetime[
+              normalizeGraphTimeLabel(datum.main.timeLabel)
+            ] ?? [])
           : []
         return {
           count: annotationsOnDatum.length
         }
       }),
-    [remappedData, annotationsByTimeLabel]
+    [remappedData, annotationsByDatetime]
   )
 
   const getFormattedValue = useCallback(
@@ -396,10 +399,18 @@ export const MainGraph = ({
       ? selectedDatum.main.timeLabel
       : null
 
+  // graph time labels are space-separated ("YYYY-MM-DD HH:MM:SS"); normalize to the
+  // standard ISO form ("YYYY-MM-DDTHH:MM:SS") that annotation code works with, both
+  // for the `annotationsByTimeLabel` lookup (keyed by normalized labels) and for the
+  // datetime handed to the annotation components.
   const annotationDatetime =
     selectedDatum && selectedDatum.main.isDefined
-      ? selectedDatum.main.timeLabel
+      ? normalizeGraphTimeLabel(selectedDatum.main.timeLabel)
       : null
+
+  const annotationsForSelectedBucket = annotationDatetime
+    ? annotationsByDatetime[annotationDatetime]
+    : undefined
 
   const zoomToPeriod = useCallback(
     (date: string) => {
@@ -507,11 +518,7 @@ export const MainGraph = ({
           {tooltip.persistent ? (
             <PersistentTooltipContents
               annotationDatetime={annotationDatetime}
-              annotations={
-                annotationDatetime
-                  ? annotationsByTimeLabel[annotationDatetime]
-                  : undefined
-              }
+              annotations={annotationsForSelectedBucket}
               isTouchDevice={isTouchDevice}
               interval={interval}
               zoomDate={zoomDate}
@@ -522,11 +529,7 @@ export const MainGraph = ({
           ) : (
             <HoveredTooltipContents
               annotationDatetime={annotationDatetime}
-              annotations={
-                annotationDatetime
-                  ? annotationsByTimeLabel[annotationDatetime]
-                  : undefined
-              }
+              annotations={annotationsForSelectedBucket}
               interval={interval}
               zoomDate={zoomDate}
               canAddAnnotation={canAddAnnotation}

--- a/assets/js/dashboard/stats/graph/main-graph.tsx
+++ b/assets/js/dashboard/stats/graph/main-graph.tsx
@@ -521,6 +521,7 @@ export const MainGraph = ({
             />
           ) : (
             <HoveredTooltipContents
+              annotationDatetime={annotationDatetime}
               annotations={
                 annotationDatetime
                   ? annotationsByTimeLabel[annotationDatetime]
@@ -538,6 +539,7 @@ export const MainGraph = ({
 }
 
 type TooltipContentsProps = {
+  annotationDatetime: string | null
   annotations: Annotation[] | undefined
   interval: Interval
   zoomDate: string | null
@@ -554,7 +556,6 @@ const PersistentTooltipContents = ({
   canAddAnnotation,
   closeTooltip
 }: {
-  annotationDatetime: string | null
   isTouchDevice: boolean
   onZoomToPeriod: (date: string) => void
   closeTooltip: () => void
@@ -564,8 +565,9 @@ const PersistentTooltipContents = ({
   const hasActions = !!zoomDate || (!!annotationDatetime && canAddAnnotation)
   return (
     <>
-      {!!annotations?.length && (
+      {!!annotationDatetime && !!annotations?.length && (
         <InteractiveAnnotationsList
+          annotationDatetime={annotationDatetime}
           annotations={annotations}
           isTouchDevice={isTouchDevice}
           closeTooltip={closeTooltip}
@@ -606,6 +608,7 @@ const PersistentTooltipContents = ({
 }
 
 const HoveredTooltipContents = ({
+  annotationDatetime,
   annotations,
   interval,
   zoomDate,
@@ -613,8 +616,11 @@ const HoveredTooltipContents = ({
 }: TooltipContentsProps) => {
   return (
     <>
-      {!!annotations?.length && (
-        <HoverAnnotationsList annotations={annotations} />
+      {!!annotationDatetime && !!annotations?.length && (
+        <HoverAnnotationsList
+          annotations={annotations}
+          annotationDatetime={annotationDatetime}
+        />
       )}
       <hr className="border-gray-600 dark:border-gray-800 my-1" />
       <div className="flex flex-col gap-y-0.5">

--- a/e2e/tests/dashboard/annotations.spec.ts
+++ b/e2e/tests/dashboard/annotations.spec.ts
@@ -68,6 +68,7 @@ test('user can create annotations across granularities, edit, and delete them', 
   // when all annotations in a bucket are exactly for the date (& time) of the bucket
   // the attribution is shortened because it's unambiguous
   const siteNoteAttributionUnambiguous = `${user.name}`
+  const personalNoteAttributionUnambiguous = 'Personal note'
 
   // Asserts the tooltip's annotation list matches provided list exactly
   const expectTooltipAnnotations = async (
@@ -78,7 +79,9 @@ test('user can create annotations across granularities, edit, and delete them', 
     for (const [i, { note, attribution }] of expected.entries()) {
       const row = rows.nth(i)
       await expect(row).toContainText(note)
-      await expect(row.getByText(attribution, { exact: true })).toBeVisible()
+      await expect(row.getByTestId('annotation-attribution')).toHaveText(
+        attribution
+      )
     }
   }
 
@@ -165,6 +168,18 @@ test('user can create annotations across granularities, edit, and delete them', 
     await expect(
       page.getByTestId('annotation-marker-on-bucket-10')
     ).toBeVisible()
+  })
+
+  await test.step('in day view, hovering the 10:00 bucket with the single note omits the duplicative datetime label from the note', async () => {
+    const hour10InDay = page.getByTestId('graph-dot-series-1-bucket-10')
+    await hour10InDay.hover()
+    await expect(tooltip).toBeVisible()
+    await expectTooltipAnnotations([
+      {
+        note: personalNoteText,
+        attribution: personalNoteAttributionUnambiguous
+      }
+    ])
   })
 
   await test.step('zoom back out to 7d, both annotations are visible on Monday', async () => {

--- a/e2e/tests/dashboard/annotations.spec.ts
+++ b/e2e/tests/dashboard/annotations.spec.ts
@@ -65,6 +65,9 @@ test('user can create annotations across granularities, edit, and delete them', 
 
   const personalNoteAttribution = 'Personal note • 29 Jun 10:00'
   const siteNoteAttribution = `${user.name} • 29 Jun`
+  // when all annotations in a bucket are exactly for the date (& time) of the bucket
+  // the attribution is shortened because it's unambiguous
+  const siteNoteAttributionUnambiguous = `${user.name}`
 
   // Asserts the tooltip's annotation list matches provided list exactly
   const expectTooltipAnnotations = async (
@@ -124,7 +127,7 @@ test('user can create annotations across granularities, edit, and delete them', 
   await test.step('right-click Monday and zoom in via "View day"', async () => {
     await mondayIn7d.hover()
     await expectTooltipAnnotations([
-      { note: siteNoteText, attribution: siteNoteAttribution }
+      { note: siteNoteText, attribution: siteNoteAttributionUnambiguous }
     ])
 
     await mondayIn7d.click({ button: 'right' })
@@ -239,7 +242,7 @@ test('user can create annotations across granularities, edit, and delete them', 
     await expect(deleteModalHeading).toBeHidden()
     await mondayIn7d.hover()
     await expectTooltipAnnotations([
-      { note: siteNoteText, attribution: siteNoteAttribution }
+      { note: siteNoteText, attribution: siteNoteAttributionUnambiguous }
     ])
     await expect(mondayMarker7d).toBeVisible()
   })

--- a/test/plausible_web/controllers/api/internal_controller/annotations_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/annotations_controller_test.exs
@@ -507,7 +507,7 @@ defmodule PlausibleWeb.Api.Internal.AnnotationsControllerTest do
             "note" => "feature released",
             "type" => "personal",
             "granularity" => "minute",
-            "datetime" => dt
+            "datetime" => unquote(dt)
           })
           |> json_response(200)
 

--- a/test/plausible_web/controllers/api/internal_controller/annotations_controller_test.exs
+++ b/test/plausible_web/controllers/api/internal_controller/annotations_controller_test.exs
@@ -495,26 +495,28 @@ defmodule PlausibleWeb.Api.Internal.AnnotationsControllerTest do
       assert response["datetime"] == "2026-01-04T14:32:00"
     end
 
-    test "converts naive local time to UTC and returns it back as local time",
-         %{conn: conn, user: user} do
-      # America/New_York is UTC-5 in January; input and output should be the same
-      # local time (round-trip), while the DB stores the UTC equivalent.
-      site = new_site(owner: user, timezone: "America/New_York")
+    for dt <- ["2026-01-04T14:30:00", "2026-01-04 14:30:00"] do
+      test "converts naive local time #{dt} to UTC and returns it back as local time",
+           %{conn: conn, user: user} do
+        # America/New_York is UTC-5 in January; input and output should be the same
+        # local time (round-trip), while the DB stores the UTC equivalent.
+        site = new_site(owner: user, timezone: "America/New_York")
 
-      response =
-        post(conn, "/api/#{site.domain}/annotations", %{
-          "note" => "feature released",
-          "type" => "personal",
-          "granularity" => "minute",
-          "datetime" => "2026-01-04T14:30:00"
-        })
-        |> json_response(200)
+        response =
+          post(conn, "/api/#{site.domain}/annotations", %{
+            "note" => "feature released",
+            "type" => "personal",
+            "granularity" => "minute",
+            "datetime" => dt
+          })
+          |> json_response(200)
 
-      assert response["datetime"] == "2026-01-04T14:30:00"
+        assert response["datetime"] == "2026-01-04T14:30:00"
 
-      reloaded = Plausible.Repo.get!(Plausible.Annotations.Annotation, response["id"])
-      assert reloaded.granularity == :minute
-      assert reloaded.datetime == ~U[2026-01-04 19:30:00Z]
+        reloaded = Plausible.Repo.get!(Plausible.Annotations.Annotation, response["id"])
+        assert reloaded.granularity == :minute
+        assert reloaded.datetime == ~U[2026-01-04 19:30:00Z]
+      end
     end
 
     test "UTC datetime string is stored as UTC and returned as site local time",


### PR DESCRIPTION
### Changes

1. Fixes "Edit note" button being covered by scrollbar in cases where the authorship line is longer due to long author name
2. Fixes missing space in note authorship line, it was cut away due to how HTML handles leading and trailing spaces
3. Stops showing note date & time in note authorship line when it's unambiguous. No point in repeating it in an already tightly packed tooltip.
4. Refactors annotations grouping logic to group by datetime labels with the T-separator (was grouping by labels with the space separator). 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
