### PR TITLE
Initialize currentEngagementURL to undefined, not location.href, refactor npm publish flow

### DIFF
--- a/.github/workflows/tracker-script-npm-release.yml
+++ b/.github/workflows/tracker-script-npm-release.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
+      id-token: write
     if: >-
       ${{ github.event.pull_request.merged == true && (
       contains(github.event.pull_request.labels.*.name, 'tracker-release: patch') ||
@@ -51,8 +52,6 @@ jobs:
       - name: Publish tracker script to NPM
         run: npm publish
         working-directory: tracker/npm_package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.TRACKER_RELEASE_NPM_TOKEN }}
 
       - name: Commit and Push changes
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321

--- a/.github/workflows/tracker.yml
+++ b/.github/workflows/tracker.yml
@@ -14,6 +14,10 @@ jobs:
   test:
     timeout-minutes: 15
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      # keep in sync with playwright package in /tracker folder
+      image: mcr.microsoft.com/playwright:v1.56.1-noble
+      options: --user 1001
     strategy:
       fail-fast: false
       matrix:
@@ -28,23 +32,6 @@ jobs:
           cache-dependency-path: tracker/package-lock.json
       - name: Install dependencies
         run: npm --prefix ./tracker ci
-      - name: Cache Playwright browsers
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ~/.cache/ms-playwright-github
-          key: playwright-${{ runner.os }}-${{ hashFiles('tracker/package-lock.json') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-      - name: Install Playwright system dependencies
-        working-directory: ./tracker
-        run: npx playwright install-deps
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        working-directory: ./tracker
-        run: npx playwright install
       - name: Run Playwright tests
         run: npm --prefix ./tracker test -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob
       - name: Upload blob report to GitHub Actions Artifacts

--- a/tracker/npm_package/CHANGELOG.md
+++ b/tracker/npm_package/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Fix issue with package resolution by adding "exports" field
+- Fix issue with accessing location object when not needed
 
 ## [0.4.5] - 2026-05-05
 

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "tracker_script_version": 35,
+  "tracker_script_version": 36,
   "type": "module",
   "scripts": {
     "lint": "eslint",

--- a/tracker/src/engagement.js
+++ b/tracker/src/engagement.js
@@ -9,7 +9,7 @@ import { sendRequest } from './networking'
 var listeningOnEngagement = false
 
 var currentEngagementIgnored
-var currentEngagementURL = location.href
+var currentEngagementURL
 var currentEngagementProps = {}
 var currentEngagementMaxScrollDepth = -1
 


### PR DESCRIPTION
Tracker package readme is supportive of SSR, but the package accesses browser-only `location` object on import, not on init / track. 

There isn't a reason to set this variable to location.href prior to `postPageviewTrack` being called, as we won't use it until engagements are registered, in which case, we will have set the URL from the payload.

This PR fixes it. Also, it
- updates tracker package publishing logic to follow https://docs.npmjs.com/trusted-publishers
- uses official playwright image to run tracker tests in

Picks up https://github.com/plausible/analytics/pull/6039, see those comments. 

TODO:
- [x] Configure NPM-side https://docs.npmjs.com/trusted-publishers#managing-trusted-publisher-configurations