### PR TITLE
Refine verification banner UI and copy

### DIFF
--- a/extra/lib/plausible/installation_support/result.ex
+++ b/extra/lib/plausible/installation_support/result.ex
@@ -6,7 +6,7 @@ defmodule Plausible.InstallationSupport.Result do
   ok?: false,
   data: nil,
   errors: [error.message],
-  recommendations: [%{text: error.recommendation, url: error.url}]
+  recommendations: [%{text: error.recommendation, inline_links: error.inline_links}]
 
   ok?: true,
   data: %{},

--- a/extra/lib/plausible/installation_support/verification/diagnostics.ex
+++ b/extra/lib/plausible/installation_support/verification/diagnostics.ex
@@ -33,35 +33,56 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
     """
 
     @enforce_keys [:message, :recommendation]
-    defstruct [:message, :recommendation, :url]
+    defstruct [:message, :recommendation, inline_links: []]
+
+    @required_link_prefix "https://plausible.io/"
 
     def new!(attrs) do
       message = Map.fetch!(attrs, :message)
+      recommendation = Map.fetch!(attrs, :recommendation)
+      inline_links = Map.get(attrs, :inline_links, [])
 
       if String.ends_with?(message, ".") do
         raise ArgumentError, "Error message must not end with a period: #{inspect(message)}"
       end
 
-      if String.ends_with?(attrs[:recommendation], ".") do
+      if String.ends_with?(recommendation, ".") do
         raise ArgumentError,
-              "Error recommendation must not end with a period: #{inspect(attrs[:recommendation])}"
+              "Error recommendation must not end with a period: #{inspect(recommendation)}"
       end
 
-      if is_binary(attrs[:url]) and not String.starts_with?(attrs[:url], "https://plausible.io") do
-        raise ArgumentError,
-              "Recommendation url must start with 'https://plausible.io': #{inspect(attrs[:url])}"
+      for %{text: text, href: href} <- inline_links do
+        if length(String.split(recommendation, text)) - 1 != 1 do
+          raise ArgumentError,
+                "Recommendation inline_links text #{inspect(text)} must appear exactly once in: #{inspect(recommendation)}"
+        end
+
+        if not String.starts_with?(href, @required_link_prefix) do
+          raise ArgumentError,
+                "Recommendation inline_links href must start with '#{@required_link_prefix}': #{inspect(href)}"
+        end
       end
 
       struct!(__MODULE__, attrs)
     end
   end
 
+  @verify_manually_inline_link %{
+    text: "verify your installation manually",
+    href: @verify_manually_url
+  }
+
   @error_succeeds_only_after_cache_bust Error.new!(%{
                                           message: "We detected an issue with your site's cache",
                                           recommendation:
-                                            "Clear the cache for your site to ensure your visitors load the latest version of your site with Plausible correctly installed",
-                                          url:
-                                            "https://plausible.io/docs/troubleshoot-integration#have-you-cleared-the-cache-of-your-site"
+                                            "Clear the cache for your site to ensure your visitors load the latest version of your site with Plausible correctly installed. Learn more",
+                                          inline_links: [
+                                            %{
+                                              text: "Learn more",
+                                              href:
+                                                "https://plausible.io/docs/troubleshoot-integration#have-you-cleared-the-cache-of-your-site"
+                                            }
+                                          ]
                                         })
 
   @spec interpret(t(), String.t(), String.t()) :: Result.t()
@@ -123,14 +144,19 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   @error_proxy_network_error Error.new!(%{
                                message: "We couldn't verify your proxied installation",
                                recommendation:
-                                 "We received an unexpected response from your proxy. Check that you've configured the proxied /event route correctly",
-                               url: "https://plausible.io/docs/proxy/introduction"
+                                 "We received an unexpected response from your proxy. Check that you've configured the proxied /event route correctly. Learn more",
+                               inline_links: [
+                                 %{
+                                   text: "Learn more",
+                                   href: "https://plausible.io/docs/proxy/introduction"
+                                 }
+                               ]
                              })
   @error_plausible_network_error Error.new!(%{
                                    message: "We couldn't verify your website",
                                    recommendation:
                                      "Please try verifying again in a few minutes, or verify your installation manually",
-                                   url: @verify_manually_url
+                                   inline_links: [@verify_manually_inline_link]
                                  })
 
   def interpret(
@@ -175,9 +201,14 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
                           message:
                             "Your site's Content Security Policy (CSP) is blocking Plausible",
                           recommendation:
-                            "Add plausible.io to the list of allowed domains in your site's Content Security Policy to allow Plausible to collect analytics",
-                          url:
-                            "https://plausible.io/docs/troubleshoot-integration#does-your-site-use-a-content-security-policy-csp"
+                            "Add plausible.io to the list of allowed domains in your site's Content Security Policy to allow Plausible to collect analytics. Learn more",
+                          inline_links: [
+                            %{
+                              text: "Learn more",
+                              href:
+                                "https://plausible.io/docs/troubleshoot-integration#does-your-site-use-a-content-security-policy-csp"
+                            }
+                          ]
                         })
   def interpret(
         %__MODULE__{
@@ -192,8 +223,8 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   @error_domain_not_found Error.new!(%{
                             message: "We couldn't reach <%= @attempted_url %>",
                             recommendation:
-                              "Check that the URL is correct and publicly accessible. If your site is intentionally private, you can verify your installation manually or review your installation",
-                            url: @verify_manually_url
+                              "Check that the URL is correct and publicly accessible. If your site is intentionally private, you'll need to verify your installation manually",
+                            inline_links: [@verify_manually_inline_link]
                           })
 
   def interpret(%__MODULE__{service_error: %{code: code}}, expected_domain, url)
@@ -208,8 +239,8 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   @error_browserless_network Error.new!(%{
                                message: "We couldn't verify <%= @attempted_url %>",
                                recommendation:
-                                 "We encountered a network error while trying to access your website. You can verify your installation manually or review your installation",
-                               url: @verify_manually_url
+                                 "We encountered a network error while trying to access your website. You can verify your installation manually",
+                               inline_links: [@verify_manually_inline_link]
                              })
 
   def interpret(
@@ -229,7 +260,7 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
                                  message: "Our verification service is temporarily unavailable",
                                  recommendation:
                                    "Please try again in a few minutes or verify your installation manually",
-                                 url: @verify_manually_url
+                                 inline_links: [@verify_manually_inline_link]
                                })
 
   def interpret(%__MODULE__{service_error: %{code: code}}, _expected_domain, _url)
@@ -240,8 +271,8 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   @error_unexpected_page_response Error.new!(%{
                                     message: "We couldn't verify <%= @attempted_url %>",
                                     recommendation:
-                                      "Accessing your website returned an unexpected status code (<%= @page_response_status %>). Check for anything that might be blocking our access to your site, such as a firewall, authentication requirements, or CDN rules. You can also verify your installation manually or review your installation",
-                                    url: @verify_manually_url
+                                      "Accessing your website returned an unexpected status code (<%= @page_response_status %>). Check for anything that might be blocking our access to your site, such as a firewall, authentication requirements, or CDN rules. You can also verify your installation manually",
+                                    inline_links: [@verify_manually_inline_link]
                                   })
 
   def interpret(
@@ -287,25 +318,25 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
                                           message: @message_plausible_not_found,
                                           recommendation:
                                             "Make sure you've copied the snippet to the head of your site, or verify your installation manually",
-                                          url: @verify_manually_url
+                                          inline_links: [@verify_manually_inline_link]
                                         })
   @error_plausible_not_found_for_npm Error.new!(%{
                                        message: @message_plausible_not_found,
                                        recommendation:
                                          "Make sure you've initialized Plausible on your site, or verify your installation manually",
-                                       url: @verify_manually_url
+                                       inline_links: [@verify_manually_inline_link]
                                      })
   @error_plausible_not_found_for_gtm Error.new!(%{
                                        message: @message_plausible_not_found,
                                        recommendation:
                                          "Make sure you've configured the GTM template correctly, or verify your installation manually",
-                                       url: @verify_manually_url
+                                       inline_links: [@verify_manually_inline_link]
                                      })
   @error_plausible_not_found_for_wordpress Error.new!(%{
                                              message: @message_plausible_not_found,
                                              recommendation:
                                                "Make sure you've enabled the WordPress plugin, or verify your installation manually",
-                                             url: @verify_manually_url
+                                             inline_links: [@verify_manually_inline_link]
                                            })
   defp error_plausible_not_found(selected_installation_type) do
     case selected_installation_type do
@@ -321,28 +352,28 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
                                         message: @unexpected_domain_message,
                                         recommendation:
                                           "Check that the snippet on your site matches the one shown in the installation instructions, or verify your installation manually",
-                                        url: @verify_manually_url
+                                        inline_links: [@verify_manually_inline_link]
                                       })
 
   @error_unexpected_domain_for_npm Error.new!(%{
                                      message: @unexpected_domain_message,
                                      recommendation:
                                        "Check you've initialized Plausible with the correct domain, or verify your installation manually",
-                                     url: @verify_manually_url
+                                     inline_links: [@verify_manually_inline_link]
                                    })
 
   @error_unexpected_domain_for_gtm Error.new!(%{
                                      message: @unexpected_domain_message,
                                      recommendation:
                                        "Check you've entered the ID in the GTM template correctly, or verify your installation manually",
-                                     url: @verify_manually_url
+                                     inline_links: [@verify_manually_inline_link]
                                    })
 
   @error_unexpected_domain_for_wordpress Error.new!(%{
                                            message: @unexpected_domain_message,
                                            recommendation:
                                              "Check you've installed the WordPress plugin correctly, or verify your installation manually",
-                                           url: @verify_manually_url
+                                           inline_links: [@verify_manually_inline_link]
                                          })
   defp error_unexpected_domain(selected_installation_type) do
     case selected_installation_type do
@@ -368,7 +399,7 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
     %Result{
       ok?: false,
       errors: [message],
-      recommendations: [%{text: recommendation, url: error.url}]
+      recommendations: [%{text: recommendation, inline_links: error.inline_links}]
     }
   end
 
@@ -379,7 +410,7 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
       ok?: false,
       data: %{unhandled: true, browserless_issue: browserless_issue},
       errors: [error.message],
-      recommendations: [%{text: error.recommendation, url: error.url}]
+      recommendations: [%{text: error.recommendation, inline_links: error.inline_links}]
     }
   end
 end

--- a/extra/lib/plausible/installation_support/verification/diagnostics.ex
+++ b/extra/lib/plausible/installation_support/verification/diagnostics.ex
@@ -59,7 +59,7 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   @error_succeeds_only_after_cache_bust Error.new!(%{
                                           message: "We detected an issue with your site's cache",
                                           recommendation:
-                                            "Please clear the cache for your site to ensure that your visitors will load the latest version of your site that has Plausible correctly installed",
+                                            "Clear the cache for your site to ensure your visitors load the latest version of your site with Plausible correctly installed",
                                           url:
                                             "https://plausible.io/docs/troubleshoot-integration#have-you-cleared-the-cache-of-your-site"
                                         })
@@ -121,10 +121,9 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   end
 
   @error_proxy_network_error Error.new!(%{
-                               message:
-                                 "We got an unexpected response from the proxy you are using for Plausible",
+                               message: "We couldn't verify your proxied installation",
                                recommendation:
-                                 "Please check that you've configured the proxied /event route correctly",
+                                 "We received an unexpected response from your proxy. Check that you've configured the proxied /event route correctly",
                                url: "https://plausible.io/docs/proxy/introduction"
                              })
   @error_plausible_network_error Error.new!(%{
@@ -174,9 +173,9 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
 
   @error_csp_disallowed Error.new!(%{
                           message:
-                            "We encountered an issue with your site's Content Security Policy (CSP)",
+                            "Your site's Content Security Policy (CSP) is blocking Plausible",
                           recommendation:
-                            "Please add plausible.io domain specifically to the allowed list of domains in your site's CSP",
+                            "Add plausible.io to the list of allowed domains in your site's Content Security Policy to allow Plausible to collect analytics",
                           url:
                             "https://plausible.io/docs/troubleshoot-integration#does-your-site-use-a-content-security-policy-csp"
                         })
@@ -191,9 +190,9 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
       do: handled_error(@error_csp_disallowed)
 
   @error_domain_not_found Error.new!(%{
-                            message: "We couldn't find your website at <%= @attempted_url %>",
+                            message: "We couldn't reach <%= @attempted_url %>",
                             recommendation:
-                              "Please check that the domain you entered is correct and reachable publicly. If it's intentionally private, you'll need to verify that Plausible works manually",
+                              "Check that the URL is correct and publicly accessible. If your site is intentionally private, you can verify your installation manually or review your installation",
                             url: @verify_manually_url
                           })
 
@@ -207,10 +206,9 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   end
 
   @error_browserless_network Error.new!(%{
-                               message:
-                                 "We couldn't verify your website at <%= @attempted_url %>",
+                               message: "We couldn't verify <%= @attempted_url %>",
                                recommendation:
-                                 "Accessing the website resulted in a network error. Please verify your installation manually",
+                                 "We encountered a network error while trying to access your website. You can verify your installation manually or review your installation",
                                url: @verify_manually_url
                              })
 
@@ -228,8 +226,7 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   end
 
   @error_browserless_temporary Error.new!(%{
-                                 message:
-                                   "Our verification tool encountered a temporary service error",
+                                 message: "Our verification service is temporarily unavailable",
                                  recommendation:
                                    "Please try again in a few minutes or verify your installation manually",
                                  url: @verify_manually_url
@@ -241,10 +238,9 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   end
 
   @error_unexpected_page_response Error.new!(%{
-                                    message:
-                                      "We couldn't verify your website at <%= @attempted_url %>",
+                                    message: "We couldn't verify <%= @attempted_url %>",
                                     recommendation:
-                                      "Accessing the website resulted in an unexpected status code <%= @page_response_status %>. Please check for anything that might be blocking us from reaching your site, like a firewall, authentication requirements, or CDN rules. If you'd prefer, you can skip this and verify your installation manually",
+                                      "Accessing your website returned an unexpected status code (<%= @page_response_status %>). Check for anything that might be blocking our access to your site, such as a firewall, authentication requirements, or CDN rules. You can also verify your installation manually or review your installation",
                                     url: @verify_manually_url
                                   })
 
@@ -290,25 +286,25 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
   @error_plausible_not_found_for_manual Error.new!(%{
                                           message: @message_plausible_not_found,
                                           recommendation:
-                                            "Please make sure you've copied the snippet to the head of your site, or verify your installation manually",
+                                            "Make sure you've copied the snippet to the head of your site, or verify your installation manually",
                                           url: @verify_manually_url
                                         })
   @error_plausible_not_found_for_npm Error.new!(%{
                                        message: @message_plausible_not_found,
                                        recommendation:
-                                         "Please make sure you've initialized Plausible on your site, or verify your installation manually",
+                                         "Make sure you've initialized Plausible on your site, or verify your installation manually",
                                        url: @verify_manually_url
                                      })
   @error_plausible_not_found_for_gtm Error.new!(%{
                                        message: @message_plausible_not_found,
                                        recommendation:
-                                         "Please make sure you've configured the GTM template correctly, or verify your installation manually",
+                                         "Make sure you've configured the GTM template correctly, or verify your installation manually",
                                        url: @verify_manually_url
                                      })
   @error_plausible_not_found_for_wordpress Error.new!(%{
                                              message: @message_plausible_not_found,
                                              recommendation:
-                                               "Please make sure you've enabled the plugin, or verify your installation manually",
+                                               "Make sure you've enabled the WordPress plugin, or verify your installation manually",
                                              url: @verify_manually_url
                                            })
   defp error_plausible_not_found(selected_installation_type) do
@@ -320,32 +316,32 @@ defmodule Plausible.InstallationSupport.Verification.Diagnostics do
     end
   end
 
-  @unexpected_domain_message "Plausible test event is not for this site"
+  @unexpected_domain_message "Your Plausible snippet is configured for a different domain"
   @error_unexpected_domain_for_manual Error.new!(%{
                                         message: @unexpected_domain_message,
                                         recommendation:
-                                          "Please check that the snippet on your site matches the installation instructions exactly, or verify your installation manually",
+                                          "Check that the snippet on your site matches the one shown in the installation instructions, or verify your installation manually",
                                         url: @verify_manually_url
                                       })
 
   @error_unexpected_domain_for_npm Error.new!(%{
                                      message: @unexpected_domain_message,
                                      recommendation:
-                                       "Please check that you've initialized Plausible with the correct domain, or verify your installation manually",
+                                       "Check you've initialized Plausible with the correct domain, or verify your installation manually",
                                      url: @verify_manually_url
                                    })
 
   @error_unexpected_domain_for_gtm Error.new!(%{
                                      message: @unexpected_domain_message,
                                      recommendation:
-                                       "Please check that you've entered the ID in the GTM template correctly, or verify your installation manually",
+                                       "Check you've entered the ID in the GTM template correctly, or verify your installation manually",
                                      url: @verify_manually_url
                                    })
 
   @error_unexpected_domain_for_wordpress Error.new!(%{
                                            message: @unexpected_domain_message,
                                            recommendation:
-                                             "Please check that you've installed the WordPress plugin correctly, or verify your installation manually",
+                                             "Check you've installed the WordPress plugin correctly, or verify your installation manually",
                                            url: @verify_manually_url
                                          })
   defp error_unexpected_domain(selected_installation_type) do

--- a/extra/lib/plausible_web/live/verification.ex
+++ b/extra/lib/plausible_web/live/verification.ex
@@ -83,14 +83,12 @@ defmodule PlausibleWeb.Live.Verification do
     ~H"""
     <.live_component
       module={@component}
