### PR TITLE
fixes to the enterprise_over_limit internal alert

### DIFF
--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -150,10 +150,10 @@ defmodule Plausible.Teams.Billing do
 
   defp revise_pageview_usage(team, usage_mod) do
     case Plausible.Workers.CheckUsage.check_pageview_usage_two_cycles(team, usage_mod) do
-      {:over_limit, _} ->
+      {:over_limit, _, _} ->
         {:needs_to_upgrade, :grace_period_ended}
 
-      {:below_limit, _} ->
+      {:below_limit, _, _} ->
         Plausible.Teams.remove_grace_period(team)
         :no_upgrade_needed
     end

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -190,16 +190,29 @@ defmodule PlausibleWeb.Email do
     })
   end
 
-  def enterprise_over_limit_internal_email(user, pageview_usage, site_usage, site_allowance) do
+  def enterprise_over_limit_internal_email(
+        team,
+        recipient_emails,
+        pageview_usage,
+        pageview_limit,
+        pageview_over,
+        site_usage,
+        site_allowance,
+        site_over
+      ) do
     base_email(%{layout: nil})
     |> to("enterprise@plausible.io")
     |> tag("enterprise-over-limit")
-    |> subject("#{user.email} has outgrown their enterprise plan")
+    |> subject("#{team.name} has outgrown their enterprise plan")
     |> render("enterprise_over_limit_internal.html", %{
-      user: user,
+      team: team,
+      recipient_emails: recipient_emails,
       pageview_usage: pageview_usage,
+      pageview_limit: pageview_limit,
+      pageview_over: pageview_over,
       site_usage: site_usage,
-      site_allowance: site_allowance
+      site_allowance: site_allowance,
+      site_over: site_over
     })
   end
 

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -190,30 +190,14 @@ defmodule PlausibleWeb.Email do
     })
   end
 
-  def enterprise_over_limit_internal_email(
-        team,
-        recipient_emails,
-        pageview_usage,
-        pageview_limit,
-        pageview_over,
-        site_usage,
-        site_allowance,
-        site_over
-      ) do
+  def enterprise_over_limit_internal_email(team, assigns) do
+    assigns = Map.put(assigns, :team, team)
+
     base_email(%{layout: nil})
     |> to("enterprise@plausible.io")
     |> tag("enterprise-over-limit")
     |> subject("#{team.name} has outgrown their enterprise plan")
-    |> render("enterprise_over_limit_internal.html", %{
-      team: team,
-      recipient_emails: recipient_emails,
-      pageview_usage: pageview_usage,
-      pageview_limit: pageview_limit,
-      pageview_over: pageview_over,
-      site_usage: site_usage,
-      site_allowance: site_allowance,
-      site_over: site_over
-    })
+    |> render("enterprise_over_limit_internal.html", assigns)
   end
 
   def dashboard_locked(user, team, usage, suggested_volume) do

--- a/lib/plausible_web/templates/email/enterprise_over_limit_internal.html.heex
+++ b/lib/plausible_web/templates/email/enterprise_over_limit_internal.html.heex
@@ -1,14 +1,30 @@
 Automated notice about an enterprise account that has gone over their limits. <br /><br />
-Customer email: {@user.email}<br />
+Team: {@team.name} ({@team.identifier})<br />
+Customer email(s): {Enum.join(@recipient_emails, ", ")}<br />
+<% cs_url = customer_support_team_url(@team) %>
+<%= if cs_url do %>
+  <a href={cs_url}>View in Customer Support</a><br />
+<% end %>
+<br />
+<%= if @pageview_over do %>
+  <strong>Pageview limit exceeded.</strong><br />
+<% end %>
 Last billing cycle: {PlausibleWeb.TextHelpers.format_date_range(
   @pageview_usage.last_cycle.date_range
 )}<br />
 Last cycle pageview usage: {PlausibleWeb.AuthView.delimit_integer(
   @pageview_usage.last_cycle.total
-)} billable pageviews<br />
+)} / {format_pageview_limit(@pageview_limit)} billable pageviews<br />
 Penultimate billing cycle: {PlausibleWeb.TextHelpers.format_date_range(
   @pageview_usage.penultimate_cycle.date_range
 )}<br />
 Penultimate cycle pageview usage: {PlausibleWeb.AuthView.delimit_integer(
   @pageview_usage.penultimate_cycle.total
-)} billable pageviews<br /> Site usage: {@site_usage} / {@site_allowance} allowed sites<br />
+)} / {format_pageview_limit(@pageview_limit)} billable pageviews<br />
+<br />
+<%= if @site_over do %>
+  <strong>Site limit exceeded.</strong><br />
+<% end %>
+Site usage: {@site_usage} / {@site_allowance} allowed sites<br />
+<br />
+A manual lock grace period has been started for this account.

