### PR TITLE
Add script for purging replayed sessions and events by ID and date range

### DIFF
--- a/lib/plausible/data_migration/purge_ingest_replay.ex
+++ b/lib/plausible/data_migration/purge_ingest_replay.ex
@@ -61,7 +61,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
 
     if days_scope < 0 or days_scope > 2 do
       raise ArgumentError,
-            "The period declared by inclusive from/to range cannot be longer than 3 days "
+            "The period declared by inclusive from/to range cannot be longer than 3 days"
     end
 
     %{rows: [[session_count]]} =

--- a/lib/plausible/data_migration/purge_ingest_replay.ex
+++ b/lib/plausible/data_migration/purge_ingest_replay.ex
@@ -1,6 +1,16 @@
 defmodule Plausible.DataMigration.PurgeIngestReplay do
   @moduledoc """
-  Script purging ingest replay
+  Script purging ingest replay.
+
+  The script is used in the ingest replay procedure when a particular replay turns
+  out to be incorrect - for instance, due to too much overlap with normally ingestged
+  events.
+
+  Three options are required:
+
+  - `session_id` - `replay_session_id` to purge, provided as an integer
+  - `from` and `to` - provided as Dates; necessary for reducing scope of database scan; 
+    the date range is inclusive; to scan a single day, `from` and `to` can be the same
   """
 
   alias Plausible.IngestRepo

--- a/lib/plausible/data_migration/purge_ingest_replay.ex
+++ b/lib/plausible/data_migration/purge_ingest_replay.ex
@@ -10,7 +10,8 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
 
   - `session_id` - `replay_session_id` to purge, provided as an integer
   - `from` and `to` - provided as Dates; necessary for reducing scope of database scan; 