-      installation_type={get_installation_type(@tracker_script_configuration)}
       domain={@domain}
       id="verification-standalone"
       attempts={@attempts}
       flow={@flow}
       super_admin?={@super_admin?}
       custom_url_input?={@custom_url_input?}
-      tracker_script_configuration={@tracker_script_configuration}
       dismissed?={@dismissed?}
     />
     """

--- a/lib/plausible_web/components/generic.ex
+++ b/lib/plausible_web/components/generic.ex
@@ -12,25 +12,37 @@ defmodule PlausibleWeb.Components.Generic do
     gray: %{
       bg: "bg-gray-100 dark:bg-gray-800",
       icon: "text-gray-600 dark:text-gray-300",
-      title_text: "text-sm text-gray-900 dark:text-gray-100",
+      title_text: "text-gray-900 dark:text-gray-100",
       body_text: "text-sm text-gray-800 dark:text-gray-200 leading-5"
+    },
+    indigo: %{
+      bg: "bg-indigo-100/60 dark:bg-indigo-900/40",
+      icon: "text-indigo-500",
+      title_text: "text-gray-900 dark:text-gray-100",
+      body_text: "text-sm text-gray-600 dark:text-gray-100/60 leading-5"
+    },
+    green: %{
+      bg: "bg-green-100/60 dark:bg-green-900/40",
+      icon: "text-green-500",
+      title_text: "text-gray-900 dark:text-gray-100",
+      body_text: "text-sm text-gray-600 dark:text-gray-100/60 leading-5"
     },
     yellow: %{
       bg: "bg-yellow-100/60 dark:bg-yellow-900/40",
       icon: "text-yellow-500",
-      title_text: "text-sm text-gray-900 dark:text-gray-100",
+      title_text: "text-gray-900 dark:text-gray-100",
       body_text: "text-sm text-gray-600 dark:text-gray-100/60 leading-5"
     },
     red: %{
       bg: "bg-red-100 dark:bg-red-900/30",
       icon: "text-red-600 dark:text-red-500",
-      title_text: "text-sm text-gray-900 dark:text-gray-100",
+      title_text: "text-gray-900 dark:text-gray-100",
       body_text: "text-sm text-gray-600 dark:text-gray-100/60 leading-5"
     },
     white: %{
       bg: "bg-white dark:bg-gray-900 shadow-sm dark:shadow-none",
       icon: "text-gray-600 dark:text-gray-400",
-      title_text: "text-sm text-gray-900 dark:text-gray-100",
+      title_text: "text-gray-900 dark:text-gray-100",
       body_text: "text-sm text-gray-600 dark:text-gray-300 leading-5"
     }
   }
@@ -222,6 +234,7 @@ defmodule PlausibleWeb.Components.Generic do
   attr(:show_icon, :boolean, default: true)
   attr(:class, :string, default: "")
   attr(:icon_class, :string, default: "")
+  attr(:title_class, :string, default: "")
   attr(:rest, :global)
   slot(:inner_block)
   slot(:actions)
@@ -253,7 +266,14 @@ defmodule PlausibleWeb.Components.Generic do
               <% end %>
             </div>
             <div class="flex-1 flex flex-col gap-y-1.5">
-              <h3 :if={@title} class={"font-medium #{@theme.title_text}"}>
+              <h3
+                :if={@title}
+                class={[
+                  @title_class == "" && "text-sm font-medium",
+                  @theme.title_text,
+                  @title_class
+                ]}
+              >
                 {@title}
               </h3>
               <div class={"#{@theme.body_text}"}>

--- a/lib/plausible_web/live/components/verification_banner.ex
+++ b/lib/plausible_web/live/components/verification_banner.ex
@@ -7,10 +7,7 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
   use Plausible
 
   alias PlausibleWeb.Router.Helpers, as: Routes
-  alias PlausibleWeb.Components.Icons
-  alias PlausibleWeb.Live.Installation.Instructions
   alias Plausible.InstallationSupport.{State, Result}
-  alias Plausible.Site.TrackerScriptConfiguration
 
   import PlausibleWeb.Components.Generic
   import PlausibleWeb.Live.Components.Form
@@ -35,9 +32,7 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
   attr(:interpretation, Result, default: nil)
   attr(:attempts, :integer, default: 0)
   attr(:flow, :string, default: "")
-  attr(:installation_type, :string, default: nil)
   attr(:custom_url_input?, :boolean, default: false)
-  attr(:tracker_script_configuration, TrackerScriptConfiguration, default: nil)
   attr(:dismissed?, :boolean, default: false)
 
   def render(assigns) do
@@ -62,11 +57,9 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
         attempts={@attempts}
         domain={@domain}
         flow={@flow}
-        installation_type={@installation_type}
         super_admin?={@super_admin?}
         verification_state={@verification_state}
         custom_url_input?={@custom_url_input?}
-        tracker_script_configuration={@tracker_script_configuration}
       />
     </div>
     """
