### PR TITLE
Fix workers dealing with enterprise plans

### DIFF
--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -5,11 +5,11 @@ defmodule Plausible.Teams.Billing do
 
   import Ecto.Query
 
-  alias Plausible.Billing.EnterprisePlan
   alias Plausible.Billing.Subscription
   alias Plausible.Billing.Subscriptions
   alias Plausible.Repo
   alias Plausible.Teams
+  alias Plausible.Workers.CheckUsage
 
   alias Plausible.Billing.{EnterprisePlan, Feature, Plan, Plans, Quota}
   alias Plausible.Billing.Feature.{Goals, Props, SitesAPI, StatsAPI, SharedLinks, SSO}
@@ -141,23 +141,29 @@ defmodule Plausible.Teams.Billing do
         {:needs_to_upgrade, :no_active_trial_or_subscription}
 
       Teams.GracePeriod.expired?(team) ->
-        revise_pageview_usage(team, usage_mod)
+        revise_usage(team, usage_mod)
 
       true ->
         :no_upgrade_needed
     end
   end
 
-  defp revise_pageview_usage(team, usage_mod) do
-    case Plausible.Workers.CheckUsage.check_pageview_usage_two_cycles(team, usage_mod) do
-      {:over_limit, _, _} ->
-        {:needs_to_upgrade, :grace_period_ended}
-
-      {:below_limit, _, _} ->
-        Plausible.Teams.remove_grace_period(team)
-        :no_upgrade_needed
+  defp revise_usage(team, usage_mod) do
+    with {:below_limit, _, _} <- CheckUsage.check_pageview_usage_two_cycles(team, usage_mod),
+         :below_limit <- revise_site_usage(team) do
+      Plausible.Teams.remove_grace_period(team)
+      :no_upgrade_needed
+    else
+      _ -> {:needs_to_upgrade, :grace_period_ended}
     end
   end
+
+  defp revise_site_usage(%Teams.Team{enterprise_plan: %EnterprisePlan{}} = team) do
+    {site_usage_status, _, _} = CheckUsage.check_site_usage_for_enterprise(team)
+    site_usage_status
+  end
+
+  defp revise_site_usage(_), do: :below_limit
 
   @doc """
   Enterprise plans are always allowed to add more sites (even when

--- a/lib/plausible/teams/billing.ex
+++ b/lib/plausible/teams/billing.ex
@@ -141,16 +141,16 @@ defmodule Plausible.Teams.Billing do
         {:needs_to_upgrade, :no_active_trial_or_subscription}
 
       Teams.GracePeriod.expired?(team) ->
-        revise_usage(team, usage_mod)
+        revise_usage_for_grace_period_ended(team, usage_mod)
 
       true ->
         :no_upgrade_needed
     end
   end
 
-  defp revise_usage(team, usage_mod) do
+  defp revise_usage_for_grace_period_ended(team, usage_mod) do
     with {:below_limit, _, _} <- CheckUsage.check_pageview_usage_two_cycles(team, usage_mod),
-         :below_limit <- revise_site_usage(team) do
+         :below_limit <- maybe_check_site_usage(team) do
       Plausible.Teams.remove_grace_period(team)
       :no_upgrade_needed
     else
@@ -158,12 +158,13 @@ defmodule Plausible.Teams.Billing do
     end
   end
 
-  defp revise_site_usage(%Teams.Team{enterprise_plan: %EnterprisePlan{}} = team) do
+  defp maybe_check_site_usage(%Teams.Team{enterprise_plan: %EnterprisePlan{}} = team) do
     {site_usage_status, _, _} = CheckUsage.check_site_usage_for_enterprise(team)
     site_usage_status
   end
 
-  defp revise_site_usage(_), do: :below_limit
+  # Can skip this check for normal plans where site limit can't be exceeded
+  defp maybe_check_site_usage(_team_with_normal_plan), do: :below_limit
 
   @doc """
   Enterprise plans are always allowed to add more sites (even when

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -88,7 +88,7 @@ defmodule Plausible.Workers.CheckUsage do
     :ok
   end
 
-  defp check_site_usage_for_enterprise(subscriber) do
+  def check_site_usage_for_enterprise(subscriber) do
     limit = subscriber.enterprise_plan.site_limit
 
     usage = Teams.Billing.site_usage(subscriber)

--- a/lib/workers/check_usage.ex
+++ b/lib/workers/check_usage.ex
@@ -89,7 +89,7 @@ defmodule Plausible.Workers.CheckUsage do
   end
 
   def check_site_usage_for_enterprise(subscriber) do
-    limit = subscriber.enterprise_plan.site_limit
+    limit = Teams.Billing.site_limit(subscriber)
 
     usage = Teams.Billing.site_usage(subscriber)
 

--- a/lib/workers/lock_sites.ex
+++ b/lib/workers/lock_sites.ex
@@ -1,4 +1,6 @@
 defmodule Plausible.Workers.LockSites do
+  @moduledoc false
+
   use Plausible.Repo
   use Oban.Worker, queue: :lock_sites
 

--- a/lib/workers/lock_sites.ex
+++ b/lib/workers/lock_sites.ex
@@ -2,6 +2,7 @@ defmodule Plausible.Workers.LockSites do
   use Plausible.Repo
   use Oban.Worker, queue: :lock_sites
 
+  alias Plausible.Billing.EnterprisePlan
   alias Plausible.Teams
 
   @impl Oban.Worker
@@ -12,7 +13,9 @@ defmodule Plausible.Workers.LockSites do
           as: :team,
           left_lateral_join: s in subquery(Teams.last_subscription_join_query()),
           on: true,
-          preload: [subscription: s]
+          left_join: ep in EnterprisePlan,
+          on: ep.team_id == t.id and ep.paddle_plan_id == s.paddle_plan_id,
+          preload: [subscription: s, enterprise_plan: ep]
       )
 
     for team <- teams do

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -542,6 +542,28 @@ defmodule Plausible.Workers.CheckUsageTest do
         assert_no_emails_delivered()
         assert Repo.reload(team).grace_period == nil
       end
