### PR TITLE
Fix flaky TableDeciderTest build(:site) ID colliding with IDs for sites inserted for other tests

### DIFF
--- a/test/plausible/stats/table_decider_test.exs
+++ b/test/plausible/stats/table_decider_test.exs
@@ -255,7 +255,7 @@ defmodule Plausible.Stats.TableDeciderTest do
   end
 
   defp make_query(filter_dimensions \\ [], dimensions \\ []) do
-    site = build(:site, id: :rand.uniform(100_000))
+    site = insert(:site)
 
     QueryBuilder.build!(site,
       metrics: [:visitors],
@@ -267,7 +267,7 @@ defmodule Plausible.Stats.TableDeciderTest do
   end
 
   defp make_query_full_filters(filters) do
-    site = build(:site, id: :rand.uniform(100_000))
+    site = insert(:site)
 
     QueryBuilder.build!(site,
       metrics: [:visitors],


### PR DESCRIPTION
### Changes

This fixes test flakyness caused by site ID collision from `build(:site)` in this test suite and `insert(:site)` from other test suites. When there was an ID collision and the inserted site had some events added, we ended up in this test suite in the code branch to update stats_start_date(), which Ecto didn't allow because the built site looked stale. 