--- a/lib/plausible_web/templates/email/enterprise_over_limit_internal.html.heex
+++ b/lib/plausible_web/templates/email/enterprise_over_limit_internal.html.heex
@@ -1,30 +1,23 @@
 Automated notice about an enterprise account that has gone over their limits. <br /><br />
-Team: {@team.name} ({@team.identifier})<br />
-Customer email(s): {Enum.join(@recipient_emails, ", ")}<br />
-<% cs_url = customer_support_team_url(@team) %>
-<%= if cs_url do %>
-  <a href={cs_url}>View in Customer Support</a><br />
-<% end %>
+Team name: {@team.name}<br /> Team identifier: {@team.identifier}<br />
+Customer email(s): {Enum.join(@team_member_emails, ", ")}<br />
+<a href={customer_support_team_url(@team)}>View in Customer Support</a>
+<br /><br />
+<strong>
+  Monthly pageviews: {if(@exceeds_pageview_limit?, do: "EXCEEDED", else: "OK")}
+</strong>
+<br /><br /> Last billing cycle<br />
+{PlausibleWeb.TextHelpers.format_date_range(@pageview_usage.last_cycle.date_range)}<br />
+<strong>{PlausibleWeb.AuthView.delimit_integer(@pageview_usage.last_cycle.total)}</strong>
+/ {format_pageview_limit(@pageview_limit)}<br />
+<br /> Penultimate billing cycle<br />
+{PlausibleWeb.TextHelpers.format_date_range(@pageview_usage.penultimate_cycle.date_range)}<br />
+<strong>{PlausibleWeb.AuthView.delimit_integer(@pageview_usage.penultimate_cycle.total)}</strong>
+/ {format_pageview_limit(@pageview_limit)}<br />
 <br />
-<%= if @pageview_over do %>
-  <strong>Pageview limit exceeded.</strong><br />
-<% end %>
-Last billing cycle: {PlausibleWeb.TextHelpers.format_date_range(
-  @pageview_usage.last_cycle.date_range
-)}<br />
-Last cycle pageview usage: {PlausibleWeb.AuthView.delimit_integer(
-  @pageview_usage.last_cycle.total
-)} / {format_pageview_limit(@pageview_limit)} billable pageviews<br />
-Penultimate billing cycle: {PlausibleWeb.TextHelpers.format_date_range(
-  @pageview_usage.penultimate_cycle.date_range
-)}<br />
-Penultimate cycle pageview usage: {PlausibleWeb.AuthView.delimit_integer(
-  @pageview_usage.penultimate_cycle.total
-)} / {format_pageview_limit(@pageview_limit)} billable pageviews<br />
-<br />
-<%= if @site_over do %>
-  <strong>Site limit exceeded.</strong><br />
-<% end %>
-Site usage: {@site_usage} / {@site_allowance} allowed sites<br />
-<br />
-A manual lock grace period has been started for this account.
+<strong>
+  Sites: {if(@exceeds_site_limit?, do: "EXCEEDED", else: "OK")}
+</strong>
+<br /><br />
+{@site_usage} / {@site_limit} allowed sites<br />
+<br /> A manual lock grace period has been started for this account.

--- a/lib/plausible_web/views/email_view.ex
+++ b/lib/plausible_web/views/email_view.ex
@@ -11,6 +11,19 @@ defmodule PlausibleWeb.EmailView do
       "?__team=#{team.identifier}"
   end
 
+  on_ee do
+    def customer_support_team_url(team) do
+      PlausibleWeb.Router.Helpers.customer_support_team_url(PlausibleWeb.Endpoint, :show, team.id)
+    end
+  end
+
+  on_ce do
+    def customer_support_team_url(_team), do: nil
+  end
+
+  def format_pageview_limit(:unlimited), do: "unlimited"
+  def format_pageview_limit(limit), do: PlausibleWeb.AuthView.delimit_integer(limit)
+
   def greet_recipient(%{user: %{name: name}}) when is_binary(name) do
     "Hey #{String.split(name) |> List.first()},"
   end

--- a/lib/plausible_web/views/email_view.ex
+++ b/lib/plausible_web/views/email_view.ex
@@ -15,9 +15,7 @@ defmodule PlausibleWeb.EmailView do
     def customer_support_team_url(team) do
       PlausibleWeb.Router.Helpers.customer_support_team_url(PlausibleWeb.Endpoint, :show, team.id)
     end
-  end
-
-  on_ce do
+  else
     def customer_support_team_url(_team), do: nil
   end
 

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -88,15 +88,15 @@ defmodule Plausible.Workers.CheckUsage do
     usage = Teams.Billing.site_usage(subscriber)
 
     if Quota.within_limit?(usage, limit) do
-      {:below_limit, {usage, limit}}
+      {:below_limit, usage, limit}
     else
-      {:over_limit, {usage, limit}}
+      {:over_limit, usage, limit}
     end
   end
 
   def maybe_remove_grace_period(subscriber, usage_mod) do
     case check_pageview_usage_last_cycle(subscriber, usage_mod) do
-      {:below_limit, _} ->
+      {:below_limit, _, _} ->
         Plausible.Teams.remove_grace_period(subscriber)
         :ok
 
@@ -107,7 +107,7 @@ defmodule Plausible.Workers.CheckUsage do
 
   defp check_regular_subscriber(subscriber, usage_mod) do
     case check_pageview_usage_two_cycles(subscriber, usage_mod) do
-      {:over_limit, pageview_usage} ->
+      {:over_limit, pageview_usage, _} ->
         suggested_volume =
           Plausible.Billing.Plans.suggest_volume(subscriber, pageview_usage.last_cycle.total)
 
@@ -124,29 +124,30 @@ defmodule Plausible.Workers.CheckUsage do
   end
 
   def check_enterprise_subscriber(subscriber, usage_mod) do
-    {pageview_status, pageview_usage} = check_pageview_usage_two_cycles(subscriber, usage_mod)
-    {site_status, {site_usage, site_allowance}} = check_site_usage_for_enterprise(subscriber)
+    {pageview_status, pageview_usage, pageview_limit} =
+      check_pageview_usage_two_cycles(subscriber, usage_mod)
 
-    if pageview_status == :below_limit and site_status == :below_limit do
-      nil
-    else
-      recipient_emails =
+    {site_status, site_usage, site_limit} =
+      check_site_usage_for_enterprise(subscriber)
+
+    exceeds_pageview_limit? = pageview_status == :over_limit
+    exceeds_site_limit? = site_status == :over_limit
+
+    if exceeds_pageview_limit? or exceeds_site_limit? do
+      team_member_emails =
         (subscriber.owners ++ subscriber.billing_members)
         |> Enum.map(& &1.email)
         |> Enum.uniq()
 
-      pageview_limit = Teams.Billing.monthly_pageview_limit(subscriber.subscription)
-
-      PlausibleWeb.Email.enterprise_over_limit_internal_email(
-        subscriber,
-        recipient_emails,
-        pageview_usage,
-        pageview_limit,
-        pageview_status == :over_limit,
-        site_usage,
-        site_allowance,
-        site_status == :over_limit
-      )
+      PlausibleWeb.Email.enterprise_over_limit_internal_email(subscriber, %{
+        team_member_emails: team_member_emails,
+        exceeds_pageview_limit?: exceeds_pageview_limit?,
+        pageview_usage: pageview_usage,
+        pageview_limit: pageview_limit,
+        exceeds_site_limit?: exceeds_site_limit?,
+        site_usage: site_usage,
+        site_limit: site_limit
+      })
       |> Plausible.Mailer.send()
 
       Plausible.Teams.start_manual_lock_grace_period(subscriber)
@@ -158,9 +159,9 @@ defmodule Plausible.Workers.CheckUsage do
     limit = Teams.Billing.monthly_pageview_limit(subscriber.subscription)
 
     if Quota.exceeds_last_two_usage_cycles?(usage, limit) do
-      {:over_limit, usage}
+      {:over_limit, usage, limit}
     else
-      {:below_limit, usage}
+      {:below_limit, usage, limit}
     end
   end
 