@@ -94,7 +87,7 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
     <button
       type="button"
       aria-label="Dismiss"
-      class="absolute right-2 top-2 z-10 rounded p-1 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+      class="absolute right-2 top-2 z-10 rounded p-1 text-gray-800 hover:text-gray-600 dark:text-gray-100/60 dark:hover:text-gray-100/70"
       onclick={dismiss_onclick(@container_id, @query_params)}
       phx-click="dismiss"
     >
@@ -110,24 +103,35 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
 
   defp render_progress(assigns) do
     ~H"""
-    <.notice title="Verifying your installation" theme={:gray}>
+    <.notice
+      title="Verifying your installation"
+      theme={:indigo}
+      title_class="text-base font-semibold text-gray-900 dark:text-gray-100"
+    >
       <:icon>
-        <div class="loading sm">
-          <div></div>
-        </div>
+        <.spinner class="mt-0.5 size-4.5" />
       </:icon>
-      <p class="animate-pulse" id="progress">{@message}</p>
+      <p class="animate-pulse text-gray-800 dark:text-gray-200 text-pretty" id="progress">
+        {@message}...
+      </p>
     </.notice>
     """
   end
 
   defp render_success(assigns) do
     ~H"""
-    <.notice title="Success!" theme={:gray} icon_class="text-green-600 dark:text-green-500">
+    <.notice
+      title="Tracking is active on your site"
+      theme={:green}
+      title_class="text-base font-semibold text-green-800 dark:text-green-300"
+      icon_class="!mt-0.5 size-5 text-green-800 dark:text-green-300"
+    >
       <:icon>
-        <Heroicons.check_badge class="size-4.5 text-green-600 dark:text-green-500" id="check-circle" />
+        <Heroicons.check_circle solid id="check-circle" />
       </:icon>
-      Your installation is working and visitors are being counted accurately.
+      <p class="text-gray-800 dark:text-gray-200 text-pretty">
+        Your dashboard is ready. Data will appear here as soon as visitors start arriving.
+      </p>
       <.super_admin_diagnostics
         :if={@super_admin? and not is_nil(@verification_state)}
         verification_state={@verification_state}
@@ -140,9 +144,8 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
     assigns =
       assign(
         assigns,
-        :expandable_instructions?,
-        assigns.installation_type in ["manual", "gtm"] and
-          not is_nil(assigns.tracker_script_configuration)
+        :offer_custom_url_input?,
+        offer_custom_url_input?(assigns.interpretation)
       )
 
     ~H"""