-    the date range is inclusive; to scan a single day, `from` and `to` can be the same
+    the date range is inclusive; to scan a single day, `from` and `to` can be the same;
+    maximum range is 3 days
   """
 
   alias Plausible.IngestRepo

--- a/lib/plausible/data_migration/purge_ingest_replay.ex
+++ b/lib/plausible/data_migration/purge_ingest_replay.ex
@@ -40,11 +40,11 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
   def run(opts \\ []) do
     from = %Date{} = Keyword.fetch!(opts, :from)
     to = %Date{} = Keyword.fetch!(opts, :to)
-    session_id = String.to_integer(Keyword.fetch!(opts, :session_id))
+    session_id = Keyword.fetch!(opts, :session_id)
 
     days_scope = Date.diff(to, from)
 
-    if session_id <= 0 do
+    if not is_integer(session_id) or session_id <= 0 do
       raise ArgumentError, "Invalid session ID"
     end
 

--- a/lib/plausible/data_migration/purge_ingest_replay.ex
+++ b/lib/plausible/data_migration/purge_ingest_replay.ex
@@ -1,0 +1,88 @@
+defmodule Plausible.DataMigration.PurgeIngestReplay do
+  @moduledoc """
+  Script purging ingest replay
+  """
+
+  alias Plausible.IngestRepo
+
+  @settings if Mix.env() in [:test, :ce_test, :e2e_test], do: [mutations_sync: 2], else: []
+
+  @confirmation_phrase "REMOVE REPLAYED INGEST"
+
+  @count_query """
+  SELECT count(*) AS count FROM {$0:Identifier} 
+  WHERE replay_session_id = {$1:UInt64} 
+    AND toDate(timestamp) >= {$2:Date} 
+    AND toDate(timestamp) <= {$3:Date}
+  """
+
+  @purge_query """
+  ALTER TABLE {$0:Identifier} DELETE 
+  WHERE replay_session_id = {$1:UInt64} 
+    AND toDate(timestamp) >= {$2:Date} 
+    AND toDate(timestamp) <= {$3:Date}
+  """
+
+  def run(opts \\ []) do
+    from = %Date{} = Keyword.fetch!(opts, :from)
+    to = %Date{} = Keyword.fetch!(opts, :to)
+    session_id = String.to_integer(Keyword.fetch!(opts, :session_id))
+
+    days_scope = Date.diff(to, from)
+
+    if session_id <= 0 do
+      raise ArgumentError, "Invalid session ID"
+    end
+
+    if days_scope < 0 or days_scope > 2 do
+      raise ArgumentError, "The number of days between the dates must be from 0 to 2 range"
+    end
+
+    %{rows: [[session_count]]} =
+      IngestRepo.query!(@count_query, ["sessions_v2", session_id, from, to], @settings)
+
+    %{rows: [[event_count]]} =
+      IngestRepo.query!(@count_query, ["events_v2", session_id, from, to], @settings)
+
+    if session_count > 0 or event_count > 0 do
+      IO.puts("""
+      About to remove replayed ingest for session ID #{session_id}
+
+      Start date: #{from}
+      End date: #{to}
+
+      Sessions found: #{session_count}
+      Events found: #{event_count}
+
+      To confirm, please type in:
+
+      #{@confirmation_phrase}
+
+      and hit Enter.
+
+      """)
+
+      confirmation = IO.gets("Confirmation: ")
+
+      if String.trim(confirmation) == @confirmation_phrase do
+        run_purge(session_id, from, to)
+      else
+        IO.puts("Wrong confirmation phrase. Aborting!")
+        {:error, :aborted}
+      end
+    else
+      IO.puts("No events found matching criteria. Aborting.")
+      {:error, :aborted}
+    end
+  end
+
+  defp run_purge(session_id, from, to) do
+    IO.puts("Purging sessions...")
+    IngestRepo.query!(@purge_query, ["sessions_v2", session_id, from, to], @settings)
+
+    IO.puts("Purging events...")
+    IngestRepo.query!(@purge_query, ["events_v2", session_id, from, to], @settings)
+
+    IO.puts("Done!")
+  end
+end

--- a/lib/plausible/data_migration/purge_ingest_replay.ex
+++ b/lib/plausible/data_migration/purge_ingest_replay.ex
@@ -59,7 +59,8 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
     end
 
     if days_scope < 0 or days_scope > 2 do
-      raise ArgumentError, "The number of days between the dates must be from 0 to 2 range"
+      raise ArgumentError,
+            "The period declared by inclusive from/to range cannot be longer than 3 days "
     end
 
     %{rows: [[session_count]]} =

--- a/lib/plausible/data_migration/purge_ingest_replay.ex
+++ b/lib/plausible/data_migration/purge_ingest_replay.ex
@@ -9,18 +9,36 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
 
   @confirmation_phrase "REMOVE REPLAYED INGEST"
 
-  @count_query """
-  SELECT count(*) AS count FROM {$0:Identifier} 
-  WHERE replay_session_id = {$1:UInt64} 
-    AND toDate(timestamp) >= {$2:Date} 
-    AND toDate(timestamp) <= {$3:Date}
+  @count_query_sessions """
+  SELECT count(*) AS count FROM sessions_v2 
+  WHERE replay_session_id = {$0:UInt64} 
+    AND toDate(start) >= {$1:Date} 
+    AND toDate(start) <= {$2:Date}
+    AND toDate(timestamp) >= {$3:Date} 
+    AND toDate(timestamp) <= {$4:Date}
   """
 
