### PR TITLE
Remove limitation that blocked users without owned sites from startin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Update custom range datepicker styles
 - Improved site transfer UI
 - Redesigned authentication pages (register, sign in, 2FA, password reset, account activation)
+- Removed limitation that blocked users without owned sites from starting a subscription
 
 ### Fixed
 

--- a/lib/plausible/billing/billing.ex
+++ b/lib/plausible/billing/billing.ex
@@ -309,6 +309,5 @@ defmodule Plausible.Billing do
   def subscription_cancelled_notice_title(), do: "Subscription cancelled"
   def subscription_past_due_notice_title(), do: "Payment failed"
   def subscription_paused_notice_title(), do: "Subscription paused"
-  def upgrade_ineligible_notice_title(), do: "No sites owned"
   def pending_site_ownerships_notice_title(), do: "Pending ownership transfers"
 end

--- a/lib/plausible/billing/qouta/quota.ex
+++ b/lib/plausible/billing/qouta/quota.ex
@@ -45,8 +45,6 @@ defmodule Plausible.Billing.Quota do
 
   def ensure_within_plan_limits(_, _, _), do: :ok
 
-  def eligible_for_upgrade?(usage), do: usage.sites > 0
-
   def ensure_feature_access(usage, plan) do
     case usage.features -- plan.features do
       [] -> :ok
@@ -63,14 +61,9 @@ defmodule Plausible.Billing.Quota do
 
   To avoid confusion, we do not recommend a lower tier for customers that
   are already on a higher tier (even if their usage is low enough).
