### PR TITLE
Fix nesting

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           CLICKHOUSE_SKIP_USER_SETUP: 1
         options: >-
-          --health-cmd nc -zw3 localhost 8123
+          --health-cmd "nc -zw3 127.0.0.1 8123"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -140,7 +140,7 @@ jobs:
         env:
           CLICKHOUSE_SKIP_USER_SETUP: 1
         options: >-
-          --health-cmd nc -zw3 localhost 8123
+          --health-cmd "nc -zw3 127.0.0.1 8123"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,22 +33,22 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_PASSWORD: postgres
-          options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       clickhouse:
         image: clickhouse/clickhouse-server:25.11.5.8-alpine
         ports:
           - 8123:8123
         env:
           CLICKHOUSE_SKIP_USER_SETUP: 1
-          options: >-
-            --health-cmd nc -zw3 localhost 8124
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+        options: >-
+          --health-cmd nc -zw3 localhost 8123
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: useblacksmith/checkout@2d63ce5ba61677748c4e92f6eb578a8694226225 # v1.2.0
         with:
@@ -128,22 +128,22 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_PASSWORD: postgres
-          options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       clickhouse:
         image: clickhouse/clickhouse-server:25.11.5.8-alpine
         ports:
           - 8123:8123
         env:
           CLICKHOUSE_SKIP_USER_SETUP: 1
-          options: >-
-            --health-cmd nc -zw3 localhost 8124
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+        options: >-
+          --health-cmd nc -zw3 localhost 8123
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Changes

This PR fixes unintended nesting in CI scripts that stops healthcheck from working. 