@@ -169,9 +170,9 @@ defmodule Plausible.Workers.CheckUsage do
     limit = Teams.Billing.monthly_pageview_limit(subscriber.subscription)
 
     if :last_cycle in Quota.exceeded_cycles(usage, limit) do
-      {:over_limit, usage}
+      {:over_limit, usage, limit}
     else
-      {:below_limit, usage}
+      {:below_limit, usage, limit}
     end
   end
 end

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -1,4 +1,10 @@
 defmodule Plausible.Workers.CheckUsage do
+  @moduledoc """
+  A Cron job that runs every day at 14:00, checking whether active
+  subscribers have outgrown their plan limits, in which case, starts
+  grace periods and notifies via email.
+  """
+
   use Plausible.Repo
   use Oban.Worker, queue: :check_usage
   require Plausible.Billing.Subscription.Status

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -87,7 +87,7 @@ defmodule Plausible.Workers.CheckUsage do
 
     usage = Teams.Billing.site_usage(subscriber)
 
-    if Quota.below_limit?(usage, limit) do
+    if Quota.within_limit?(usage, limit) do
       {:below_limit, {usage, limit}}
     else
       {:over_limit, {usage, limit}}
@@ -124,25 +124,32 @@ defmodule Plausible.Workers.CheckUsage do
   end
 
   def check_enterprise_subscriber(subscriber, usage_mod) do
-    pageview_usage = check_pageview_usage_two_cycles(subscriber, usage_mod)
-    site_usage = check_site_usage_for_enterprise(subscriber)
+    {pageview_status, pageview_usage} = check_pageview_usage_two_cycles(subscriber, usage_mod)
+    {site_status, {site_usage, site_allowance}} = check_site_usage_for_enterprise(subscriber)
 
-    case {pageview_usage, site_usage} do
-      {{:below_limit, _}, {:below_limit, _}} ->
-        nil
+    if pageview_status == :below_limit and site_status == :below_limit do
+      nil
+    else
+      recipient_emails =
+        (subscriber.owners ++ subscriber.billing_members)
+        |> Enum.map(& &1.email)
+        |> Enum.uniq()
 
-      {{_, pageview_usage}, {_, {site_usage, site_allowance}}} ->
-        for owner <- subscriber.owners ++ subscriber.billing_members do
-          PlausibleWeb.Email.enterprise_over_limit_internal_email(
-            owner,
-            pageview_usage,
-            site_usage,
-            site_allowance
-          )
-          |> Plausible.Mailer.send()
-        end
+      pageview_limit = Teams.Billing.monthly_pageview_limit(subscriber.subscription)
 
-        Plausible.Teams.start_manual_lock_grace_period(subscriber)
+      PlausibleWeb.Email.enterprise_over_limit_internal_email(
+        subscriber,
+        recipient_emails,
+        pageview_usage,
+        pageview_limit,
+        pageview_status == :over_limit,
+        site_usage,
+        site_allowance,
+        site_status == :over_limit
+      )
+      |> Plausible.Mailer.send()
+
+      Plausible.Teams.start_manual_lock_grace_period(subscriber)
     end
   end
 

--- a/test/plausible_web/email_test.exs
+++ b/test/plausible_web/email_test.exs
@@ -264,9 +264,11 @@ defmodule PlausibleWeb.EmailTest do
     end
   end
 
-  describe "enterprise_over_limit_internal_email/4" do
+  describe "enterprise_over_limit_internal_email/8" do
     test "renders pageview usage by billing cycles + sites usage/limit" do
-      user = build(:user)
+      team = build(:team, name: "Acme Inc", identifier: Ecto.UUID.generate())
+      owner = build(:user, email: "owner@acme.test")
+      billing_member = build(:user, email: "billing@acme.test")
       penultimate_cycle = Date.range(~D[2023-03-01], ~D[2023-03-31])
       last_cycle = Date.range(~D[2023-04-01], ~D[2023-04-30])
 
@@ -276,20 +278,63 @@ defmodule PlausibleWeb.EmailTest do
       }
 
       %{html_body: html_body, subject: subject} =
-        PlausibleWeb.Email.enterprise_over_limit_internal_email(user, pageview_usage, 80, 50)
+        PlausibleWeb.Email.enterprise_over_limit_internal_email(
+          team,
+          [owner.email, billing_member.email],
+          pageview_usage,
+          100_000_000,
+          true,
+          80,
+          50,
+          true
+        )
 
-      assert subject == "#{user.email} has outgrown their enterprise plan"
+      assert subject == "Acme Inc has outgrown their enterprise plan"
+
+      assert html_body =~ "Team: Acme Inc (#{team.identifier})"
+      assert html_body =~ "Customer email(s): owner@acme.test, billing@acme.test"
+      assert html_body =~ "Pageview limit exceeded."
+      assert html_body =~ "Site limit exceeded."
 
       assert html_body =~
                "Last billing cycle: #{PlausibleWeb.TextHelpers.format_date_range(last_cycle)}"
 
-      assert html_body =~ "Last cycle pageview usage: 100,222,999 billable pageviews"
+      assert html_body =~ "Last cycle pageview usage: 100,222,999 / 100,000,000 billable pageviews"
 
       assert html_body =~
                "Penultimate billing cycle: #{PlausibleWeb.TextHelpers.format_date_range(penultimate_cycle)}"
 
-      assert html_body =~ "Penultimate cycle pageview usage: 100,141,888 billable pageviews"
+      assert html_body =~
+               "Penultimate cycle pageview usage: 100,141,888 / 100,000,000 billable pageviews"
+
       assert html_body =~ "Site usage: 80 / 50 allowed sites"
+    end
+
+    test "renders :unlimited pageview limit" do
+      team = build(:team, name: "Acme Inc", identifier: Ecto.UUID.generate())
+      penultimate_cycle = Date.range(~D[2023-03-01], ~D[2023-03-31])
+      last_cycle = Date.range(~D[2023-04-01], ~D[2023-04-30])
+
+      pageview_usage = %{
+        penultimate_cycle: %{date_range: penultimate_cycle, total: 100},
+        last_cycle: %{date_range: last_cycle, total: 200}
+      }
+
+      %{html_body: html_body} =
+        PlausibleWeb.Email.enterprise_over_limit_internal_email(
+          team,
+          ["owner@acme.test"],
+          pageview_usage,
+          :unlimited,
+          false,
+          80,
+          50,
+          true
+        )
+
+      assert html_body =~ "Last cycle pageview usage: 200 / unlimited billable pageviews"
+      refute html_body =~ "Pageview limit exceeded."
+      assert html_body =~ "Site limit exceeded."
     end
   end
 

--- a/test/plausible_web/email_test.exs
+++ b/test/plausible_web/email_test.exs
@@ -264,54 +264,50 @@ defmodule PlausibleWeb.EmailTest do
     end
   end
 
-  describe "enterprise_over_limit_internal_email/8" do
+  describe "enterprise_over_limit_internal_email/2" do
     test "renders pageview usage by billing cycles + sites usage/limit" do
-      team = build(:team, name: "Acme Inc", identifier: Ecto.UUID.generate())
+      team = insert(:team, name: "Acme Inc", identifier: Ecto.UUID.generate())
       owner = build(:user, email: "owner@acme.test")
       billing_member = build(:user, email: "billing@acme.test")
       penultimate_cycle = Date.range(~D[2023-03-01], ~D[2023-03-31])
       last_cycle = Date.range(~D[2023-04-01], ~D[2023-04-30])
 
       pageview_usage = %{
-        penultimate_cycle: %{date_range: penultimate_cycle, total: 100_141_888},
-        last_cycle: %{date_range: last_cycle, total: 100_222_999}
+        penultimate_cycle: %{date_range: penultimate_cycle, total: 123_141_888},
+        last_cycle: %{date_range: last_cycle, total: 123_222_999}
       }
 
       %{html_body: html_body, subject: subject} =
-        PlausibleWeb.Email.enterprise_over_limit_internal_email(
-          team,
-          [owner.email, billing_member.email],
-          pageview_usage,
-          100_000_000,
-          true,
-          80,
-          50,
-          true
-        )
+        PlausibleWeb.Email.enterprise_over_limit_internal_email(team, %{
+          team_member_emails: [owner.email, billing_member.email],
+          exceeds_pageview_limit?: true,
+          pageview_usage: pageview_usage,
+          pageview_limit: 100_000_000,
+          exceeds_site_limit?: false,
+          site_usage: 50,
+          site_limit: 50
+        })
 
       assert subject == "Acme Inc has outgrown their enterprise plan"
 