@@ -153,47 +156,129 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
           else: "We couldn't verify your installation"
       }
       theme={:yellow}
+      show_icon={false}
+      title_class="text-base font-semibold text-yellow-800 dark:text-yellow-400"
     >
-      <:icon>
-        <Heroicons.exclamation_circle class="size-4.5 text-yellow-500" id="error-circle" />
-      </:icon>
-      <p :if={@interpretation} id="recommendation" class="mt-2">
-        <span>{List.first(@interpretation.recommendations).text}.&nbsp;</span>
-        <.styled_link href={List.first(@interpretation.recommendations).url} new_tab={true}>
-          Learn more
-        </.styled_link>
-      </p>
-      <div x-data="{ instructionsExpanded: false }">
-        <div class="mt-5 flex flex-wrap items-center gap-2">
-          <.retry_form_or_button custom_url_input?={@custom_url_input?} domain={@domain} />
-          <.expand_installation_instructions_button
-            :if={@expandable_instructions?}
-            installation_type={@installation_type}
-          />
-          <.review_instructions_link
-            :if={@installation_type in ["wordpress", "npm"]}
-            installation_type={@installation_type}
-          />
-        </div>
-        <.expandable_installation_instructions
-          :if={@expandable_instructions?}
-          installation_type={@installation_type}
-          tracker_script_configuration={@tracker_script_configuration}
-        />
-      </div>
-      <.additional_help_links
-        custom_url_input?={@custom_url_input?}
+      <.recommendation
+        :if={@interpretation}
         interpretation={@interpretation}
-        attempts={@attempts}
+        offer_custom_url_input?={@offer_custom_url_input?}
         domain={@domain}
         flow={@flow}
       />
+      <div class="mt-5 flex flex-wrap items-center gap-2">
+        <.retry_form_or_button custom_url_input?={@custom_url_input?} domain={@domain} />
+        <.button_link
+          :if={not @custom_url_input? and @offer_custom_url_input?}
+          mt?={false}
+          href="#"
+          phx-click="show-custom-url-form"
+          id="verify-custom-url-link"
+          theme="ghost"
+          size="sm"
+          class="hover:bg-gray-600/10 dark:hover:bg-white/10 hover:border-transparent dark:hover:border-transparent"
+        >
+          Try another URL
+        </.button_link>
+        <.button_link
+          :if={not @custom_url_input? and not @offer_custom_url_input?}
+          mt?={false}
+          href={Routes.site_path(PlausibleWeb.Endpoint, :installation, @domain, flow: @flow)}
+          theme="ghost"
+          size="sm"
+          class="hover:bg-gray-600/10 dark:hover:bg-white/10 hover:border-transparent dark:hover:border-transparent"
+        >
+          Review installation
+        </.button_link>
+      </div>
+      <.contact_us_link :if={ee?() and @attempts >= 3} />
       <.super_admin_diagnostics
         :if={@super_admin? and not is_nil(@verification_state)}
         verification_state={@verification_state}
       />
     </.notice>
     """
+  end
+
+  defp offer_custom_url_input?(interpretation) do
+    match?(%{data: %{offer_custom_url_input: true}}, interpretation)
+  end
+
+  defp recommendation(assigns) do
+    recommendation = List.first(assigns.interpretation.recommendations)
+
+    review_installation_url =
+      Routes.site_path(
+        PlausibleWeb.Endpoint,
+        :installation,
+        assigns.domain,
+        flow: assigns.flow
+      )
+
+    body =
+      recommendation_body(
+        recommendation.text,
+        recommendation.url,
+        review_installation_url,
+        assigns.offer_custom_url_input?
+      )
+
+    assigns = assign(assigns, :body, body)
+
+    ~H"""
+    <p id="recommendation" class="text-gray-800 dark:text-gray-200 text-pretty">
+      {@body}
+    </p>
+    """
+  end
+
+  @verify_manually_phrase "verify your installation manually"
+  @both_phrases "verify your installation manually or review your installation"
+
+  defp recommendation_body(
+         text,
+         verify_manually_url,
+         review_installation_url,
+         offer_custom_url_input?
+       ) do
+    cond do
+      offer_custom_url_input? and String.contains?(text, @both_phrases) ->
+        [leading, _rest] = String.split(text, @both_phrases, parts: 2)
+
+        [
+          leading,
+          external_link("verify your installation manually", verify_manually_url),
+          " or ",
+          internal_link("review your installation", review_installation_url),
+          "."
+        ]
+
+      String.contains?(text, @verify_manually_phrase) ->
+        [leading, _rest] = String.split(text, @verify_manually_phrase, parts: 2)
+
+        [
+          leading,
+          external_link("verify your installation manually", verify_manually_url),
+          "."
+        ]
+
+      true ->
+        [text, ". ", external_link("Learn more", verify_manually_url)]
+    end
+  end
+
+  defp external_link(text, url) do
+    Phoenix.HTML.raw(
+      ~s|<a href="#{html_escape(url)}" class="underline" target="_blank" rel="noopener noreferrer">#{html_escape(text)}</a>|
+    )
+  end
+
+  defp internal_link(text, url) do
+    Phoenix.HTML.raw(~s|<a href="#{html_escape(url)}" class="underline">#{html_escape(text)}</a>|)
+  end
+
+  defp html_escape(value) do
+    value |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
   end
 
   defp retry_form_or_button(%{custom_url_input?: true} = assigns) do
@@ -206,12 +291,12 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
         aria-label="Website URL"
         required
         mt?={false}
-        width="w-44"
+        width="w-64 h-[38px] dark:bg-white/15 dark:border-transparent"
         placeholder={"https://#{@domain}"}
         value={"https://#{@domain}"}
       />
-      <.button type="submit" mt?={false} theme="secondary" size="sm">
-        Check again
+      <.button type="submit" mt?={false} theme="primary" size="sm">
+        Verify URL
       </.button>
     </form>
     """
@@ -225,96 +310,26 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
       phx-click="retry"
       theme="secondary"
       size="sm"
+      class="dark:bg-white/15 dark:hover:bg-white/20 dark:border-transparent"
     >
       Check again
     </.button_link>
     """
   end
 
-  defp expand_installation_instructions_button(assigns) do
+  defp contact_us_link(assigns) do
     ~H"""
-    <span x-on:click.prevent="instructionsExpanded = !instructionsExpanded">
-      <.button_link
-        mt?={false}
-        href="#"
-        theme="ghost"
-        size="sm"
-        class="hover:bg-gray-900/10 dark:hover:bg-white/10 hover:border-transparent dark:hover:border-transparent"
+    <p class="mt-5 text-[0.825rem] text-gray-800 dark:text-gray-200">
+      Need help?
+      <a
+        href="https://plausible.io/contact"
+        class="underline"
+        target="_blank"
+        rel="noopener noreferrer"
       >
