### PR TITLE
Fix a typo (that causes 500) and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file.
 - Fixed issue with users with billing role not being able to create personal segments
 - Fixed period arrow keys hijacking custom-range calendar
 - Fixed dashboard CSV export failing when the dashboard is filtered by entry page or exit page
+- Fixed entry page hostname breakdown crashing when revenue metrics are queried
 
 ## v3.2.0 - 2026-01-16
 

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -283,7 +283,7 @@ defmodule Plausible.Stats.SQL.Expression do
     do: select_merge_as(q, [..., t], %{key => t.entry_page})
 
   def select_dimension_from_join(q, key, "visit:entry_page_hostname"),
-    do: select_merge_as(q, [..., t], %{key => t.entry_page_hostaname})
+    do: select_merge_as(q, [..., t], %{key => t.entry_page_hostname})
 
   def select_dimension_from_join(q, key, "visit:exit_page"),
     do: select_merge_as(q, [..., t], %{key => t.exit_page})

--- a/test/plausible/stats/query/query_test.exs
+++ b/test/plausible/stats/query/query_test.exs
@@ -670,4 +670,54 @@ defmodule Plausible.Stats.QueryTest do
       assert results == [%{dimensions: ["author"], metrics: [1]}]
     end
   end
+
+  describe "hostname dimensions" do
+    @tag :ee_only
+    for hostname_dim <- ["visit:entry_page_hostname", "visit:exit_page_hostname"] do
+      test "revenue metrics in #{hostname_dim} breakdown", %{site: site} do
+        insert(:goal, site: site, event_name: "Purchase", currency: "USD")
+
+        populate_stats(site, [
+          build(:pageview,
+            user_id: 1,
+            hostname: "onetwothree.com",
+            timestamp: ~N[2021-01-01 00:00:00]
+          ),
+          build(:event,
+            name: "Purchase",
+            user_id: 1,
+            hostname: "onetwothree.com",
+            revenue_reporting_amount: Decimal.new("100"),
+            revenue_reporting_currency: "USD",
+            timestamp: ~N[2021-01-01 00:00:10]
+          ),
+          build(:pageview,
+            user_id: 1,
+            hostname: "onetwothree.com",
+            timestamp: ~N[2021-01-01 00:00:20]
+          )
+        ])
+
+        {:ok, query} =
+          QueryBuilder.build(site, %ParsedQueryParams{
+            metrics: [:total_revenue, :average_revenue],
+            input_date_range: :all,
+            dimensions: [unquote(hostname_dim)],
+            filters: [[:is, "event:goal", ["Purchase"]]]
+          })
+
+        %Stats.QueryResult{results: results} = Stats.query(site, query)
+
+        assert results == [
+                 %{
+                   dimensions: ["onetwothree.com"],
+                   metrics: [
+                     %{currency: :USD, long: "$100.00", short: "$100.0", value: 100.0},
+                     %{currency: :USD, long: "$100.00", short: "$100.0", value: 100.0}
+                   ]
+                 }
+               ]
+      end
+    end
+  end
 end

--- a/test/plausible/stats/query/query_test.exs
+++ b/test/plausible/stats/query/query_test.exs
@@ -672,8 +672,8 @@ defmodule Plausible.Stats.QueryTest do
   end
 
   describe "hostname dimensions" do
-    @tag :ee_only
     for hostname_dim <- ["visit:entry_page_hostname", "visit:exit_page_hostname"] do
+      @tag :ee_only
       test "revenue metrics in #{hostname_dim} breakdown", %{site: site} do
         insert(:goal, site: site, event_name: "Purchase", currency: "USD")
 


### PR DESCRIPTION
### Changes

The typo (`t.entry_page_hostaname`) currently causes entry page hostname breakdown query to fail when filtering by a revenue goal and selecting revenue a metric. Fixed and covered with tests for both entry and exit page hostname breakdown cases.

Reproduce on staging: https://staging.plausible.io/plausible.io/entry-pages-with-hostname?f=is,goal,AddToCart&period=all

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
