### PR TITLE
Fix flaky special goals test by waiting for verification page to load fully

### DIFF
--- a/e2e/tests/fixtures.ts
+++ b/e2e/tests/fixtures.ts
@@ -159,6 +159,10 @@ export async function addSite({
   await page.getByRole('button', { name: 'Install Plausible' }).click()
 
   await expect(page).toHaveURL(/\/installation/)
+
+  await expect(
+    page.getByRole('button', { name: /Verify .* installation/ })
+  ).toBeVisible()
 }
 
 export async function makeSitePublic({


### PR DESCRIPTION
### Changes
The e2e test testing special goals was flaky. We proceeded to the dashboard in e2e tests too quick from the verification screen for the automatic async special goal creation logic to run. This adds an await on the verification screen, which allows the special goal creation logic to run. 