-        <span class="inline-flex items-center gap-0.5">
-          {review_instructions_label(@installation_type)}
-          <span x-show="!instructionsExpanded" x-cloak>
-            <Heroicons.chevron_down mini class="size-4" />
-          </span>
-          <span x-show="instructionsExpanded" x-cloak>
-            <Heroicons.chevron_up mini class="size-4" />
-          </span>
-        </span>
-      </.button_link>
-    </span>
-    """
-  end
-
-  defp review_instructions_link(assigns) do
-    ~H"""
-    <.button_link
-      mt?={false}
-      href={install_help_href(@installation_type)}
-      theme="ghost"
-      size="sm"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="hover:bg-gray-900/10 dark:hover:bg-white/10 hover:border-transparent dark:hover:border-transparent"
-    >
-      Review instructions <Icons.external_link_icon class="inline-block size-3.5 ml-1" />
-    </.button_link>
-    """
-  end
-
-  defp expandable_installation_instructions(assigns) do
-    ~H"""
-    <div x-show="instructionsExpanded" x-cloak class="mt-5">
-      <Instructions.copy_snippet_box
-        :if={@installation_type == "manual"}
-        tracker_script_configuration={@tracker_script_configuration}
-      />
-      <Instructions.gtm_instructions_content_inner
-        :if={@installation_type == "gtm"}
-        tracker_script_configuration={@tracker_script_configuration}
-      />
-    </div>
-    """
-  end
-
-  defp additional_help_links(assigns) do
-    ~H"""
-    <div class="mt-5">
-      <ul class="list-disc space-y-2 ml-4 text-sm">
-        <li :if={
-          not @custom_url_input? && @interpretation && is_map(@interpretation.data) &&
-            @interpretation.data[:offer_custom_url_input]
-        }>
-          Is your website located at a different URL?
-          <.styled_link href="#" phx-click="show-custom-url-form" id="verify-custom-url-link">
-            Click here
-          </.styled_link>
-        </li>
-        <li :if={ee?() and @attempts >= 3}>
-          Need further help with your installation?
-          <.styled_link href="https://plausible.io/contact">
-            Contact us
-          </.styled_link>
-        </li>
-        <li>
-          Want to choose another installation method?
-          <.styled_link href={
-            Routes.site_path(PlausibleWeb.Endpoint, :installation, @domain, flow: @flow)
-          }>
-            Click here
-          </.styled_link>
-        </li>
-      </ul>
-    </div>
+        Contact us
+      </a>
+    </p>
     """
   end
 
@@ -325,7 +340,7 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
       x-data="{ showDiagnostics: false }"
       id="super-admin-report"
     >
-      <p class="text-sm">
+      <p class="text-sm text-gray-800 dark:text-gray-200">
         <a
           href="#"
           @click.prevent="showDiagnostics = !showDiagnostics"
@@ -349,12 +364,4 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
 
   defp to_string_value(value) when is_binary(value), do: value
   defp to_string_value(value), do: inspect(value)
-
-  defp review_instructions_label("manual"), do: "View snippet"
-  defp review_instructions_label(_installation_type), do: "Review instructions"
-
-  defp install_help_href("wordpress"), do: "https://plausible.io/wordpress-analytics-plugin"
-
-  defp install_help_href("npm"),
-    do: "https://www.npmjs.com/package/@plausible-analytics/tracker"
 end

--- a/lib/plausible_web/live/components/verification_banner.ex
+++ b/lib/plausible_web/live/components/verification_banner.ex
@@ -206,22 +206,14 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
 
   defp recommendation(assigns) do
     recommendation = List.first(assigns.interpretation.recommendations)
-
-    review_installation_url =
-      Routes.site_path(
-        PlausibleWeb.Endpoint,
-        :installation,
-        assigns.domain,
-        flow: assigns.flow
-      )
+    main = render_recommendation(recommendation.text, recommendation.inline_links)
 
     body =
-      recommendation_body(
-        recommendation.text,
-        recommendation.url,
-        review_installation_url,
-        assigns.offer_custom_url_input?
-      )
+      if assigns.offer_custom_url_input? do
+        [main, ". ", review_installation_link_sentence(assigns), "."]
+      else
+        [main, "."]
+      end
 
     assigns = assign(assigns, :body, body)
 
@@ -232,49 +224,31 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
     """
   end
 
-  @verify_manually_phrase "verify your installation manually"
-  @both_phrases "verify your installation manually or review your installation"
+  defp render_recommendation(text, inline_links) do
+    html =
+      Enum.reduce(inline_links, html_escape(text), fn %{text: link_text, href: href}, acc ->
+        String.replace(acc, link_text, link_markup(link_text, href), global: false)
+      end)
 
-  defp recommendation_body(
-         text,
-         verify_manually_url,
-         review_installation_url,
-         offer_custom_url_input?
-       ) do
-    cond do
-      offer_custom_url_input? and String.contains?(text, @both_phrases) ->
-        [leading, _rest] = String.split(text, @both_phrases, parts: 2)
-
-        [
-          leading,
-          external_link("verify your installation manually", verify_manually_url),
-          " or ",
-          internal_link("review your installation", review_installation_url),
-          "."
-        ]
-
-      String.contains?(text, @verify_manually_phrase) ->
-        [leading, _rest] = String.split(text, @verify_manually_phrase, parts: 2)
-
-        [
-          leading,
-          external_link("verify your installation manually", verify_manually_url),
-          "."
-        ]
-
-      true ->
-        [text, ". ", external_link("Learn more", verify_manually_url)]
-    end
+    Phoenix.HTML.raw(html)
   end
 
-  defp external_link(text, url) do
-    Phoenix.HTML.raw(
-      ~s|<a href="#{html_escape(url)}" class="underline" target="_blank" rel="noopener noreferrer">#{html_escape(text)}</a>|
-    )
+  defp review_installation_link_sentence(assigns) do
+    review_installation_url =
+      Routes.site_path(PlausibleWeb.Endpoint, :installation, assigns.domain, flow: assigns.flow)
+
+    render_recommendation("See your installation instructions again here", [
+      %{text: "here", href: review_installation_url}
+    ])
   end
 