-  @purge_query """
-  ALTER TABLE {$0:Identifier} DELETE 
-  WHERE replay_session_id = {$1:UInt64} 
-    AND toDate(timestamp) >= {$2:Date} 
-    AND toDate(timestamp) <= {$3:Date}
+  @count_query_events """
+  SELECT count(*) AS count FROM events_v2 
+  WHERE replay_session_id = {$0:UInt64} 
+    AND toDate(timestamp) >= {$1:Date} 
+    AND toDate(timestamp) <= {$2:Date}
+  """
+
+  @purge_query_sessions """
+  ALTER TABLE sessions_v2 DELETE 
+  WHERE replay_session_id = {$0:UInt64} 
+    AND toDate(start) >= {$1:Date} 
+    AND toDate(start) <= {$2:Date}
+    AND toDate(timestamp) >= {$3:Date} 
+    AND toDate(timestamp) <= {$4:Date}
+  """
+
+  @purge_query_events """
+  ALTER TABLE events_v2 DELETE 
+  WHERE replay_session_id = {$0:UInt64} 
+    AND toDate(timestamp) >= {$1:Date} 
+    AND toDate(timestamp) <= {$2:Date}
   """
 
   def run(opts \\ []) do
@@ -39,10 +57,14 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
     end
 
     %{rows: [[session_count]]} =
-      IngestRepo.query!(@count_query, ["sessions_v2", session_id, from, to], @settings)
+      IngestRepo.query!(
+        @count_query_sessions,
+        [session_id, Date.add(from, -2), to, from, to],
+        @settings
+      )
 
     %{rows: [[event_count]]} =
-      IngestRepo.query!(@count_query, ["events_v2", session_id, from, to], @settings)
+      IngestRepo.query!(@count_query_events, [session_id, from, to], @settings)
 
     if session_count > 0 or event_count > 0 do
       IO.puts("""
@@ -78,10 +100,15 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
 
   defp run_purge(session_id, from, to) do
     IO.puts("Purging sessions...")
-    IngestRepo.query!(@purge_query, ["sessions_v2", session_id, from, to], @settings)
+
+    IngestRepo.query!(
+      @purge_query_sessions,
+      [session_id, Date.add(from, -2), to, from, to],
+      @settings
+    )
 
     IO.puts("Purging events...")
-    IngestRepo.query!(@purge_query, ["events_v2", session_id, from, to], @settings)
+    IngestRepo.query!(@purge_query_events, [session_id, from, to], @settings)
 
     IO.puts("Done!")
   end

--- a/lib/plausible/data_migration/purge_ingest_replay.ex
+++ b/lib/plausible/data_migration/purge_ingest_replay.ex
@@ -14,8 +14,6 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
   WHERE replay_session_id = {$0:UInt64} 
     AND toDate(start) >= {$1:Date} 
     AND toDate(start) <= {$2:Date}
-    AND toDate(timestamp) >= {$3:Date} 
-    AND toDate(timestamp) <= {$4:Date}
   """
 
   @count_query_events """
@@ -30,8 +28,6 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
   WHERE replay_session_id = {$0:UInt64} 
     AND toDate(start) >= {$1:Date} 
     AND toDate(start) <= {$2:Date}
-    AND toDate(timestamp) >= {$3:Date} 
-    AND toDate(timestamp) <= {$4:Date}
   """
 
   @purge_query_events """
@@ -59,7 +55,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
     %{rows: [[session_count]]} =
       IngestRepo.query!(
         @count_query_sessions,
-        [session_id, Date.add(from, -2), to, from, to],
+        [session_id, from, to],
         @settings
       )
 
@@ -103,7 +99,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplay do
 
     IngestRepo.query!(
       @purge_query_sessions,
-      [session_id, Date.add(from, -2), to, from, to],
+      [session_id, from, to],
       @settings
     )
 

--- a/test/plausible/data_migration/purge_ingest_replay_test.exs
+++ b/test/plausible/data_migration/purge_ingest_replay_test.exs
@@ -146,7 +146,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
 
       test "raises on invalid session date range" do
         assert_raise ArgumentError,
-                     ~r/The number of days between the dates must be from 0 to 2 range/,
+                     ~r/The period declared by inclusive from\/to range cannot be longer than 3 days/,
                      fn ->
                        PurgeIngestReplay.run(
                          from: ~D[2026-07-27],
@@ -156,7 +156,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
                      end
 
         assert_raise ArgumentError,
-                     ~r/The number of days between the dates must be from 0 to 2 range/,
+                     ~r/The period declared by inclusive from\/to range cannot be longer than 3 days/,
                      fn ->
                        PurgeIngestReplay.run(
                          from: ~D[2026-07-26],

--- a/test/plausible/data_migration/purge_ingest_replay_test.exs
+++ b/test/plausible/data_migration/purge_ingest_replay_test.exs
@@ -15,7 +15,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
                           PurgeIngestReplay.run(
                             from: ~D[2026-07-26],
                             to: ~D[2026-07-27],
-                            session_id: "123"
+                            session_id: 123
                           )
                end) =~ "No events found matching criteria. Aborting"
       end
@@ -66,7 +66,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
                      PurgeIngestReplay.run(
                        from: ~D[2026-07-26],
                        to: ~D[2026-07-27],
-                       session_id: "#{replay_session_id}"
+                       session_id: replay_session_id
                      )
           end)
 
