### PR TITLE
Remove unvalidated site / team name from emails subject and body

### DIFF
--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -284,7 +284,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(email)
     |> tag("new-user-team-invitation")
-    |> subject("[#{Plausible.product_name()}] You've been invited to \"#{team.name}\" team")
+    |> subject("[#{Plausible.product_name()}] You've been invited to a team")
     |> render("new_user_team_invitation.html",
       invitation_id: invitation_id,
       team: team,
@@ -296,7 +296,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(email)
     |> tag("existing-user-team-invitation")
-    |> subject("[#{Plausible.product_name()}] You've been invited to \"#{team.name}\" team")
+    |> subject("[#{Plausible.product_name()}] You've been invited to a team")
     |> render("existing_user_team_invitation.html",
       team: team,
       inviter: inviter
@@ -307,7 +307,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(email)
     |> tag("guest-to-team-member-promotion")
-    |> subject("[#{Plausible.product_name()}] Welcome to \"#{team.name}\" team")
+    |> subject("[#{Plausible.product_name()}] Welcome to your new team")
     |> render("guest_to_team_member_promotion.html", inviter: inviter, team: team)
   end
 

--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -261,7 +261,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(email)
     |> tag("new-user-invitation")
-    |> subject("[#{Plausible.product_name()}] You've been invited to #{site.domain}")
+    |> subject("[#{Plausible.product_name()}] You've been invited to a site")
     |> render("new_user_invitation.html",
       invitation_id: invitation_id,
       site: site,
@@ -273,7 +273,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(email)
     |> tag("existing-user-invitation")
-    |> subject("[#{Plausible.product_name()}] You've been invited to #{site.domain}")
+    |> subject("[#{Plausible.product_name()}] You've been invited to a site")
     |> render("existing_user_invitation.html",
       site: site,
       inviter: inviter
@@ -315,7 +315,7 @@ defmodule PlausibleWeb.Email do
     priority_email()
     |> to(email)
     |> tag("ownership-transfer-request")
-    |> subject("[#{Plausible.product_name()}] Request to transfer ownership of #{site.domain}")
+    |> subject("[#{Plausible.product_name()}] Request to transfer a site to you")
     |> render("ownership_transfer_request.html",
       invitation_id: invitation_id,
       inviter: inviter,

--- a/lib/plausible_web/templates/email/existing_user_invitation.html.heex
+++ b/lib/plausible_web/templates/email/existing_user_invitation.html.heex
@@ -1,4 +1,4 @@
-{@inviter.email} has invited you to the {@site.domain} site on {Plausible.product_name()}.
+{@inviter.email} has invited you to one of their sites on {Plausible.product_name()}.
 <a href={Routes.site_url(PlausibleWeb.Endpoint, :index) <> "?__team=none"}>Click here</a>
 to view and respond to the invitation. The invitation
 will expire 48 hours after this email is sent. If this invitation has expired, please contact the person who invited you to ask them to resend it.

--- a/lib/plausible_web/templates/email/existing_user_team_invitation.html.heex
+++ b/lib/plausible_web/templates/email/existing_user_team_invitation.html.heex
@@ -1,4 +1,4 @@
-{@inviter.email} has invited you to the "{@team.name}" team on {Plausible.product_name()}.
+{@inviter.email} has invited you to their team on {Plausible.product_name()}.
 <a href={Routes.site_url(PlausibleWeb.Endpoint, :index)}>Click here</a>
 to view and respond to the invitation. The invitation
 will expire 48 hours after this email is sent.

--- a/lib/plausible_web/templates/email/guest_to_team_member_promotion.html.heex
+++ b/lib/plausible_web/templates/email/guest_to_team_member_promotion.html.heex
@@ -1,4 +1,4 @@
-{@inviter.email} has promoted you to a team member in the "{@team.name}" team on {Plausible.product_name()}.
+{@inviter.email} has promoted you to a team member on {Plausible.product_name()}.
 <a href={PlausibleWeb.Router.Helpers.site_url(PlausibleWeb.Endpoint, :index) <> "?__team=#{@team.identifier}"}>
   Click here
 </a>

--- a/lib/plausible_web/templates/email/new_user_invitation.html.heex
+++ b/lib/plausible_web/templates/email/new_user_invitation.html.heex
@@ -1,4 +1,4 @@
-{@inviter.email} has invited you to join the {@site.domain} site on {Plausible.product_name()}.
+{@inviter.email} has invited you to join one of their sites on {Plausible.product_name()}.
 <a href={
   Routes.auth_url(
     PlausibleWeb.Endpoint,

--- a/lib/plausible_web/templates/email/new_user_team_invitation.html.heex
+++ b/lib/plausible_web/templates/email/new_user_team_invitation.html.heex
@@ -1,4 +1,4 @@
-{@inviter.email} has invited you to join the "{@team.name}" team on {Plausible.product_name()}.
+{@inviter.email} has invited you to join their team on {Plausible.product_name()}.
 <a href={
   Routes.auth_url(
     PlausibleWeb.Endpoint,

--- a/lib/plausible_web/templates/email/ownership_transfer_request.html.heex
+++ b/lib/plausible_web/templates/email/ownership_transfer_request.html.heex
@@ -1,4 +1,4 @@
-{@inviter.email} has requested to transfer the ownership of {@site.domain} site on {Plausible.product_name()} to you. Please accept the request within 48 hours.
+{@inviter.email} has requested to transfer the ownership of one of their sites on {Plausible.product_name()} to you. Please accept the request within 48 hours.
 <%= if @new_owner_account do %>
   <a href={Routes.site_url(PlausibleWeb.Endpoint, :index)}>Click here</a>
   to view and respond to the invitation.

--- a/test/plausible/teams/invitations/invite_to_site_test.exs
+++ b/test/plausible/teams/invitations/invite_to_site_test.exs
@@ -46,7 +46,9 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
 
       assert_email_delivered_with(
         to: [nil: invitee.email],
-        subject: @subject_prefix <> "You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to a site",
+        text_body:
+          ~r/#{Regex.escape("#{inviter.email} has invited you to one of their sites on #{Plausible.product_name()}.")}/
       )
     end
 
@@ -59,8 +61,10 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
-        subject: @subject_prefix <> "You've been invited to #{site.domain}",
-        html_body: ~r/#{invitation_id}/
+        subject: @subject_prefix <> "You've been invited to a site",
+        html_body: ~r/#{invitation_id}/,
+        text_body:
+          ~r/#{Regex.escape("#{inviter.email} has invited you to join one of their sites on #{Plausible.product_name()}.")}/
       )
     end
 
@@ -130,7 +134,9 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
-        subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}"
+        subject: @subject_prefix <> "Request to transfer a site to you",
+        text_body:
+          ~r/#{Regex.escape("#{inviter.email} has requested to transfer the ownership of one of their sites on #{Plausible.product_name()} to you.")}/
       )
     end
 
@@ -144,7 +150,7 @@ defmodule Plausible.Teams.Invitations.InviteToSiteTest do
 
       assert_email_delivered_with(
         to: [nil: "vini@plausible.test"],
-        subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}"
+        subject: @subject_prefix <> "Request to transfer a site to you"
       )
     end
 

--- a/test/plausible/teams/invitations/invite_to_team_test.exs
+++ b/test/plausible/teams/invitations/invite_to_team_test.exs
@@ -28,7 +28,9 @@ defmodule Plausible.Teams.Invitations.InviteToTeamTest do
 
         assert_email_delivered_with(
           to: [nil: invitee.email],
-          subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+          subject: @subject_prefix <> "You've been invited to a team",
+          text_body:
+            ~r/#{Regex.escape("#{inviter.email} has invited you to their team on #{Plausible.product_name()}.")}/
         )
       end
     end
@@ -52,8 +54,10 @@ defmodule Plausible.Teams.Invitations.InviteToTeamTest do
 
         assert_email_delivered_with(
           to: [nil: invitee.email],
-          subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team",
-          html_body: ~r/#{team_invitation.invitation_id}/
+          subject: @subject_prefix <> "You've been invited to a team",
+          html_body: ~r/#{team_invitation.invitation_id}/,
+          text_body:
+            ~r/#{Regex.escape("#{inviter.email} has invited you to join their team on #{Plausible.product_name()}.")}/
         )
       end
     end
@@ -77,7 +81,7 @@ defmodule Plausible.Teams.Invitations.InviteToTeamTest do
 
         assert_email_delivered_with(
           to: [nil: invitee.email],
-          subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+          subject: @subject_prefix <> "You've been invited to a team"
         )
       end
     end

--- a/test/plausible/teams/management/layout_test.exs
+++ b/test/plausible/teams/management/layout_test.exs
@@ -282,7 +282,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
 
       assert_email_delivered_with(
         to: [nil: "test@example.com"],
-        subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+        subject: @subject_prefix <> "You've been invited to a team"
       )
 
       layout = Layout.init(team)
@@ -373,7 +373,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
 
       assert_email_delivered_with(
         to: [nil: "new@example.com"],
-        subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+        subject: @subject_prefix <> "You've been invited to a team"
       )
 
       assert_email_delivered_with(
@@ -410,7 +410,7 @@ defmodule Plausible.Teams.Management.LayoutTest do
 
       assert_email_delivered_with(
         to: [nil: "new@example.com"],
-        subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+        subject: @subject_prefix <> "You've been invited to a team"
       )
 
       assert_email_delivered_with(

--- a/test/plausible/teams/memberships/update_role_test.exs
+++ b/test/plausible/teams/memberships/update_role_test.exs
@@ -111,7 +111,9 @@ defmodule Plausible.Teams.Memberships.UpdateRoleTest do
 
     assert_email_delivered_with(
       to: [nil: user.email],
-      subject: @subject_prefix <> "Welcome to \"#{team.name}\" team"
+      subject: @subject_prefix <> "Welcome to your new team",
+      text_body:
+        ~r/#{Regex.escape("#{owner.email} has promoted you to a team member on #{Plausible.product_name()}.")}/
     )
   end
 

--- a/test/plausible_web/controllers/api/external_sites_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_sites_controller_test.exs
@@ -1181,7 +1181,7 @@ defmodule PlausibleWeb.Api.ExternalSitesControllerTest do
 
         assert_email_delivered_with(
           to: [nil: "test@example.com"],
-          subject: ~r/You've been invited to #{site.domain}/
+          subject: ~r/You've been invited to a site/
         )
       end
 

--- a/test/plausible_web/controllers/site/membership_controller_test.exs
+++ b/test/plausible_web/controllers/site/membership_controller_test.exs
@@ -135,7 +135,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: "john.doe@example.com"],
-        subject: @subject_prefix <> "You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to a site"
       )
     end
 
@@ -150,7 +150,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: existing_user.email],
-        subject: @subject_prefix <> "You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to a site"
       )
     end
 
@@ -184,7 +184,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: "joe@example.com"],
-        subject: @subject_prefix <> "You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to a site"
       )
 
       req2 =
@@ -195,7 +195,7 @@ defmodule PlausibleWeb.Site.MembershipControllerTest do
 
       assert_email_delivered_with(
         to: [nil: "joe@example.com"],
-        subject: @subject_prefix <> "You've been invited to #{site.domain}"
+        subject: @subject_prefix <> "You've been invited to a site"
       )
 
       assert Phoenix.Flash.get(req2.assigns.flash, :success) =~

--- a/test/plausible_web/live/customer_support/sites_test.exs
+++ b/test/plausible_web/live/customer_support/sites_test.exs
@@ -99,7 +99,7 @@ defmodule PlausibleWeb.Live.CustomerSupport.SitesTest do
 
         assert_email_delivered_with(
           to: [nil: "arbitrary@example.com"],
-          subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}",
+          subject: @subject_prefix <> "Request to transfer a site to you",
           html_body: ~r/#{user.email}/
         )
       end