-      assert html_body =~ "Team: Acme Inc (#{team.identifier})"
+      assert html_body =~ "Team name: Acme Inc"
+      assert html_body =~ "Team identifier: #{team.identifier}"
       assert html_body =~ "Customer email(s): owner@acme.test, billing@acme.test"
-      assert html_body =~ "Pageview limit exceeded."
-      assert html_body =~ "Site limit exceeded."
+      assert html_body =~ "Monthly pageviews: EXCEEDED"
+      assert html_body =~ "Sites: OK"
 
-      assert html_body =~
-               "Last billing cycle: #{PlausibleWeb.TextHelpers.format_date_range(last_cycle)}"
+      assert html_body =~ PlausibleWeb.TextHelpers.format_date_range(last_cycle)
+      assert html_body =~ "123,222,999"
+      assert html_body =~ "/ 100,000,000"
 
-      assert html_body =~ "Last cycle pageview usage: 100,222,999 / 100,000,000 billable pageviews"
+      assert html_body =~ PlausibleWeb.TextHelpers.format_date_range(penultimate_cycle)
+      assert html_body =~ "123,141,888"
 
-      assert html_body =~
-               "Penultimate billing cycle: #{PlausibleWeb.TextHelpers.format_date_range(penultimate_cycle)}"
-
-      assert html_body =~
-               "Penultimate cycle pageview usage: 100,141,888 / 100,000,000 billable pageviews"
-
-      assert html_body =~ "Site usage: 80 / 50 allowed sites"
+      assert html_body =~ "50 / 50 allowed sites"
     end
 
     test "renders :unlimited pageview limit" do
-      team = build(:team, name: "Acme Inc", identifier: Ecto.UUID.generate())
+      team = insert(:team, name: "Acme Inc", identifier: Ecto.UUID.generate())
       penultimate_cycle = Date.range(~D[2023-03-01], ~D[2023-03-31])
       last_cycle = Date.range(~D[2023-04-01], ~D[2023-04-30])
 
@@ -321,20 +317,20 @@ defmodule PlausibleWeb.EmailTest do
       }
 
       %{html_body: html_body} =
-        PlausibleWeb.Email.enterprise_over_limit_internal_email(
-          team,
-          ["owner@acme.test"],
-          pageview_usage,
-          :unlimited,
-          false,
-          80,
-          50,
-          true
-        )
+        PlausibleWeb.Email.enterprise_over_limit_internal_email(team, %{
+          team_member_emails: ["owner@acme.test"],
+          exceeds_pageview_limit?: false,
+          pageview_usage: pageview_usage,
+          pageview_limit: :unlimited,
+          exceeds_site_limit?: true,
+          site_usage: 51,
+          site_limit: 50
+        })
 
-      assert html_body =~ "Last cycle pageview usage: 200 / unlimited billable pageviews"
-      refute html_body =~ "Pageview limit exceeded."
-      assert html_body =~ "Site limit exceeded."
+      assert html_body =~ "200"
+      assert html_body =~ "/ unlimited"
+      assert html_body =~ "Monthly pageviews: OK"
+      assert html_body =~ "Sites: EXCEEDED"
     end
   end
 

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -385,7 +385,7 @@ defmodule Plausible.Workers.CheckUsageTest do
         assert Repo.reload(team_of(user)).grace_period.id == existing_grace_period.id
       end
 
-      test "checks billable pageview usage for enterprise customer, sends usage information to enterprise@plausible.io",
+      test "pageview limit exceeded -> sends internal email and starts manual lock grace period",
            %{
              user: user
            } do
@@ -413,6 +413,11 @@ defmodule Plausible.Workers.CheckUsageTest do
           to: [{nil, "enterprise@plausible.io"}],
           subject: "#{team_of(user).name} has outgrown their enterprise plan"
         )
+
+        assert user
+               |> team_of()
+               |> Repo.reload()
+               |> Plausible.Teams.GracePeriod.manual_lock_active?()
       end
 
       test "sends a single alert to enterprise@plausible.io even when the team has multiple owners/billing members",
@@ -484,19 +489,10 @@ defmodule Plausible.Workers.CheckUsageTest do
         )
       end
 
-      test "checks site limit for enterprise customer, sends usage information to enterprise@plausible.io",
+      test "site limit exceeded -> sends internal email and starts manual lock grace period",
            %{
              user: user
            } do
