### PR TITLE
Change source of nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 # platform specific, it makes sense to build it in the docker
 
 
+#### Node
+FROM node:24.17.0-alpine3.23@sha256:7c70d1235c0b4c2bc9eeed5393d19f1bbdde6885ba0d58ba62bb385d7b0f3ff1 AS nodejs
+
 #### Builder
 FROM hexpm/elixir:1.20.2-erlang-28.5.0.3-alpine-3.23.5@sha256:6f03034e254126f063959873d8d3b811ee92abaabab27b62c53982c4a1034e39 AS buildcontainer
 
@@ -21,7 +24,13 @@ RUN mkdir /app
 WORKDIR /app
 
 # install build dependencies
-RUN apk add --no-cache git "nodejs=24.17.0-r0" yarn npm python3 ca-certificates wget gnupg make gcc libc-dev brotli
+RUN apk add --no-cache git python3 ca-certificates wget gnupg make gcc libc-dev brotli
+
+# nodejs and npm come from the node image, apk can not pin a nodejs version reliably
+COPY --from=nodejs /usr/local/bin/node /usr/local/bin/node
+COPY --from=nodejs /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+  ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 COPY mix.exs ./
 COPY mix.lock ./


### PR DESCRIPTION
This PR updates the way Node.js and npm are installed in the `Dockerfile` to provide more reliable version pinning and improve build reproducibility. Instead of installing Node.js and npm via `apk`, the build now uses a dedicated Node.js image and copies the necessary binaries into the build container.

Fixes https://github.com/plausible/analytics/issues/6581


When https://github.com/dependabot/dependabot-core/pull/12988 is merged, we can move to `COPY --from=node:24.17.0-alpine3.23 /usr/local/bin/node /usr/local/bin/node`