--- a/test/plausible_web/live/site_transfer_settings_test.exs
+++ b/test/plausible_web/live/site_transfer_settings_test.exs
@@ -289,7 +289,7 @@ defmodule PlausibleWeb.Live.SiteTransferSettingsTest do
 
       assert_email_delivered_with(
         to: [nil: "john.doe@example.com"],
-        subject: @subject_prefix <> "Request to transfer ownership of #{site.domain}"
+        subject: @subject_prefix <> "Request to transfer a site to you"
       )
     end
 

--- a/test/plausible_web/live/team_management_test.exs
+++ b/test/plausible_web/live/team_management_test.exs
@@ -107,7 +107,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
   describe "live" do
     setup [:create_user, :log_in, :create_team, :setup_team]
 
-    test "renders member, immediately delivers invitation", %{conn: conn, user: user, team: team} do
+    test "renders member, immediately delivers invitation", %{conn: conn, user: user} do
       {lv, html} = get_liveview(conn, with_html?: true)
       member_row1 = find(html, "#{member_el()}:nth-of-type(1)") |> text()
       assert member_row1 =~ "#{user.name}"
@@ -129,7 +129,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
 
       assert_email_delivered_with(
         to: [nil: "new@example.com"],
-        subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+        subject: @subject_prefix <> "You've been invited to a team"
       )
     end
 