@@ -121,7 +121,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
                           PurgeIngestReplay.run(
                             from: ~D[2026-07-26],
                             to: ~D[2026-07-27],
-                            session_id: "#{replay_session_id}"
+                            session_id: replay_session_id
                           )
                end) =~ "No events found matching criteria. Aborting"
       end
@@ -131,7 +131,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
           PurgeIngestReplay.run(
             from: ~D[2026-07-26],
             to: ~D[2026-07-27],
-            session_id: "0"
+            session_id: 0
           )
 
           assert_raise MatchError, fn ->
@@ -151,7 +151,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
                        PurgeIngestReplay.run(
                          from: ~D[2026-07-27],
                          to: ~D[2026-07-26],
-                         session_id: "123"
+                         session_id: 123
                        )
                      end
 
@@ -161,7 +161,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
                        PurgeIngestReplay.run(
                          from: ~D[2026-07-26],
                          to: ~D[2026-07-29],
-                         session_id: "123"
+                         session_id: 123
                        )
                      end
 
@@ -169,7 +169,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
           PurgeIngestReplay.run(
             from: ~D[2026-07-26],
             to: :invalid,
-            session_id: "123"
+            session_id: 123
           )
         end
 
@@ -177,7 +177,7 @@ defmodule Plausible.DataMigration.PurgeIngestReplayTest do
           PurgeIngestReplay.run(
             from: :invalid,
             to: ~D[2026-07-29],
-            session_id: "123"
+            session_id: 123
           )
         end
       end

--- a/test/plausible/data_migration/purge_ingest_replay_test.exs
+++ b/test/plausible/data_migration/purge_ingest_replay_test.exs
@@ -1,0 +1,184 @@
+defmodule Plausible.DataMigration.PurgeIngestReplayTest do
+  use Plausible.DataCase, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Plausible.DataMigration.PurgeIngestReplay
+
+  describe "run/1" do
+    test "aborts where there are no replayed events within range" do
+      assert capture_io(fn ->
+               assert {:error, :aborted} =
+                        PurgeIngestReplay.run(
+                          from: ~D[2026-07-26],
+                          to: ~D[2026-07-27],
+                          session_id: "123"
+                        )
+             end) =~ "No events found matching criteria. Aborting"
+    end
+
+    test "purges replayed events in scope" do
+      site = new_site()
+
+      replay_session_id = random_id()
+      other_replay_session_id = random_id()
+
+      populate_stats(site, [
+        # out of scope
+        build(:pageview,
+          timestamp: ~N[2026-07-25 11:44:56],
+          replay_session_id: replay_session_id
+        ),
+        # different replay
+        build(:pageview,
+          timestamp: ~N[2026-07-25 11:44:56],
+          replay_session_id: other_replay_session_id
+        ),
+        # non-replay event
+        build(:pageview, timestamp: ~N[2026-07-25 11:44:56]),
+        # in scope
+        build(:pageview,
+          timestamp: ~N[2026-07-26 11:44:56],
+          replay_session_id: replay_session_id
+        ),
+        build(:pageview,
+          user_id: 456,
+          timestamp: ~N[2026-07-26 13:12:33],
+          replay_session_id: replay_session_id
+        ),
+        build(:pageview,
+          user_id: 456,
+          timestamp: ~N[2026-07-26 13:32:43],
+          replay_session_id: replay_session_id
+        ),
+        build(:pageview, timestamp: ~N[2026-07-27 14:44:56], replay_session_id: replay_session_id)
+      ])
+
+      output =
+        capture_io("REMOVE REPLAYED INGEST", fn ->
+          assert :ok =
+                   PurgeIngestReplay.run(
+                     from: ~D[2026-07-26],
+                     to: ~D[2026-07-27],
+                     session_id: "#{replay_session_id}"
+                   )
+        end)
+
+      assert output =~ "About to remove replayed ingest for session ID #{replay_session_id}"
+      assert output =~ "Start date: 2026-07-26"
+      assert output =~ "End date: 2026-07-27"
+      assert output =~ "Sessions found: 3"
+      assert output =~ "Events found: 4"
+      assert output =~ "Purging sessions..."
+      assert output =~ "Purging events..."
+      assert output =~ "Done!"
+
+      assert eventually(fn ->
+               assert %{rows: [[session_count]]} =
+                        Plausible.IngestRepo.query!(
+                          "SELECT count(*) FROM events_v2 WHERE replay_session_id = #{replay_session_id}"
+                        )
+
+               assert %{rows: [[event_count]]} =
+                        Plausible.IngestRepo.query!(
+                          "SELECT count(*) FROM sessions_v2 WHERE replay_session_id = #{replay_session_id}"
+                        )
+
+               # only out of scope event is left
+               {session_count == 1 and event_count == 1, true}
+             end)
+    end
+
+    test "aborts when no matching replay events are in scope" do
+      site = new_site()
+
+      replay_session_id = random_id()
+      other_replay_session_id = random_id()
+
+      populate_stats(site, [
+        # out of scope
+        build(:pageview,
+          timestamp: ~N[2026-07-25 11:44:56],
+          replay_session_id: replay_session_id
+        ),
+        # different replay
+        build(:pageview,
+          timestamp: ~N[2026-07-25 11:44:56],
+          replay_session_id: other_replay_session_id
+        ),
+        # non-replay event
+        build(:pageview, timestamp: ~N[2026-07-25 11:44:56])
+      ])
+
+      assert capture_io(fn ->
+               assert {:error, :aborted} =
+                        PurgeIngestReplay.run(
+                          from: ~D[2026-07-26],
+                          to: ~D[2026-07-27],
+                          session_id: "#{replay_session_id}"
+                        )
+             end) =~ "No events found matching criteria. Aborting"
+    end
+
+    test "raises on invalid session ID" do
+      assert_raise ArgumentError, ~r/Invalid session ID/, fn ->
+        PurgeIngestReplay.run(
+          from: ~D[2026-07-26],
+          to: ~D[2026-07-27],
+          session_id: "0"
+        )
+
+        assert_raise MatchError, fn ->
+          PurgeIngestReplay.run(
+            from: ~D[2026-07-26],
+            to: ~D[2026-07-27],
+            session_id: :invalid
+          )
+        end
+      end
+    end
+
+    test "raises on invalid session date range" do
+      assert_raise ArgumentError,
+                   ~r/The number of days between the dates must be from 0 to 2 range/,
+                   fn ->
+                     PurgeIngestReplay.run(
+                       from: ~D[2026-07-27],
+                       to: ~D[2026-07-26],
+                       session_id: "123"
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/The number of days between the dates must be from 0 to 2 range/,
+                   fn ->
+                     PurgeIngestReplay.run(
+                       from: ~D[2026-07-26],
+                       to: ~D[2026-07-29],
+                       session_id: "123"
+                     )
+                   end
+
+      assert_raise MatchError, fn ->
+        PurgeIngestReplay.run(
+          from: ~D[2026-07-26],
+          to: :invalid,
+          session_id: "123"
+        )
+      end
+
+      assert_raise MatchError, fn ->
+        PurgeIngestReplay.run(
+          from: :invalid,
+          to: ~D[2026-07-29],
+          session_id: "123"
+        )
+      end
+    end
+  end
+
+  defp random_id() do
+    :crypto.strong_rand_bytes(8)
+    |> :binary.decode_unsigned()
+  end
+end

--- a/test/plausible/data_migration/purge_ingest_replay_test.exs
+++ b/test/plausible/data_migration/purge_ingest_replay_test.exs
@@ -1,184 +1,191 @@
 defmodule Plausible.DataMigration.PurgeIngestReplayTest do
-  use Plausible.DataCase, async: true
+  use Plausible
 
-  import ExUnit.CaptureIO
+  on_ee do
+    use Plausible.DataCase, async: true
 
-  alias Plausible.DataMigration.PurgeIngestReplay
+    import ExUnit.CaptureIO
 
-  describe "run/1" do
-    test "aborts where there are no replayed events within range" do
-      assert capture_io(fn ->
-               assert {:error, :aborted} =
-                        PurgeIngestReplay.run(
-                          from: ~D[2026-07-26],
-                          to: ~D[2026-07-27],
-                          session_id: "123"
-                        )
-             end) =~ "No events found matching criteria. Aborting"
-    end
+    alias Plausible.DataMigration.PurgeIngestReplay
 
-    test "purges replayed events in scope" do
-      site = new_site()
+    describe "run/1" do
+      test "aborts where there are no replayed events within range" do
+        assert capture_io(fn ->
+                 assert {:error, :aborted} =
+                          PurgeIngestReplay.run(
+                            from: ~D[2026-07-26],
+                            to: ~D[2026-07-27],
+                            session_id: "123"
+                          )
+               end) =~ "No events found matching criteria. Aborting"
+      end
 
-      replay_session_id = random_id()
-      other_replay_session_id = random_id()
+      test "purges replayed events in scope" do
+        site = new_site()
 
-      populate_stats(site, [
-        # out of scope
-        build(:pageview,
-          timestamp: ~N[2026-07-25 11:44:56],
-          replay_session_id: replay_session_id
-        ),
-        # different replay
-        build(:pageview,
-          timestamp: ~N[2026-07-25 11:44:56],
-          replay_session_id: other_replay_session_id
-        ),
-        # non-replay event
-        build(:pageview, timestamp: ~N[2026-07-25 11:44:56]),
-        # in scope
-        build(:pageview,
-          timestamp: ~N[2026-07-26 11:44:56],
-          replay_session_id: replay_session_id
-        ),
-        build(:pageview,
-          user_id: 456,
-          timestamp: ~N[2026-07-26 13:12:33],
-          replay_session_id: replay_session_id
-        ),
-        build(:pageview,
-          user_id: 456,
-          timestamp: ~N[2026-07-26 13:32:43],
-          replay_session_id: replay_session_id
-        ),
-        build(:pageview, timestamp: ~N[2026-07-27 14:44:56], replay_session_id: replay_session_id)
-      ])
+        replay_session_id = random_id()
+        other_replay_session_id = random_id()
 
-      output =
-        capture_io("REMOVE REPLAYED INGEST", fn ->
-          assert :ok =
-                   PurgeIngestReplay.run(
-                     from: ~D[2026-07-26],
-                     to: ~D[2026-07-27],
-                     session_id: "#{replay_session_id}"
-                   )
-        end)
+        populate_stats(site, [
+          # out of scope
+          build(:pageview,
+            timestamp: ~N[2026-07-25 11:44:56],
+            replay_session_id: replay_session_id
+          ),
+          # different replay
+          build(:pageview,
+            timestamp: ~N[2026-07-25 11:44:56],
+            replay_session_id: other_replay_session_id
+          ),
+          # non-replay event
+          build(:pageview, timestamp: ~N[2026-07-25 11:44:56]),
+          # in scope
+          build(:pageview,
+            timestamp: ~N[2026-07-26 11:44:56],
+            replay_session_id: replay_session_id
+          ),
+          build(:pageview,
+            user_id: 456,
+            timestamp: ~N[2026-07-26 13:12:33],
+            replay_session_id: replay_session_id
+          ),
+          build(:pageview,
+            user_id: 456,
+            timestamp: ~N[2026-07-26 13:32:43],
+            replay_session_id: replay_session_id
+          ),
+          build(:pageview,
+            timestamp: ~N[2026-07-27 14:44:56],
+            replay_session_id: replay_session_id
+          )
+        ])
 
-      assert output =~ "About to remove replayed ingest for session ID #{replay_session_id}"
-      assert output =~ "Start date: 2026-07-26"
-      assert output =~ "End date: 2026-07-27"
-      assert output =~ "Sessions found: 3"
-      assert output =~ "Events found: 4"
-      assert output =~ "Purging sessions..."
-      assert output =~ "Purging events..."
-      assert output =~ "Done!"
+        output =
+          capture_io("REMOVE REPLAYED INGEST", fn ->
+            assert :ok =
+                     PurgeIngestReplay.run(
+                       from: ~D[2026-07-26],
+                       to: ~D[2026-07-27],
+                       session_id: "#{replay_session_id}"
+                     )
+          end)
 
-      assert eventually(fn ->
-               assert %{rows: [[session_count]]} =
-                        Plausible.IngestRepo.query!(
-                          "SELECT count(*) FROM events_v2 WHERE replay_session_id = #{replay_session_id}"
-                        )
+        assert output =~ "About to remove replayed ingest for session ID #{replay_session_id}"
+        assert output =~ "Start date: 2026-07-26"
+        assert output =~ "End date: 2026-07-27"
+        assert output =~ "Sessions found: 3"
+        assert output =~ "Events found: 4"
+        assert output =~ "Purging sessions..."
+        assert output =~ "Purging events..."
+        assert output =~ "Done!"
 
-               assert %{rows: [[event_count]]} =
-                        Plausible.IngestRepo.query!(
-                          "SELECT count(*) FROM sessions_v2 WHERE replay_session_id = #{replay_session_id}"
-                        )
+        assert eventually(fn ->
+                 assert %{rows: [[session_count]]} =
+                          Plausible.IngestRepo.query!(
+                            "SELECT count(*) FROM events_v2 WHERE replay_session_id = #{replay_session_id}"
+                          )
 
-               # only out of scope event is left
-               {session_count == 1 and event_count == 1, true}
-             end)
-    end
+                 assert %{rows: [[event_count]]} =
+                          Plausible.IngestRepo.query!(
+                            "SELECT count(*) FROM sessions_v2 WHERE replay_session_id = #{replay_session_id}"
+                          )
 
-    test "aborts when no matching replay events are in scope" do
-      site = new_site()
+                 # only out of scope event is left
+                 {session_count == 1 and event_count == 1, true}
+               end)
+      end
 
-      replay_session_id = random_id()
-      other_replay_session_id = random_id()
+      test "aborts when no matching replay events are in scope" do
+        site = new_site()
 
-      populate_stats(site, [
-        # out of scope
-        build(:pageview,
-          timestamp: ~N[2026-07-25 11:44:56],
-          replay_session_id: replay_session_id
-        ),
-        # different replay
-        build(:pageview,
-          timestamp: ~N[2026-07-25 11:44:56],
-          replay_session_id: other_replay_session_id
-        ),
-        # non-replay event
-        build(:pageview, timestamp: ~N[2026-07-25 11:44:56])
-      ])
+        replay_session_id = random_id()
+        other_replay_session_id = random_id()
 
-      assert capture_io(fn ->
-               assert {:error, :aborted} =
-                        PurgeIngestReplay.run(
-                          from: ~D[2026-07-26],
-                          to: ~D[2026-07-27],
-                          session_id: "#{replay_session_id}"
-                        )
-             end) =~ "No events found matching criteria. Aborting"
-    end
+        populate_stats(site, [
+          # out of scope
+          build(:pageview,
+            timestamp: ~N[2026-07-25 11:44:56],
+            replay_session_id: replay_session_id
+          ),
+          # different replay
+          build(:pageview,
+            timestamp: ~N[2026-07-25 11:44:56],
+            replay_session_id: other_replay_session_id
+          ),
+          # non-replay event
+          build(:pageview, timestamp: ~N[2026-07-25 11:44:56])
+        ])
 
-    test "raises on invalid session ID" do
-      assert_raise ArgumentError, ~r/Invalid session ID/, fn ->
-        PurgeIngestReplay.run(
-          from: ~D[2026-07-26],
-          to: ~D[2026-07-27],
-          session_id: "0"
-        )
+        assert capture_io(fn ->
+                 assert {:error, :aborted} =
+                          PurgeIngestReplay.run(
+                            from: ~D[2026-07-26],
+                            to: ~D[2026-07-27],
+                            session_id: "#{replay_session_id}"
+                          )
+               end) =~ "No events found matching criteria. Aborting"
+      end
+
+      test "raises on invalid session ID" do
+        assert_raise ArgumentError, ~r/Invalid session ID/, fn ->
+          PurgeIngestReplay.run(
+            from: ~D[2026-07-26],
+            to: ~D[2026-07-27],
+            session_id: "0"
+          )
+
+          assert_raise MatchError, fn ->
+            PurgeIngestReplay.run(
+              from: ~D[2026-07-26],
+              to: ~D[2026-07-27],
+              session_id: :invalid
+            )
+          end
+        end
+      end
+
+      test "raises on invalid session date range" do
+        assert_raise ArgumentError,
+                     ~r/The number of days between the dates must be from 0 to 2 range/,
+                     fn ->
+                       PurgeIngestReplay.run(
+                         from: ~D[2026-07-27],
+                         to: ~D[2026-07-26],
+                         session_id: "123"
+                       )
+                     end
+
+        assert_raise ArgumentError,
+                     ~r/The number of days between the dates must be from 0 to 2 range/,
+                     fn ->
+                       PurgeIngestReplay.run(
+                         from: ~D[2026-07-26],
+                         to: ~D[2026-07-29],
+                         session_id: "123"
+                       )
+                     end
 
         assert_raise MatchError, fn ->
           PurgeIngestReplay.run(
             from: ~D[2026-07-26],
-            to: ~D[2026-07-27],
-            session_id: :invalid
+            to: :invalid,
+            session_id: "123"
+          )
+        end
+
+        assert_raise MatchError, fn ->
+          PurgeIngestReplay.run(
+            from: :invalid,
+            to: ~D[2026-07-29],
+            session_id: "123"
           )
         end
       end
     end
 
-    test "raises on invalid session date range" do
-      assert_raise ArgumentError,
-                   ~r/The number of days between the dates must be from 0 to 2 range/,
-                   fn ->
-                     PurgeIngestReplay.run(
-                       from: ~D[2026-07-27],
-                       to: ~D[2026-07-26],
-                       session_id: "123"
-                     )
-                   end
-
-      assert_raise ArgumentError,
-                   ~r/The number of days between the dates must be from 0 to 2 range/,
-                   fn ->
-                     PurgeIngestReplay.run(
-                       from: ~D[2026-07-26],
-                       to: ~D[2026-07-29],
-                       session_id: "123"
-                     )
-                   end
-
-      assert_raise MatchError, fn ->
-        PurgeIngestReplay.run(
-          from: ~D[2026-07-26],
-          to: :invalid,
-          session_id: "123"
-        )
-      end
-
-      assert_raise MatchError, fn ->
-        PurgeIngestReplay.run(
-          from: :invalid,
-          to: ~D[2026-07-29],
-          session_id: "123"
-        )
-      end
+    defp random_id() do
+      :crypto.strong_rand_bytes(8)
+      |> :binary.decode_unsigned()
     end
-  end
-
-  defp random_id() do
-    :crypto.strong_rand_bytes(8)
-    |> :binary.decode_unsigned()
   end
 end


### PR DESCRIPTION
### Changes

This PR implements a helper script for safely deleting replayed events.

It explicitly prevents deletion of normal events and sessions (replay_session_id = 0).

As the date range is strictly limited to 3 days at most, the number of partitions involved in the operation should be low enough to not require further optimisations.
