### PR TITLE
App layout refactor: Phase 1

### DIFF
--- a/lib/plausible_web/components/layouts.ex
+++ b/lib/plausible_web/components/layouts.ex
@@ -1,0 +1,44 @@
+defmodule PlausibleWeb.Layouts do
+  @moduledoc false
+
+  use Phoenix.Component
+
+  alias PlausibleWeb.Router.Helpers, as: Routes
+
+  def legacy(assigns) do
+    ~H"""
+    <div class={["flex flex-col", if(!assigns[:embedded], do: "h-full")]}>
+      <%= if !assigns[:embedded] && assigns[:flash] do %>
+        {PlausibleWeb.LayoutView.render("_flash.html", assigns)}
+      <% end %>
+
+      <%= if !assigns[:embedded] && !assigns[:hide_header?] do %>
+        {PlausibleWeb.LayoutView.render("_header.html", assigns)}
+
+        <%= if !assigns[:disable_global_notices?] do %>
+          {PlausibleWeb.LayoutView.render("_notice.html", assigns)}
+        <% end %>
+      <% end %>
+
+      <main class="flex-1 flex flex-col">
+        {Map.get(assigns, :inner_layout) || @inner_content}
+      </main>
+
+      <%= if assigns[:embedded] do %>
+        <div data-iframe-height></div>
+        <script type="text/javascript" src={Routes.static_path(@conn, "/js/embed.content.js")}>
+        </script>
+      <% end %>
+      <%= if !assigns[:hide_footer?] do %>
+        {PlausibleWeb.LayoutView.render("_footer.html", assigns)}
+      <% end %>
+      <script type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}>
+      </script>
+      <%= if assigns[:load_dashboard_js] do %>
+        <script type="text/javascript" src={Routes.static_path(@conn, "/js/dashboard.js")}>
+        </script>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/plausible_web/templates/layout/app.html.heex
+++ b/lib/plausible_web/templates/layout/app.html.heex
@@ -29,44 +29,9 @@
     {render("_tracking.html", assigns)}
   </head>
   <body
-    class={[
-      "flex flex-col",
-      assigns[:bg_class] || "bg-gray-50 dark:bg-gray-950",
-      if !assigns[:embedded] do
-        "h-full"
-      end
-    ]}
+    class={assigns[:bg_class] || "bg-gray-50 dark:bg-gray-950"}
     style={if assigns[:background], do: "background-color: #{assigns[:background]}"}
   >
-    <%= if !assigns[:embedded] && assigns[:flash] do %>
-      {render("_flash.html", assigns)}
-    <% end %>
-
-    <%= if !assigns[:embedded] && !assigns[:hide_header?] do %>
-      {render("_header.html", assigns)}
-
-      <%= if !assigns[:disable_global_notices?] do %>
-        {render("_notice.html", assigns)}
-      <% end %>
-    <% end %>
-
-    <main class="flex-1 flex flex-col">
-      {Map.get(assigns, :inner_layout) || @inner_content}
-    </main>
-
-    <%= if assigns[:embedded] do %>
-      <div data-iframe-height></div>
-      <script type="text/javascript" src={Routes.static_path(@conn, "/js/embed.content.js")}>
-      </script>
-    <% end %>
-    <%= if !assigns[:hide_footer?] do %>
-      {render("_footer.html", assigns)}
-    <% end %>
-    <script type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}>
-    </script>
-    <%= if assigns[:load_dashboard_js] do %>
-      <script type="text/javascript" src={Routes.static_path(@conn, "/js/dashboard.js")}>
-      </script>
-    <% end %>
+    <Layouts.legacy {assigns} />
   </body>
 </html>

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -171,7 +171,7 @@ defmodule PlausibleWeb.LayoutView do
   def team_switcher(assigns) do
     teams = assigns[:teams]
 
-    if teams && length(teams) > 0 do
+    if teams && teams != [] do
       current_team = assigns[:current_team]
       my_team = assigns[:my_team]
       current_included? = current_team && Enum.any?(teams, &(&1.id == current_team.id))

--- a/lib/plausible_web/views/layout_view.ex
+++ b/lib/plausible_web/views/layout_view.ex
@@ -5,6 +5,7 @@ defmodule PlausibleWeb.LayoutView do
   alias Plausible.Teams
   alias PlausibleWeb.Components.Billing.Notice
   alias PlausibleWeb.Components.Layout
+  alias PlausibleWeb.Layouts
 
   require Plausible.Billing
 


### PR DESCRIPTION
### Intro

Kick off a gradual modernization of our app's layouts, moving away from the old/classic Phoenix router/controller-assigned `.heex` layouts towards easily nestable function components with explicitly typed assigns. Rather than one large re-write, we'll end up in a state where:

1. Every existing template continues to work with a `Layout.legacy` component (i.e. current `app.html.heex`, but delegating to a new `<.app>` layout under the hood)
2. It's possible to completely opt out from that legacy layout and use `<.app>` layout directly, feeding it whatever assigns necessary, straight from the template context

### Why do it?

Currently, it's the monolith root template that renders every part of the app "chrome", i.e. the visual UI (including logo, footer, account dropdown menu, notices, etc) surrounding the page main content. Whether or not a chrome element is supposed to render or not, is currently being controlled by `conn.assigns` (e.g. `disable_global_notices?: true`). The downsides:

* A LiveView cannot own its layout -- there needs to be a server round-trip so that we could read `conn` again.
* Currently in order to define a distinct app chrome (such as `auth` or `onboarding` that were recently introduced), one would have to create a custom plug just to keep assigns like `disable_global_notices?: true, hide_header?: true, ...` in sync between LiveViews and controller-rendered pages.
* Impossible to opt out of shared app chrome without also sacrificing `<html>` / `<head>` document shell.
* Difficult to follow where a specific layout element is set in code (router? controller? on_mount? template itself?)

Using function components means every template itself is responsible for all the visual content that it renders. This also allows LiveViews to own their own layouts by simply wrapping what's rendered in `<.app {assigns} >`. And looking at any template, the whole page content is clear in an instant, without having to go through the whole router -> controller -> view pipeline to find out if/where some layout gets assigned.

### Phases

**Phase 1** [This PR] — Turn the root layout's body into a function component
**[Phase 2](https://github.com/plausible/analytics/pull/6599)** — Introduce `Layouts.app` and use it in `Layout.legacy`
**[Phase 3](https://github.com/plausible/analytics/pull/6600)** — Let individual pages opt out of legacy layout. Do so for auth pages.

### This PR

* Introduce `Layouts.legacy` -- a function component that renders the whole body of the app, given the whole `conn.assigns` object (incl. `@inner_layout`, `@inner_content`)
* `bg_class` and `background` (color) assigns still need to stay in `app.html.heex` because otherwise dark/light flickers will surface

### Tests
- [x] This PR does not require tests

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI