### PR TITLE
Increment version to 0.4.6

### DIFF
--- a/tracker/npm_package/CHANGELOG.md
+++ b/tracker/npm_package/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.4.6] - 2026-08-10
+
 - Fix issue with package resolution by adding "exports" field
 - Fix issue with accessing location object when not needed
 

--- a/tracker/npm_package/package.json
+++ b/tracker/npm_package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plausible-analytics/tracker",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Plausible Analytics official frontend tracking library",
   "scripts": {
     "test": "echo \"Error: Testing done in the tracker folder\" && exit 1"


### PR DESCRIPTION
### Changes

NPM publish job succeeded (and 0.4.6 is on npmjs.org), but automatic version increment commit failed due to unverified email. Looking into how to verify. 

Because there's no `publish package, commit version update` _transaction_, the master branch is now wrong about the package version. This commit updates it to match reality. 

```
Run EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321
Running in /home/runner/work/analytics/analytics
Add input parsed as single string, running 1 git add command.
> Using 'apata <apata@users.noreply.github.com>' as author.
> Using "Released tracker script version 0.4.6" as commit message.
Internal logs
Outputs
Error: Error: Pushing to https://github.com/plausible/analytics
remote: You must verify your email address.
remote: See https://github.com/settings/emails.
fatal: unable to access 'https://github.com/plausible/analytics/': The requested URL returned error: 403
```