### PR TITLE
Add workaround for Clickhouse query condition cache bug

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -647,23 +647,36 @@ ch_transport_opts =
     ch_transport_opts
   end
 
+# Workaround for a ClickHouse bug where sampled queries poison the query
+# condition cache, causing subsequent unsampled queries to return invalid
+# results. Sampling is EE only, so this is scoped to EE builds.
+# Fixed upstream in ClickHouse/ClickHouse#108488; remove once ClickHouse
+# updated.
+ch_query_condition_cache_settings =
+  if config_env() in [:ce, :ce_dev, :ce_test] do
+    []
+  else
+    [use_query_condition_cache: 0]
+  end
+
 config :plausible, Plausible.ClickhouseRepo,
   queue_target: 500,
   queue_interval: 2000,
   timeout: 15_000,
   url: ch_db_url,
   transport_opts: ch_transport_opts,
-  settings: [
-    readonly: 1,
-    join_algorithm: "direct,parallel_hash,hash",
-    # stops queries when :timeout ClickhouseRepo connection :timeout value reached
-    cancel_http_readonly_queries_on_client_close: 1,
-    # stops queries when they will likely take over 20s
-    # NB! when :timeout is overridden to be over 20s,
-    # for it to have meaningful effect,
-    # this must be overridden as well
-    max_execution_time: 20
-  ]
+  settings:
+    [
+      readonly: 1,
+      join_algorithm: "direct,parallel_hash,hash",
+      # stops queries when ClickhouseRepo connection :timeout value reached
+      cancel_http_readonly_queries_on_client_close: 1,
+      # stops queries when they will likely take over 20s
+      # NB! when :timeout is overridden to be over 20s,
+      # for it to have meaningful effect,
+      # this must be overridden as well
+      max_execution_time: 20
+    ] ++ ch_query_condition_cache_settings
 
 config :plausible, Plausible.IngestRepo,
   queue_target: 500,


### PR DESCRIPTION
### Changes

There's a Clickhouse bug (fixed upstream in https://github.com/ClickHouse/ClickHouse/pull/108488) that causes queries to return invalid values when run after a sampled query. This workaround disables `use_query_condition_cache` for all sampled queries and almost all queries in general (just not on the server/cluster as a whole). Can be removed when CH is updated. 

I tried targeting just sampled queries (at the point where we add the log_comment setting to the query), but the sample statement can be deep in the Ecto query, so I didn't think it was durable enough. 

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