-  defp internal_link(text, url) do
-    Phoenix.HTML.raw(~s|<a href="#{html_escape(url)}" class="underline">#{html_escape(text)}</a>|)
+  defp link_markup(text, href) do
+    external_attrs =
+      if String.starts_with?(href, "http"),
+        do: ~s| target="_blank" rel="noopener noreferrer"|,
+        else: ""
+
+    ~s|<a href="#{html_escape(href)}" class="underline"#{external_attrs}>#{html_escape(text)}</a>|
   end
 
   defp html_escape(value) do
@@ -320,15 +294,7 @@ defmodule PlausibleWeb.Live.Components.VerificationBanner do
   defp contact_us_link(assigns) do
     ~H"""
     <p class="mt-5 text-[0.825rem] text-gray-800 dark:text-gray-200">
-      Need help?
-      <a
-        href="https://plausible.io/contact"
-        class="underline"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Contact us
-      </a>
+      Need help? {Phoenix.HTML.raw(link_markup("Contact us", "https://plausible.io/contact"))}
     </p>
     """
   end

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -582,15 +582,9 @@ defmodule PlausibleWeb.Live.Sites do
               >
                 {@site.domain}
               </h3>
-              <span
-                :if={@needs_verification?}
-                class="inline-flex items-center rounded-full bg-yellow-100 dark:bg-yellow-900/40 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:text-yellow-300"
-              >
-                Setup pending
-              </span>
             </div>
           </div>
-          <.site_stats sparkline={@sparkline} />
+          <.site_stats sparkline={@sparkline} needs_verification?={@needs_verification?} />
         </div>
       </.unstyled_link>
 
@@ -680,6 +674,7 @@ defmodule PlausibleWeb.Live.Sites do
   end
 
   attr(:sparkline, :any, required: true)
+  attr(:needs_verification?, :boolean, default: false)
 
   def site_stats(assigns) do
     ~H"""
@@ -708,7 +703,10 @@ defmodule PlausibleWeb.Live.Sites do
             </p>
           </div>
 
-          <.percentage_change change={@sparkline.visitors_change} />
+          <.pill :if={@needs_verification?} color={:yellow}>
+            Setup pending
+          </.pill>
+          <.percentage_change :if={not @needs_verification?} change={@sparkline.visitors_change} />
         </div>
       </span>
     </div>

--- a/test/plausible/installation_support/verification/checks_test.exs
+++ b/test/plausible/installation_support/verification/checks_test.exs
@@ -22,12 +22,12 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          ok?: false,
                          data: %{offer_custom_url_input: true},
                          errors: [
-                           ^any(:string, ~r/We couldn't find your website at #{@url_to_verify}$/)
+                           ^any(:string, ~r/We couldn't reach #{@url_to_verify}$/)
                          ],
                          recommendations: [
                            %{
                              text:
-                               "Please check that the domain you entered is correct and reachable publicly. If it's intentionally private, you'll need to verify that Plausible works manually",
+                               "Check that the URL is correct and publicly accessible. If your site is intentionally private, you can verify your installation manually or review your installation",
                              url:
                                "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
                            }
@@ -49,12 +49,12 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          ok?: false,
                          data: %{offer_custom_url_input: true},
                          errors: [
-                           ^any(:string, ~r/We couldn't find your website at #{url_to_verify}$/)
+                           ^any(:string, ~r/We couldn't reach #{url_to_verify}$/)
                          ],
                          recommendations: [
                            %{
                              text:
-                               "Please check that the domain you entered is correct and reachable publicly. If it's intentionally private, you'll need to verify that Plausible works manually",
+                               "Check that the URL is correct and publicly accessible. If your site is intentionally private, you can verify your installation manually or review your installation",
                              url:
                                "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
                            }
@@ -94,13 +94,13 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
 
       for {installation_type, expected_recommendation} <- [
             {"wordpress",
-             "Please check that you've installed the WordPress plugin correctly, or verify your installation manually"},
+             "Check you've installed the WordPress plugin correctly, or verify your installation manually"},
             {"gtm",
-             "Please check that you've entered the ID in the GTM template correctly, or verify your installation manually"},
+             "Check you've entered the ID in the GTM template correctly, or verify your installation manually"},
             {"npm",
-             "Please check that you've initialized Plausible with the correct domain, or verify your installation manually"},
+             "Check you've initialized Plausible with the correct domain, or verify your installation manually"},
             {"manual",
-             "Please check that the snippet on your site matches the installation instructions exactly, or verify your installation manually"}
+             "Check that the snippet on your site matches the one shown in the installation instructions, or verify your installation manually"}
           ] do
         test "returns error when test event domain doesn't match the expected domain, with recommendation for installation type: #{installation_type}" do
           verification_stub =
@@ -119,7 +119,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
 
           assert_matches %Result{
                            ok?: false,
-                           errors: ["Plausible test event is not for this site"],
+                           errors: ["Your Plausible snippet is configured for a different domain"],
                            recommendations: [
                              %{
                                text: unquote(expected_recommendation),
@@ -154,7 +154,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
 
         assert_matches %Result{
                          ok?: false,
-                         errors: [^any(:string, ~r/.*proxy.*/)],
+                         errors: [^any(:string, ~r/.*proxied.*/)],
                          recommendations: [
                            %{
                              text: ^any(:string, ~r/.*proxied.*/),
@@ -213,7 +213,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          recommendations: [
                            %{
                              text:
-                               "Please make sure you've copied the snippet to the head of your site, or verify your installation manually",
+                               "Make sure you've copied the snippet to the head of your site, or verify your installation manually",
                              url:
                                "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
                            }
@@ -236,12 +236,12 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
         assert_matches %Result{
                          ok?: false,
                          errors: [
-                           "We encountered an issue with your site's Content Security Policy (CSP)"
+                           "Your site's Content Security Policy (CSP) is blocking Plausible"
                          ],
                          recommendations: [
                            %{
                              text:
-                               "Please add plausible.io domain specifically to the allowed list of domains in your site's CSP",
+                               "Add plausible.io to the list of allowed domains in your site's Content Security Policy to allow Plausible to collect analytics",
                              url:
                                "https://plausible.io/docs/troubleshoot-integration#does-your-site-use-a-content-security-policy-csp"
                            }
@@ -261,13 +261,11 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
         assert_matches %Result{
                          ok?: false,
                          data: %{offer_custom_url_input: true},
-                         errors: [
-                           "We couldn't verify your website at https://example.com"
-                         ],
+                         errors: ["We couldn't verify https://example.com"],
                          recommendations: [
                            %{
                              text:
-                               "Accessing the website resulted in a network error. Please verify your installation manually",
+                               "We encountered a network error while trying to access your website. You can verify your installation manually or review your installation",
                              url:
                                "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
                            }
@@ -291,13 +289,11 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
         assert_matches %Result{
                          ok?: false,
                          data: %{offer_custom_url_input: true},
-                         errors: [
-                           "We couldn't verify your website at https://example.com"
-                         ],
+                         errors: ["We couldn't verify https://example.com"],
                          recommendations: [
                            %{
                              text:
-                               "Accessing the website resulted in an unexpected status code 403. Please check for anything that might be blocking us from reaching your site, like a firewall, authentication requirements, or CDN rules. If you'd prefer, you can skip this and verify your installation manually",
+                               "Accessing your website returned an unexpected status code (403). Check for anything that might be blocking our access to your site, such as a firewall, authentication requirements, or CDN rules. You can also verify your installation manually or review your installation",
                              url:
                                "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
                            }
@@ -309,13 +305,13 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
 
       for {installation_type, expected_recommendation} <- [
             {"wordpress",
-             "Please make sure you've enabled the plugin, or verify your installation manually"},
+             "Make sure you've enabled the WordPress plugin, or verify your installation manually"},
             {"gtm",
-             "Please make sure you've configured the GTM template correctly, or verify your installation manually"},
+             "Make sure you've configured the GTM template correctly, or verify your installation manually"},
             {"npm",
-             "Please make sure you've initialized Plausible on your site, or verify your installation manually"},
+             "Make sure you've initialized Plausible on your site, or verify your installation manually"},
             {"manual",
-             "Please make sure you've copied the snippet to the head of your site, or verify your installation manually"}
+             "Make sure you've copied the snippet to the head of your site, or verify your installation manually"}
           ] do
         test "returns error \"We couldn't detect Plausible on your site\" when plausible_is_on_window is false (with best guess recommendation for installation type: #{installation_type})" do
           verification_stub =
@@ -484,7 +480,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
 
         assert_matches %Result{
                          ok?: false,
-                         errors: [^any(:string, ~r/.*temporary service error.*/)],
+                         errors: [^any(:string, ~r/.*temporarily unavailable.*/)],
                          recommendations: [
                            %{
                              text: ^any(:string, ~r/.*in a few minutes.*/),
@@ -514,7 +510,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
 
           assert_matches %Result{
                            ok?: false,
-                           errors: [^any(:string, ~r/.*temporary service error.*/)],
+                           errors: [^any(:string, ~r/.*temporarily unavailable.*/)],
                            recommendations: [
                              %{
                                text: ^any(:string, ~r/.*in a few minutes.*/),

--- a/test/plausible/installation_support/verification/checks_test.exs
+++ b/test/plausible/installation_support/verification/checks_test.exs
@@ -13,6 +13,11 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
 
     @expected_domain "example.com"
     @url_to_verify "https://#{@expected_domain}"
+    @verify_manually_url "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+    @verify_manually_inline_link %{
+      text: "verify your installation manually",
+      href: @verify_manually_url
+    }
 
     describe "URL check" do
       test "returns error when DNS check fails with domain not found error, offers custom URL input" do
@@ -27,9 +32,8 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          recommendations: [
                            %{
                              text:
-                               "Check that the URL is correct and publicly accessible. If your site is intentionally private, you can verify your installation manually or review your installation",
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                               "Check that the URL is correct and publicly accessible. If your site is intentionally private, you can verify your installation manually",
+                             inline_links: [^@verify_manually_inline_link]
                            }
                          ]
                        } =
@@ -54,9 +58,8 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          recommendations: [
                            %{
                              text:
-                               "Check that the URL is correct and publicly accessible. If your site is intentionally private, you can verify your installation manually or review your installation",
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                               "Check that the URL is correct and publicly accessible. If your site is intentionally private, you can verify your installation manually",
+                             inline_links: [^@verify_manually_inline_link]
                            }
                          ]
                        } =
@@ -123,8 +126,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                            recommendations: [
                              %{
                                text: unquote(expected_recommendation),
-                               url:
-                                 "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                               inline_links: [^@verify_manually_inline_link]
                              }
                            ]
                          } =
@@ -158,7 +160,12 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          recommendations: [
                            %{
                              text: ^any(:string, ~r/.*proxied.*/),
-                             url: "https://plausible.io/docs/proxy/introduction"
+                             inline_links: [
+                               %{
+                                 text: "Learn more",
+                                 href: "https://plausible.io/docs/proxy/introduction"
+                               }
+                             ]
                            }
                          ]
                        } =
@@ -187,9 +194,9 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          errors: [^any(:string, ~r/.*couldn't verify.*/)],
                          recommendations: [
                            %{
-                             text: ^any(:string, ~r/.*try verifying again.*/),
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                             text:
+                               "Please try verifying again in a few minutes, or verify your installation manually",
+                             inline_links: [^@verify_manually_inline_link]
                            }
                          ]
                        } =
@@ -214,8 +221,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                            %{
                              text:
                                "Make sure you've copied the snippet to the head of your site, or verify your installation manually",
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                             inline_links: [^@verify_manually_inline_link]
                            }
                          ]
                        } =
@@ -241,9 +247,14 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          recommendations: [
                            %{
                              text:
-                               "Add plausible.io to the list of allowed domains in your site's Content Security Policy to allow Plausible to collect analytics",
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#does-your-site-use-a-content-security-policy-csp"
+                               "Add plausible.io to the list of allowed domains in your site's Content Security Policy to allow Plausible to collect analytics. Learn more",
+                             inline_links: [
+                               %{
+                                 text: "Learn more",
+                                 href:
+                                   "https://plausible.io/docs/troubleshoot-integration#does-your-site-use-a-content-security-policy-csp"
+                               }
+                             ]
                            }
                          ]
                        } =
@@ -265,9 +276,8 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          recommendations: [
                            %{
                              text:
-                               "We encountered a network error while trying to access your website. You can verify your installation manually or review your installation",
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                               "We encountered a network error while trying to access your website. You can verify your installation manually",
+                             inline_links: [^@verify_manually_inline_link]
                            }
                          ]
                        } =
@@ -293,9 +303,8 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          recommendations: [
                            %{
                              text:
-                               "Accessing your website returned an unexpected status code (403). Check for anything that might be blocking our access to your site, such as a firewall, authentication requirements, or CDN rules. You can also verify your installation manually or review your installation",
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                               "Accessing your website returned an unexpected status code (403). Check for anything that might be blocking our access to your site, such as a firewall, authentication requirements, or CDN rules. You can also verify your installation manually",
+                             inline_links: [^@verify_manually_inline_link]
                            }
                          ]
                        } =
@@ -330,8 +339,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                            recommendations: [
                              %{
                                text: unquote(expected_recommendation),
-                               url:
-                                 "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                               inline_links: [^@verify_manually_inline_link]
                              }
                            ]
                          } =
@@ -359,8 +367,7 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                            recommendations: [
                              %{
                                text: unquote(expected_recommendation),
-                               url:
-                                 "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                               inline_links: [^@verify_manually_inline_link]
                              }
                            ]
                          } =
@@ -422,8 +429,13 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          recommendations: [
                            %{
                              text: ^any(:string, ~r/.*cache.*/),
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#have-you-cleared-the-cache-of-your-site"
+                             inline_links: [
+                               %{
+                                 text: "Learn more",
+                                 href:
+                                   "https://plausible.io/docs/troubleshoot-integration#have-you-cleared-the-cache-of-your-site"
+                               }
+                             ]
                            }
                          ]
                        } = run_checks(verification_stub) |> Checks.interpret_diagnostics()
@@ -483,9 +495,9 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                          errors: [^any(:string, ~r/.*temporarily unavailable.*/)],
                          recommendations: [
                            %{
-                             text: ^any(:string, ~r/.*in a few minutes.*/),
-                             url:
-                               "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                             text:
+                               "Please try again in a few minutes or verify your installation manually",
+                             inline_links: [^@verify_manually_inline_link]
                            }
                          ]
                        } = Checks.interpret_diagnostics(state)
@@ -513,9 +525,9 @@ defmodule Plausible.InstallationSupport.Verification.ChecksTest do
                            errors: [^any(:string, ~r/.*temporarily unavailable.*/)],
                            recommendations: [
                              %{
-                               text: ^any(:string, ~r/.*in a few minutes.*/),
-                               url:
-                                 "https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"
+                               text:
+                                 "Please try again in a few minutes or verify your installation manually",
+                               inline_links: [^@verify_manually_inline_link]
                              }
                            ]
                          } = Checks.interpret_diagnostics(state)

--- a/test/plausible/installation_support/verification/diagnostics_test.exs
+++ b/test/plausible/installation_support/verification/diagnostics_test.exs
@@ -1,0 +1,46 @@
+defmodule Plausible.InstallationSupport.Verification.DiagnosticsTest do
+  use ExUnit.Case, async: true
+
+  alias Plausible.InstallationSupport.Verification.Diagnostics.Error
+
+  describe "Error.new!/1" do
+    test "accepts a recommendation whose inline_links text appears exactly once" do
+      assert %Error{} =
+               Error.new!(%{
+                 message: "Something went wrong",
+                 recommendation: "Check the docs for more info",
+                 inline_links: [%{text: "docs", href: "https://plausible.io/docs"}]
+               })
+    end
+
+    test "raises when inline_links text isn't found in the recommendation" do
+      assert_raise ArgumentError, ~r/must appear exactly once/, fn ->
+        Error.new!(%{
+          message: "Something went wrong",
+          recommendation: "Check the manual for more info",
+          inline_links: [%{text: "docs", href: "https://plausible.io/docs"}]
+        })
+      end
+    end
+
+    test "raises when inline_links text appears more than once in the recommendation" do
+      assert_raise ArgumentError, ~r/must appear exactly once/, fn ->
+        Error.new!(%{
+          message: "Something went wrong",
+          recommendation: "Check the docs, or check the docs again",
+          inline_links: [%{text: "the docs", href: "https://plausible.io/docs"}]
+        })
+      end
+    end
+
+    test "raises when inline_links href doesn't point at plausible.io" do
+      assert_raise ArgumentError, ~r/must start with/, fn ->
+        Error.new!(%{
+          message: "Something went wrong",
+          recommendation: "Check the docs for more info",
+          inline_links: [%{text: "docs", href: "https://example.com/docs"}]
+        })
+      end
+    end
+  end
+end

--- a/test/plausible_web/live/components/verification_banner_test.exs
+++ b/test/plausible_web/live/components/verification_banner_test.exs
@@ -11,9 +11,8 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
     @component PlausibleWeb.Live.Components.VerificationBanner
     @progress ~s|#verification-ui p#progress|
 
-    @loading_spinner ~s|div#verification-ui div.loading|
-    @check_circle ~s|div#verification-ui #check-circle|
-    @error_circle ~s|div#verification-ui #error-circle|
+    @loading_spinner ~s|#verification-ui svg.animate-spin|
+    @check_circle ~s|#verification-ui #check-circle|
     @recommendations ~s|#recommendation|
     @super_admin_report ~s|#super-admin-report|
 
@@ -22,24 +21,23 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
       assert element_exists?(html, @progress)
 
       assert text_of_element(html, @progress) ==
-               "We're visiting your site to ensure that everything is working"
+               "We're visiting your site to ensure that everything is working..."
 
       assert element_exists?(html, @loading_spinner)
-      refute class_of_element(html, @loading_spinner) =~ "hidden"
       refute element_exists?(html, @recommendations)
       refute element_exists?(html, @check_circle)
       refute element_exists?(html, @super_admin_report)
     end
 
-    test "renders error badge on error" do
+    test "renders failed state without progress spinner" do
       html = render_component(@component, domain: "example.com", success?: false, finished?: true)
       refute element_exists?(html, @loading_spinner)
       refute element_exists?(html, @check_circle)
       refute element_exists?(html, @recommendations)
-      assert element_exists?(html, @error_circle)
+      assert html =~ "We couldn&#39;t verify your installation"
     end
 
-    test "renders diagnostic interpretation" do
+    test "renders diagnostic interpretation with inline verify/review links" do
       interpretation =
         Verification.Checks.interpret_diagnostics(%State{
           url: "https://example.com",
@@ -56,9 +54,56 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
         )
 
       assert [recommendation] = html |> find(@recommendations) |> Enum.map(&text/1)
-      assert recommendation =~ "check that the domain you entered is correct"
+      assert recommendation =~ "Check that the URL is correct and publicly accessible"
+      assert recommendation =~ "verify your installation manually"
+      assert recommendation =~ "review your installation"
+
+      assert element_exists?(
+               html,
+               ~s|#recommendation a[href="https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"]|
+             )
+
+      assert element_exists?(
+               html,
+               ~s|#recommendation a[href="/example.com/installation?flow="]|
+             )
 
       refute element_exists?(html, @super_admin_report)
+    end
+
+    test "renders inline verify-manually link when the recommendation mentions it (no custom URL retry)" do
+      interpretation =
+        Verification.Checks.interpret_diagnostics(%State{
+          url: "https://example.com",
+          data_domain: "example.com",
+          diagnostics: %Verification.Diagnostics{
+            plausible_is_on_window: false,
+            selected_installation_type: "manual"
+          }
+        })
+
+      refute Map.get(interpretation.data || %{}, :offer_custom_url_input) == true
+
+      html =
+        render_component(@component,
+          domain: "example.com",
+          success?: false,
+          finished?: true,
+          interpretation: interpretation
+        )
+
+      assert [recommendation] = html |> find(@recommendations) |> Enum.map(&text/1)
+      assert recommendation =~ "Make sure you've copied the snippet"
+      assert recommendation =~ "verify your installation manually"
+      refute recommendation =~ "review your installation"
+      refute recommendation =~ "Learn more"
+
+      assert element_exists?(
+               html,
+               ~s|#recommendation a[href="https://plausible.io/docs/troubleshoot-integration#how-to-manually-check-your-integration"]|
+             )
+
+      refute element_exists?(html, ~s|#recommendation a[href^="/example.com/installation"]|)
     end
 
     test "renders super-admin report" do
@@ -99,20 +144,20 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
     test "renders a progress message" do
       html = render_component(@component, domain: "example.com", message: "Arbitrary message")
 
-      assert text_of_element(html, @progress) == "Arbitrary message"
+      assert text_of_element(html, @progress) == "Arbitrary message..."
     end
 
-    test "renders contact link on >3 attempts" do
+    test "renders contact link on >=3 attempts" do
       html = render_component(@component, domain: "example.com", attempts: 2, finished?: true)
-      refute html =~ "Need further help with your installation?"
+      refute html =~ "Need help?"
       refute element_exists?(html, ~s|a[href="https://plausible.io/contact"]|)
 
       html = render_component(@component, domain: "example.com", attempts: 3, finished?: true)
-      assert html =~ "Need further help with your installation?"
+      assert html =~ "Need help?"
       assert element_exists?(html, ~s|a[href="https://plausible.io/contact"]|)
     end
 
-    test "renders a click-to-show-form link to verify installation at a different URL" do
+    test "renders a Try another URL ghost button when a custom URL retry is offered" do
       interpretation =
         Verification.Checks.interpret_diagnostics(%State{
           url: "example.com",
@@ -133,11 +178,12 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
           interpretation: interpretation
         )
 
-      assert text_of_element(html, "#verify-custom-url-link") =~ "Click here"
+      assert text_of_element(html, "#verify-custom-url-link") =~ "Try another URL"
       assert element_exists?(html, ~s|a#verify-custom-url-link[phx-click="show-custom-url-form"]|)
+      refute html =~ "Review installation"
     end
 
-    test "renders the custom URL input inline, retry button becomes the form's submit button, hides the prompt link" do
+    test "renders the custom URL input inline, replacing Check again with the Verify URL submit button, and hides the secondary action" do
       interpretation =
         Verification.Checks.interpret_diagnostics(%State{
           url: "example.com",
@@ -159,9 +205,10 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
 
       refute element_exists?(html, "#verify-custom-url-link")
       refute element_exists?(html, ~s|a[phx-click="retry"]|)
+      refute html =~ "Review installation"
 
       assert text_of_element(html, ~s|form[phx-submit="verify-custom-url"] button[type="submit"]|) =~
-               "Check again"
+               "Verify URL"
 
       assert element_exists?(
                html,
@@ -172,13 +219,12 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
                "https://example.com"
     end
 
-    test "offers an installation-instructions escape path on failure, no more settings link" do
+    test "offers a Review installation ghost button on failure by default" do
       html =
         render_component(@component,
           domain: "example.com",
           success?: false,
           finished?: true,
-          installation_type: "wordpress",
           flow: PlausibleWeb.Flows.review()
         )
 
@@ -188,6 +234,8 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
                html,
                ~s|a[href="/example.com/installation?flow=review"]|
              )
+
+      assert html =~ "Review installation"
     end
   end
 end

--- a/test/plausible_web/live/components/verification_banner_test.exs
+++ b/test/plausible_web/live/components/verification_banner_test.exs
@@ -37,7 +37,7 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
       assert html =~ "We couldn&#39;t verify your installation"
     end
 
-    test "renders diagnostic interpretation with inline verify/review links" do
+    test "renders diagnostic interpretation with inline verify link and standalone review-installation sentence" do
       interpretation =
         Verification.Checks.interpret_diagnostics(%State{
           url: "https://example.com",
@@ -56,7 +56,8 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
       assert [recommendation] = html |> find(@recommendations) |> Enum.map(&text/1)
       assert recommendation =~ "Check that the URL is correct and publicly accessible"
       assert recommendation =~ "verify your installation manually"
-      assert recommendation =~ "review your installation"
+      refute recommendation =~ "review your installation"
+      assert recommendation =~ "See your installation instructions again here"
 
       assert element_exists?(
                html,
@@ -97,6 +98,7 @@ defmodule PlausibleWeb.Live.Components.VerificationBannerTest do
       assert recommendation =~ "verify your installation manually"
       refute recommendation =~ "review your installation"
       refute recommendation =~ "Learn more"
+      refute recommendation =~ "See your installation instructions again here"
 
       assert element_exists?(
                html,

--- a/test/plausible_web/live/verification_test.exs
+++ b/test/plausible_web/live/verification_test.exs
@@ -132,7 +132,7 @@ defmodule PlausibleWeb.Live.VerificationTest do
 
       assert eventually(fn ->
                html = render(lv)
-               {html =~ "Success!", html}
+               {html =~ "Tracking is active on your site", html}
              end)
     end
 
@@ -174,7 +174,7 @@ defmodule PlausibleWeb.Live.VerificationTest do
       # must stay hidden.
       assert eventually(fn ->
                html = render(lv)
-               {html =~ "Success!", html}
+               {html =~ "Tracking is active on your site", html}
              end)
 
       html = render(lv)
@@ -199,16 +199,16 @@ defmodule PlausibleWeb.Live.VerificationTest do
     end
 
     for {expected_text, saved_installation_type} <- [
-          {"Please make sure you've copied the snippet to the head of your site, or verify your installation manually.",
+          {"Make sure you've copied the snippet to the head of your site, or verify your installation manually.",
            "manual"},
-          {"Please make sure you've initialized Plausible on your site, or verify your installation manually.",
+          {"Make sure you've initialized Plausible on your site, or verify your installation manually.",
            "npm"},
-          {"Please make sure you've configured the GTM template correctly, or verify your installation manually.",
+          {"Make sure you've configured the GTM template correctly, or verify your installation manually.",
            "gtm"},
-          {"Please make sure you've enabled the plugin, or verify your installation manually.",
+          {"Make sure you've enabled the WordPress plugin, or verify your installation manually.",
            "wordpress"},
           # falls back to manual when there's no saved installation type
-          {"Please make sure you've copied the snippet to the head of your site, or verify your installation manually.",
+          {"Make sure you've copied the snippet to the head of your site, or verify your installation manually.",
            nil}
         ] do
       @tag :ee_only
@@ -246,7 +246,7 @@ defmodule PlausibleWeb.Live.VerificationTest do
 
         assert element_exists?(html, @retry_button)
 
-        assert html =~ htmlize_quotes(unquote(expected_text))
+        assert text_of_element(html, "#recommendation") =~ unquote(expected_text)
         refute element_exists?(html, "#super-admin-report")
       end
     end


### PR DESCRIPTION
### Changes

- Simplify failure CTAs: keep "Check again" as primary, add ghost "Review installation" (or "Try another URL" when a custom URL retry is offered); remove installation-guide, change-method, and view-snippet expandable logic
- Render inline "verify your installation manually" / "review your installation" links inside recommendation text (offer_custom_url_input scenarios) via safe HTML helpers, avoiding HEEx whitespace pitfalls
- Tighten diagnostics title and body copy
- Move the "Setup pending" pill in the sites list to replace the percentage indicator; use the generic pill component
- Extend the notice component with title_class override and a spinner slot; swap success icon to solid check-circle

### Tests
- [x] Automated tests have been added

### Dark mode
- [x] The UI has been tested both in dark and light mode