-
-  `nil` is returned if the usage is not eligible for upgrade.
   """
   def suggest_tier(usage, highest_starter, highest_growth, highest_business, owned_tier) do
     cond do
-      not eligible_for_upgrade?(usage) ->
-        nil
-
       not is_nil(highest_starter) and usage_fits_plan?(usage, highest_starter) and
           owned_tier not in [:business, :growth] ->
         :starter

--- a/lib/plausible_web/components/billing/notice.ex
+++ b/lib/plausible_web/components/billing/notice.ex
@@ -212,24 +212,6 @@ defmodule PlausibleWeb.Components.Billing.Notice do
 
   def subscription_paused(assigns), do: ~H""
 
-  def upgrade_ineligible(assigns) do
-    ~H"""
-    <aside id="upgrade-eligible-notice" class="pb-6">
-      <.notice
-        title={Plausible.Billing.upgrade_ineligible_notice_title()}
-        theme={:yellow}
-        class="shadow-md dark:shadow-none"
-      >
-        You cannot start a subscription as your account doesn't own any sites. The account that owns the sites is responsible for the billing. Please either
-        <.styled_link href="https://plausible.io/docs/transfer-ownership">
-          transfer the sites
-        </.styled_link>
-        to your account or start a subscription from the account that owns your sites.
-      </.notice>
-    </aside>
-    """
-  end
-
   def pending_site_ownerships_notice(%{pending_ownership_count: count} = assigns) do
     if count > 0 do
       message =

--- a/lib/plausible_web/components/billing/plan_box.ex
+++ b/lib/plausible_web/components/billing/plan_box.ex
@@ -239,9 +239,6 @@ defmodule PlausibleWeb.Components.Billing.PlanBox do
 
     {checkout_disabled, disabled_message} =
       cond do
-        not Quota.eligible_for_upgrade?(assigns.usage) ->
-          {true, nil}
-
         change_plan_link_text == "Currently on this plan" && not subscription_deleted ->
           {true, nil}
 

--- a/lib/plausible_web/live/choose_plan.ex
+++ b/lib/plausible_web/live/choose_plan.ex
@@ -139,7 +139,6 @@ defmodule PlausibleWeb.Live.ChoosePlan do
         />
         <Notice.subscription_past_due class="pb-6" subscription={@subscription} />
         <Notice.subscription_paused class="pb-6" subscription={@subscription} />
-        <Notice.upgrade_ineligible :if={not Quota.eligible_for_upgrade?(@usage)} />
 
         <div class="mt-6 w-full md:flex">
           <a

--- a/lib/plausible_web/live/site_transfer_settings.ex
+++ b/lib/plausible_web/live/site_transfer_settings.ex
@@ -29,19 +29,23 @@ defmodule PlausibleWeb.Live.SiteTransferSettings do
 
     show_teams? = team_options != []
 
-    show_my_team? =
-      not is_nil(socket.assigns[:my_team]) and socket.assigns.my_team.id != site.team_id
+    my_team = socket.assigns[:my_team]
 
-    my_team_notice =
+    show_my_team? = not is_nil(my_team) and my_team.id != site.team_id
+
+    {my_team_notice, my_team_upgrade_href} =
       cond do
-        not is_nil(socket.assigns[:my_team]) and socket.assigns.my_team.id == site.team_id ->
-          "The site is already in your personal sites."
+        not is_nil(my_team) and my_team.id == site.team_id ->
+          {"The site is already in your personal sites.", nil}
 
-        is_nil(socket.assigns[:my_team]) ->
-          "You don't have an active subscription."
+        is_nil(my_team) ->
+          {"You don't have an active subscription.",
+           Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan) <> "?__team=none"}
 
         true ->
-          nil
+          {nil,
+           Routes.billing_path(PlausibleWeb.Endpoint, :choose_plan) <>
+             "?__team=#{my_team.identifier}"}
       end
 
     initial_destination =
@@ -59,7 +63,9 @@ defmodule PlausibleWeb.Live.SiteTransferSettings do
         team_options: team_options,
         show_teams?: show_teams?,
         show_my_team?: show_my_team?,
-        my_team_notice: my_team_notice
+        my_team_notice: my_team_notice,
+        my_team_upgrade_href: my_team_upgrade_href,
+        my_team_no_plan_error?: false
       )
       |> assign_form(%{"destination" => initial_destination})
 
@@ -172,6 +178,17 @@ defmodule PlausibleWeb.Live.SiteTransferSettings do
                 class="ml-7 mt-1 text-sm text-gray-500/60 dark:text-gray-400/60 text-pretty"
               >
                 {@my_team_notice}
+                <.styled_link :if={@my_team_upgrade_href} href={@my_team_upgrade_href}>
+                  Start a subscription
+                </.styled_link>
+              </p>
+              <p
+                :if={@my_team_no_plan_error?}
+                class="ml-7 mt-1 text-xs text-red-500 leading-4.5 text-pretty"
+              >
+                You don't have an active subscription for My personal sites.
+                <a href={@my_team_upgrade_href} class="underline">Start a subscription</a>
+                first and then try moving the site again.
               </p>
             </div>
           </fieldset>
@@ -190,7 +207,7 @@ defmodule PlausibleWeb.Live.SiteTransferSettings do
   end
 
   def handle_event("validate", %{"form" => params}, socket) do
-    {:noreply, assign_form(socket, params)}
+    {:noreply, socket |> assign(my_team_no_plan_error?: false) |> assign_form(params)}
   end
 
   def handle_event("save", %{"form" => params}, socket) do
@@ -228,6 +245,12 @@ defmodule PlausibleWeb.Live.SiteTransferSettings do
            socket
            |> put_flash(:success, "Site team was changed")
            |> redirect(to: Routes.site_path(socket, :index, __team: destination_team.identifier))}
+
+        {:error, :no_plan} when my_team? ->
+          {:noreply,
+           socket
+           |> assign(my_team_no_plan_error?: true)
+           |> assign_form(params, action: :insert)}
 
         {:error, reason} ->
           {:noreply,
@@ -294,10 +317,6 @@ defmodule PlausibleWeb.Live.SiteTransferSettings do
 
   defp change_team_error_message(:no_plan, false = _my_team?) do
     "This team doesn't have a subscription. Please start a subscription for the team first and then try moving the site again."
-  end
-
-  defp change_team_error_message(:no_plan, true = _my_team?) do
-    "You don't have a subscription. Please start a subscription first and then try moving the site again."
   end
 
   defp change_team_error_message({:over_plan_limits, _}, false = _my_team?) do

--- a/test/plausible/billing/quota_test.exs
+++ b/test/plausible/billing/quota_test.exs
@@ -1057,20 +1057,6 @@ defmodule Plausible.Billing.QuotaTest do
       %{user: user, team: team}
     end
 
-    test "returns nil if usage doesn't have any sites", %{team: team} do
-      suggested_tier =
-        team
-        |> Plausible.Teams.Billing.quota_usage(with_features: true)
-        |> Quota.suggest_tier(
-          @highest_starter_plan,
-          @highest_growth_plan,
-          @highest_business_plan,
-          nil
-        )
-
-      assert suggested_tier == nil
-    end
-
     test "returns :custom if the monthly pageview limit exceeds regular plans",
          %{team: team} do
       suggested_tier =

--- a/test/plausible_web/live/choose_plan_test.exs
+++ b/test/plausible_web/live/choose_plan_test.exs
@@ -1262,23 +1262,6 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
       end
     end
 
-    describe "for a user with no sites" do
-      setup [:create_user, :log_in]
-
-      test "does not allow to subscribe and renders notice", %{conn: conn} do
-        {:ok, _lv, doc} = get_liveview(conn)
-
-        check_notice_titles(doc, [Billing.upgrade_ineligible_notice_title()])
-
-        assert text_of_element(doc, "#upgrade-eligible-notice") =~
-                 "You cannot start a subscription"
-
-        assert class_of_element(doc, @starter_checkout_button) =~ "pointer-events-none"
-        assert class_of_element(doc, @growth_checkout_button) =~ "pointer-events-none"
-        assert class_of_element(doc, @business_checkout_button) =~ "pointer-events-none"
-      end
-    end
-
     describe "for a user with no sites but pending ownership transfer" do
       setup [:create_user, :log_in]
 
@@ -1314,7 +1297,6 @@ defmodule PlausibleWeb.Live.ChoosePlanTest do
         Billing.subscription_cancelled_notice_title(),
         Billing.subscription_past_due_notice_title(),
         Billing.subscription_paused_notice_title(),
-        Billing.upgrade_ineligible_notice_title(),
         Billing.pending_site_ownerships_notice_title()
       ]
       |> Enum.each(fn title ->

--- a/test/plausible_web/live/site_transfer_settings_test.exs
+++ b/test/plausible_web/live/site_transfer_settings_test.exs
@@ -135,6 +135,13 @@ defmodule PlausibleWeb.Live.SiteTransferSettingsTest do
 
       assert text_of_element(html, "#site-transfer-form") =~
                "You don't have an active subscription"
+
+      assert text_of_element(html, "#site-transfer-form") =~ "Start a subscription"
+
+      assert element_exists?(
+               html,
+               ~s|#site-transfer-form a[href="/billing/choose-plan?__team=none"]|
+             )
     end
 
     test "Team destination is preselected when available", %{
@@ -487,7 +494,15 @@ defmodule PlausibleWeb.Live.SiteTransferSettingsTest do
           "form" => %{"destination" => "my_team", "my_team_available" => "true"}
         })
 
-      assert text_of_element(html, "#site-transfer-form") =~ "You don't have a subscription"
+      assert text_of_element(html, "#site-transfer-form") =~
+               "You don't have an active subscription for My personal sites."
+
+      assert text_of_element(html, "#site-transfer-form") =~ "Start a subscription"
+
+      assert element_exists?(
+               html,
+               ~s|#site-transfer-form a[href^="/billing/choose-plan?__team="]|
+             )
     end
 
     @tag :ee_only


### PR DESCRIPTION
…g a subscription.

### Changes

- The "No sites owned" upgrade gate no longer applies; any team can subscribe regardless of site count.
- Site transfer form now offers an upgrade link when moving to "My personal sites" without an active subscription.
- The reason for doing this is that with the recent improvements to the site transfer flow, we're already detecting at the start whether a site can be moved to My personal sites. It's not possible to initiate a site transfer to My personal sites without a subscription, but it's also not possible to start a subscription without sites; thus creating a dead end.

<img width="2610" height="1948" alt="CleanShot 2026-07-23 at 13 02 02@2x" src="https://github.com/user-attachments/assets/1c493e08-73fe-4fff-86ee-ba61fc957739" />
<img width="2704" height="2118" alt="CleanShot 2026-07-23 at 12 41 16@2x" src="https://github.com/user-attachments/assets/cbe24310-95c3-4c69-9925-fa93e294a834" />


### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
