### PR TITLE
Distinguish repeated signup submissions

### DIFF
--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -50,6 +50,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
          captcha_error: nil,
          password_strength: Auth.User.password_strength(changeset),
          disable_submit: false,
+         signup_previous_error: nil,
          trigger_submit: false,
          heading: heading,
          subtitle: subtitle
@@ -95,7 +96,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
           id="register-form"
           class="flex flex-col gap-y-6"
           action={Routes.auth_path(@socket, :login)}
-          onsubmit={form_submit_event(@invitation)}
+          onsubmit={form_submit_event(@invitation, @signup_previous_error)}
           phx-change="validate"
           phx-submit="register"
           phx-trigger-action={@trigger_submit}
@@ -172,11 +173,13 @@ defmodule PlausibleWeb.Live.RegisterForm do
   end
 
   on_ee do
-    defp form_submit_event(invitation) do
-      "window.plausible('Signup#{if invitation, do: " via invitation"}')"
+    defp form_submit_event(invitation, previous_error) do
+      options = Jason.encode!(%{"props" => %{"previous_error" => previous_error || "none"}})
+
+      "window.plausible('Signup#{if invitation, do: " via invitation"}', #{options})"
     end
   else
-    defp form_submit_event(_), do: ""
+    defp form_submit_event(_, _), do: ""
   end
 
   defp name_input(assigns) do
@@ -273,8 +276,10 @@ defmodule PlausibleWeb.Live.RegisterForm do
   end
 
   defp captcha_failed(socket) do
+    error = "Please complete the captcha to register"
+
     socket
-    |> assign(:captcha_error, "Please complete the captcha to register")
+    |> assign(captcha_error: error, signup_previous_error: error)
     |> PlausibleWeb.Components.Captcha.reset()
   end
 
@@ -293,10 +298,20 @@ defmodule PlausibleWeb.Live.RegisterForm do
       {:error, changeset} ->
         socket =
           socket
-          |> assign(form: to_form(Map.put(changeset, :action, :validate)))
+          |> assign(
+            form: to_form(Map.put(changeset, :action, :validate)),
+            signup_previous_error: signup_error(changeset)
+          )
           |> PlausibleWeb.Components.Captcha.reset()
 
         {:noreply, socket}
+    end
+  end
+
+  defp signup_error(changeset) do
+    case List.first(changeset.errors) do
+      {_field, {message, _options}} -> message
+      nil -> "unknown"
     end
   end
 

--- a/lib/plausible_web/live/register_form.ex
+++ b/lib/plausible_web/live/register_form.ex
@@ -10,6 +10,12 @@ defmodule PlausibleWeb.Live.RegisterForm do
   alias Plausible.Teams
   alias PlausibleWeb.Layouts
 
+  @signup_error_categories %{
+    name: "name",
+    email: "email",
+    password: "password"
+  }
+
   def mount(params, _session, socket) do
     socket =
       socket
@@ -279,7 +285,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
     error = "Please complete the captcha to register"
 
     socket
-    |> assign(captcha_error: error, signup_previous_error: error)
+    |> assign(captcha_error: error, signup_previous_error: "captcha")
     |> PlausibleWeb.Components.Captcha.reset()
   end
 
@@ -310,7 +316,7 @@ defmodule PlausibleWeb.Live.RegisterForm do
 
   defp signup_error(changeset) do
     case List.first(changeset.errors) do
-      {_field, {message, _options}} -> message
+      {field, _error} -> Map.get(@signup_error_categories, field, "unknown")
       nil -> "unknown"
     end
   end

--- a/test/plausible_web/live/register_form_test.exs
+++ b/test/plausible_web/live/register_form_test.exs
@@ -292,10 +292,12 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
     |> render_change(%{id => text})
   end
 
-  defp assert_signup_tracking(html, previous_error) do
-    assert html =~ "Signup"
-    assert html =~ "previous_error"
-    assert html =~ previous_error
+  on_ee do
+    defp assert_signup_tracking(html, previous_error) do
+      assert html =~ "Signup"
+      assert html =~ "previous_error"
+      assert html =~ previous_error
+    end
   end
 
   defp mock_captcha_success() do

--- a/test/plausible_web/live/register_form_test.exs
+++ b/test/plausible_web/live/register_form_test.exs
@@ -99,7 +99,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert_push_event(lv, "reset-frc-captcha", %{})
 
       on_ee do
-        assert_signup_tracking(html, "Please complete the captcha to register")
+        assert_signup_tracking(html, "captcha")
       end
 
       refute Repo.one(User)
@@ -122,7 +122,7 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert_push_event(lv, "reset-frc-captcha", %{})
 
       on_ee do
-        assert_signup_tracking(html, "has already been taken")
+        assert_signup_tracking(html, "email")
       end
     end
   end
@@ -293,10 +293,11 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
   end
 
   on_ee do
-    defp assert_signup_tracking(html, previous_error) do
-      assert html =~ "Signup"
-      assert html =~ "previous_error"
-      assert html =~ previous_error
+    defp assert_signup_tracking(html, previous_error_category) do
+      options = Jason.encode!(%{"props" => %{"previous_error" => previous_error_category}})
+
+      assert text_of_attr(html, "#register-form", "onsubmit") ==
+               "window.plausible('Signup', #{options})"
     end
   end
 

--- a/test/plausible_web/live/register_form_test.exs
+++ b/test/plausible_web/live/register_form_test.exs
@@ -50,6 +50,11 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       lv = get_liveview(conn, "/register")
 
+      on_ee do
+        html = render(lv)
+        assert_signup_tracking(html, "none")
+      end
+
       type_into_input(lv, "user[name]", "Mary Sue")
       type_into_input(lv, "user[email]", "mary.sue@plausible.test")
       type_into_input(lv, "user[password]", "very-long-and-very-secret-123")
@@ -93,6 +98,10 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
       assert html =~ "Please complete the captcha to register"
       assert_push_event(lv, "reset-frc-captcha", %{})
 
+      on_ee do
+        assert_signup_tracking(html, "Please complete the captcha to register")
+      end
+
       refute Repo.one(User)
     end
 
@@ -111,6 +120,10 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
 
       assert html =~ "has already been taken"
       assert_push_event(lv, "reset-frc-captcha", %{})
+
+      on_ee do
+        assert_signup_tracking(html, "has already been taken")
+      end
     end
   end
 
@@ -277,6 +290,12 @@ defmodule PlausibleWeb.Live.RegisterFormTest do
     lv
     |> element("form")
     |> render_change(%{id => text})
+  end
+
+  defp assert_signup_tracking(html, previous_error) do
+    assert html =~ "Signup"
+    assert html =~ "previous_error"
+    assert html =~ previous_error
   end
 
   defp mock_captcha_success() do


### PR DESCRIPTION
### Background

PR #6514 changed signup tracking from a LiveView hook to an inline form onsubmit handler.

Before this change, Signup was tracked only after the user record was created successfully. After it, Signup is sent when the browser submits the form, before CAPTCHA verification and server-side validation complete.

Since this change, there is a significant gap between unique conversions and total conversions. This means the same users are re-submitting the form multiple times. The goal of this PR is to understand better if there's some UX friction on the registration form. Could also just be bots caught by captcha. But then why aren't the bots excluded from our tracking? Anyways, this will help narrow things down.

### Changes

Track the previous registration error on Signup events.

Each initial signup submission sends:
{"previous_error": "none"}

A later submission after a rejected attempt sends the previous CAPTCHA or validation error. This makes it possible to identify repeated submissions caused by issues such as CAPTCHA failure or an existing email address.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