@@ -364,7 +364,7 @@ defmodule PlausibleWeb.Live.TeamMangementTest do
 
       assert_email_delivered_with(
         to: [nil: member2.email],
-        subject: @subject_prefix <> "Welcome to \"#{team.name}\" team"
+        subject: @subject_prefix <> "Welcome to your new team"
       )
     end
 

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -124,15 +124,13 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       assert_redirect(lv, "/settings/team/general?__team=" <> team.identifier)
 
-      team = Repo.reload!(team)
-
       assert_email_delivered_with(
         to: [nil: "new@example.com"],
-        subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+        subject: @subject_prefix <> "You've been invited to a team"
       )
     end
 
-    test "allows updating pending invitation role in place", %{conn: conn, team: team} do
+    test "allows updating pending invitation role in place", %{conn: conn} do
       lv = get_child_lv(conn)
       add_invite(lv, "new@example.com", "admin")
 
@@ -148,11 +146,9 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       save_layout(lv)
 
-      team = Repo.reload!(team)
-
       assert_email_delivered_with(
         to: [nil: "new@example.com"],
-        subject: @subject_prefix <> "You've been invited to \"#{team.name}\" team"
+        subject: @subject_prefix <> "You've been invited to a team"
       )
     end
 
@@ -207,7 +203,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       assert_email_delivered_with(
         to: [nil: "guest@example.com"],
-        subject: @subject_prefix <> "Welcome to \"A-Team!\" team"
+        subject: @subject_prefix <> "Welcome to your new team"
       )
     end
 


### PR DESCRIPTION
### Changes

Removes unvalidated site and team names from automated email subject and body. Protects against the server being used to send mass emails.

The drawback is that the messages look more generic. 

I've kept the email of the inviter in the body: this should allow the recipient to verify directly with the inviter without clicking any links in the email. 

### Tests
- [x] Automated tests have been added

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
