### PR TITLE
Publish tracker package 0.4.6

### DIFF
--- a/tracker/README.md
+++ b/tracker/README.md
@@ -9,7 +9,7 @@ See also [ARCHITECTURE.md](./ARCHITECTURE.md)
 
 ### Dependencies
 
-To download dependencies, do:
+To download dependencies, do
 
 ```bash
 npm install


### PR DESCRIPTION
### Changes

Because the PR https://github.com/plausible/analytics/pull/6158 was from a fork, the Github workflow "Tracker: publish NPM release" failed. This PR is needed to get it to run. 