### PR TITLE
Match repository URL for tracker package

### DIFF
--- a/tracker/npm_package/package.json
+++ b/tracker/npm_package/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/plausible/plausible.git"
+    "url": "git+https://github.com/plausible/analytics.git"
   },
   "keywords": [
     "web-analytics",


### PR DESCRIPTION
### Changes

Automatic publishing job fails with the following error. This PR matches the repository.url to what npm expects.

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@plausible-analytics%2ftracker - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/plausible/plausible.git", expected to match "https://github.com/plausible/analytics" from provenance
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-08-06T09_45_35_201Z-debug-0.log
Error: Process completed with exit code 1.
```