+
+      test "respects grandfathered unlimited site limit" do
+        user = new_user(team: [inserted_at: ~N[2021-05-04 23:59:59]])
+
+        subscribe_to_enterprise_plan(user,
+          site_limit: 2,
+          subscription: [
+            last_bill_date: Date.shift(Date.utc_today(), day: -1),
+            status: unquote(status)
+          ]
+        )
+
+        new_site(owner: user)
+        new_site(owner: user)
+        new_site(owner: user)
+
+        CheckUsage.perform(nil)
+
+        assert_no_emails_delivered()
+
+        assert Repo.reload(team_of(user)).grace_period == nil
+      end
     end
   end
 

--- a/test/workers/check_usage_test.exs
+++ b/test/workers/check_usage_test.exs
@@ -7,7 +7,8 @@ defmodule Plausible.Workers.CheckUsageTest do
 
   require Plausible.Billing.Subscription.Status
 
-  setup [:create_user, :create_site]
+  @moduletag :ee_only
+
   @paddle_id_10k "558018"
   @date_range Date.range(Date.utc_today(), Date.utc_today())
 
@@ -16,6 +17,8 @@ defmodule Plausible.Workers.CheckUsageTest do
     Plausible.Billing.Subscription.Status.past_due(),
     Plausible.Billing.Subscription.Status.deleted()
   ]
+
+  setup [:create_user, :create_site]
 
   test "ignores user without subscription" do
     CheckUsage.perform(nil)
@@ -271,7 +274,8 @@ defmodule Plausible.Workers.CheckUsageTest do
       end
 
       test "skips checking users who already have a grace period", %{user: user} do
-        %{grace_period: existing_grace_period} = Plausible.Teams.start_grace_period(team_of(user))
+        %{grace_period: existing_grace_period} =
+          Plausible.Teams.start_grace_period(team_of(user))
 
         usage_stub =
           Plausible.Teams.Billing

--- a/test/workers/lock_sites_test.exs
+++ b/test/workers/lock_sites_test.exs
@@ -3,6 +3,7 @@ defmodule Plausible.Workers.LockSitesTest do
   require Plausible.Billing.Subscription.Status
   alias Plausible.Workers.LockSites
   alias Plausible.Billing.Subscription
+  alias Plausible.Teams
 
   @moduletag :ee_only
 
@@ -12,11 +13,36 @@ defmodule Plausible.Workers.LockSitesTest do
 
     user
     |> team_of()
-    |> Plausible.Teams.start_manual_lock_grace_period()
+    |> Teams.start_manual_lock_grace_period()
 
     LockSites.perform(nil)
 
     refute Repo.reload!(site.team).locked
+  end
+
+  test "does not unlock a manually locked enterprise team" do
+    user = new_user()
+    site = new_site(owner: user)
+    team = team_of(user)
+
+    subscribe_to_enterprise_plan(user, site_limit: 1)
+
+    new_site(owner: user)
+    assert Teams.Billing.site_usage(team) == 2
+
+    team =
+      team
+      |> Teams.start_manual_lock_grace_period()
+      |> Teams.end_grace_period()
+
+    Plausible.Billing.SiteLocker.set_lock_status_for(team, true)
+
+    LockSites.perform(nil)
+
+    team = Repo.reload!(site.team)
+    assert team.locked
+    assert team.grace_period
+    assert team.grace_period.manual_lock
   end
 
   test "does not lock trial user's site" do


### PR DESCRIPTION
### Changes

Two commits, two independent bug fixes:

1. `LockSites` unlocking manually locked enterprise teams

Currently, the `LockSites` worker automatically unlocks sites that have reduced their pageview usage and fallen back within their plan limits. But there's no exception for enterprise plans, where sites limit should matter too. Currently, if an enterprise team gets manually locked (due to not upgrading to a new enterprise plan we've created for them), the SiteLocker undoes that the next midnight, on the condition that their pageviews are OK. Fix: check the sites usage too.

2. `CheckUsage.check_site_usage_for_enterprise` not respecting grandfathered "unlimited" sites

Any accounts created before `2021-05-05` have unlimited sites, but `CheckUsage` does not account for that. I don't think it has ever happened before, but currently we'd get an internal notification saying "this team has outgrown their enterprise plan... sites: 110 / 100", even though they'd see that they have unlimited sites in their team/account settings. Fix: use the global `Plausible.Teams.Billing.site_limit` function to determine the site limit for the team.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