-        usage_stub =
-          Plausible.Teams.Billing
-          |> stub(:monthly_pageview_usage, fn _user ->
-            %{
-              penultimate_cycle: %{date_range: @date_range, total: 1},
-              last_cycle: %{date_range: @date_range, total: 1}
-            }
-          end)
-
         subscribe_to_enterprise_plan(user,
           site_limit: 2,
           subscription: [
@@ -507,29 +503,26 @@ defmodule Plausible.Workers.CheckUsageTest do
 
         new_site(owner: user)
         new_site(owner: user)
-        new_site(owner: user)
 
-        CheckUsage.perform(nil, usage_stub)
+        team = team_of(user)
+
+        assert Plausible.Teams.Billing.site_usage(team) == 3
+
+        CheckUsage.perform(nil)
 
         assert_email_delivered_with(
           to: [{nil, "enterprise@plausible.io"}],
-          subject: "#{team_of(user).name} has outgrown their enterprise plan"
+          subject: "#{team.name} has outgrown their enterprise plan",
+          html_body: ~r/3 \/ 2/
         )
+
+        assert team |> Repo.reload() |> Plausible.Teams.GracePeriod.manual_lock_active?()
       end
 
       test "does not alert or start a grace period when site usage is exactly at the site limit",
            %{
              user: user
            } do
-        usage_stub =
-          Plausible.Teams.Billing
-          |> stub(:monthly_pageview_usage, fn _user ->
-            %{
-              penultimate_cycle: %{date_range: @date_range, total: 1},
-              last_cycle: %{date_range: @date_range, total: 1}
-            }
-          end)
-
         subscribe_to_enterprise_plan(user,
           site_limit: 2,
           subscription: [
@@ -539,70 +532,15 @@ defmodule Plausible.Workers.CheckUsageTest do
         )
 
         new_site(owner: user)
-        new_site(owner: user)
 
-        CheckUsage.perform(nil, usage_stub)
+        team = team_of(user)
+
+        assert Plausible.Teams.Billing.site_usage(team) == 2
+
+        CheckUsage.perform(nil)
 
         assert_no_emails_delivered()
-        assert Repo.reload(team_of(user)).grace_period == nil
-      end
-
-      test "alerts and starts a grace period as soon as site usage is one site above the site limit",
-           %{
-             user: user
-           } do
-        usage_stub =
-          Plausible.Teams.Billing
-          |> stub(:monthly_pageview_usage, fn _user ->
-            %{
-              penultimate_cycle: %{date_range: @date_range, total: 1},
-              last_cycle: %{date_range: @date_range, total: 1}
-            }
-          end)
-
-        subscribe_to_enterprise_plan(user,
-          site_limit: 2,
-          subscription: [
-            last_bill_date: Date.shift(Date.utc_today(), day: -1),
-            status: unquote(status)
-          ]
-        )
-
-        new_site(owner: user)
-        new_site(owner: user)
-        new_site(owner: user)
-
-        CheckUsage.perform(nil, usage_stub)
-
-        assert_email_delivered_with(
-          to: [{nil, "enterprise@plausible.io"}],
-          subject: "#{team_of(user).name} has outgrown their enterprise plan"
-        )
-
-        assert user |> team_of() |> Repo.reload() |> Plausible.Teams.GracePeriod.active?()
-      end
-
-      test "starts grace period when plan is outgrown", %{user: user} do
-        usage_stub =
-          Plausible.Teams.Billing
-          |> stub(:monthly_pageview_usage, fn _user ->
-            %{
-              penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
-              last_cycle: %{date_range: @date_range, total: 1_100_000}
-            }
-          end)
-
-        subscribe_to_enterprise_plan(
-          user,
-          monthly_pageview_limit: 1_000_000,
-          subscription: [
-            last_bill_date: Date.shift(Date.utc_today(), day: -1),
-            status: unquote(status)
-          ]
-        )
-
-        CheckUsage.perform(nil, usage_stub)
-        assert user |> team_of() |> Repo.reload() |> Plausible.Teams.GracePeriod.active?()
+        assert Repo.reload(team).grace_period == nil
       end
     end
   end

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -411,8 +411,45 @@ defmodule Plausible.Workers.CheckUsageTest do
 
         assert_email_delivered_with(
           to: [{nil, "enterprise@plausible.io"}],
-          subject: "#{user.email} has outgrown their enterprise plan"
+          subject: "#{team_of(user).name} has outgrown their enterprise plan"
         )
+      end
+
+      test "sends a single alert to enterprise@plausible.io even when the team has multiple owners/billing members",
+           %{
+             user: user
+           } do
+        usage_stub =
+          Plausible.Teams.Billing
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 1_100_000},
+              last_cycle: %{date_range: @date_range, total: 1_100_000}
+            }
+          end)
+
+        subscribe_to_enterprise_plan(
+          user,
+          monthly_pageview_limit: 1_000_000,
+          subscription: [
+            last_bill_date: Date.shift(Date.utc_today(), day: -1),
+            status: unquote(status)
+          ]
+        )
+
+        team = team_of(user)
+        billing_member = Plausible.Teams.Test.new_user()
+        Plausible.Teams.Test.add_member(team, user: billing_member, role: :billing)
+
+        CheckUsage.perform(nil, usage_stub)
+
+        assert_email_delivered_with(
+          to: [{nil, "enterprise@plausible.io"}],
+          subject: "#{team.name} has outgrown their enterprise plan",
+          html_body: ~r/#{Regex.escape(user.email)}.*#{Regex.escape(billing_member.email)}/s
+        )
+
+        assert_no_emails_delivered()
       end
 
       test "will only check usage if enterprise plan matches subscription's paddle plan id",
@@ -443,7 +480,7 @@ defmodule Plausible.Workers.CheckUsageTest do
 
         refute_email_delivered_with(
           to: [{nil, "enterprise@plausible.io"}],
-          subject: "#{user.email} has outgrown their enterprise plan"
+          subject: "#{team_of(user).name} has outgrown their enterprise plan"
         )
       end
 
@@ -476,8 +513,73 @@ defmodule Plausible.Workers.CheckUsageTest do
 
         assert_email_delivered_with(
           to: [{nil, "enterprise@plausible.io"}],
-          subject: "#{user.email} has outgrown their enterprise plan"
+          subject: "#{team_of(user).name} has outgrown their enterprise plan"
         )
+      end
+
+      test "does not alert or start a grace period when site usage is exactly at the site limit",
+           %{
+             user: user
+           } do
+        usage_stub =
+          Plausible.Teams.Billing
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 1},
+              last_cycle: %{date_range: @date_range, total: 1}
+            }
+          end)
+
+        subscribe_to_enterprise_plan(user,
+          site_limit: 2,
+          subscription: [
+            last_bill_date: Date.shift(Date.utc_today(), day: -1),
+            status: unquote(status)
+          ]
+        )
+
+        new_site(owner: user)
+        new_site(owner: user)
+
+        CheckUsage.perform(nil, usage_stub)
+
+        assert_no_emails_delivered()
+        assert Repo.reload(team_of(user)).grace_period == nil
+      end
+
+      test "alerts and starts a grace period as soon as site usage is one site above the site limit",
+           %{
+             user: user
+           } do
+        usage_stub =
+          Plausible.Teams.Billing
+          |> stub(:monthly_pageview_usage, fn _user ->
+            %{
+              penultimate_cycle: %{date_range: @date_range, total: 1},
+              last_cycle: %{date_range: @date_range, total: 1}
+            }
+          end)
+
+        subscribe_to_enterprise_plan(user,
+          site_limit: 2,
+          subscription: [
+            last_bill_date: Date.shift(Date.utc_today(), day: -1),
+            status: unquote(status)
+          ]
+        )
+
+        new_site(owner: user)
+        new_site(owner: user)
+        new_site(owner: user)
+
+        CheckUsage.perform(nil, usage_stub)
+
+        assert_email_delivered_with(
+          to: [{nil, "enterprise@plausible.io"}],
+          subject: "#{team_of(user).name} has outgrown their enterprise plan"
+        )
+
+        assert user |> team_of() |> Repo.reload() |> Plausible.Teams.GracePeriod.active?()
       end
 
       test "starts grace period when plan is outgrown", %{user: user} do


### PR DESCRIPTION
it's been a while since we touched this alert so I've taken the liberty to get some ai help to bring it up to date with teams, CRM etc. main changes:

- do not send multiple alerts when the same team goes over the limit (right now it sends one email per team owner)
- do not send the alert when someone hits the site limit, only when someone goes above the site limit (right now it sends the alerts and starts grace period when someone hits the limit)
- show what's over the limit and add a link to the team to make it easier to handle the case
