### PR TITLE
[Team Deletions] Migration: add team deletion schedule

### DIFF
--- a/priv/repo/migrations/20260820120000_create_team_deletion_schedules.exs
+++ b/priv/repo/migrations/20260820120000_create_team_deletion_schedules.exs
@@ -18,6 +18,7 @@ defmodule Plausible.Repo.Migrations.CreateTeamDeletionSchedules do
       timestamps()
     end
 
+    create index(:team_deletion_schedules, [:team_id])
     create index(:team_deletion_schedules, [:status])
     create index(:team_deletion_schedules, [:deletion_date])
     create index(:team_deletion_schedules, [:first_notice_due_date])

--- a/priv/repo/migrations/20260820120000_create_team_deletion_schedules.exs
+++ b/priv/repo/migrations/20260820120000_create_team_deletion_schedules.exs
@@ -22,14 +22,14 @@ defmodule Plausible.Repo.Migrations.CreateTeamDeletionSchedules do
     create index(:team_deletion_schedules, [:deletion_date])
     create index(:team_deletion_schedules, [:first_notice_due_date])
 
-    # Only one active (i.e. not yet cancelled/deleted) schedule per team - a team
+    # Only one active (i.e. not yet cancelled/completed) schedule per team - a team
     # can churn, come back, and churn again over time, so this isn't a plain
     # unique index on team_id.
     create index(
              :team_deletion_schedules,
              [:team_id],
              unique: true,
-             where: "status NOT IN ('cancelled', 'deleted')",
+             where: "status NOT IN ('cancelled', 'completed')",
              name: :one_active_schedule_per_team
            )
   end

--- a/priv/repo/migrations/20260820120000_create_team_deletion_schedules.exs
+++ b/priv/repo/migrations/20260820120000_create_team_deletion_schedules.exs
@@ -1,0 +1,36 @@
+defmodule Plausible.Repo.Migrations.CreateTeamDeletionSchedules do
+  use Ecto.Migration
+
+  def change do
+    create table(:team_deletion_schedules) do
+      add :team_id, references(:teams, on_delete: :delete_all), null: false
+      add :category, :text, null: false
+      add :expiry_date, :date, null: false
+      add :deletion_date, :date, null: false
+      add :is_backlog, :boolean, null: false, default: false
+      add :status, :text, null: false, default: "scheduled"
+      add :first_notice_due_date, :date, null: false
+      add :first_notice_sent_at, :naive_datetime
+      add :reminder_sent_at, :naive_datetime
+      add :snoozed_until, :date
+      add :snooze_note, :text
+
+      timestamps()
+    end
+
+    create index(:team_deletion_schedules, [:status])
+    create index(:team_deletion_schedules, [:deletion_date])
+    create index(:team_deletion_schedules, [:first_notice_due_date])
+
+    # Only one active (i.e. not yet cancelled/deleted) schedule per team - a team
+    # can churn, come back, and churn again over time, so this isn't a plain
+    # unique index on team_id.
+    create index(
+             :team_deletion_schedules,
+             [:team_id],
+             unique: true,
+             where: "status NOT IN ('cancelled', 'deleted')",
+             name: :one_active_schedule_per_team
+           )
+  end
+end


### PR DESCRIPTION
This isn't final form, but an initial base migration for tracking/audting team deletions life cycle (expired trials, cancelled subscriptions).

Discussion: https://3.basecamp.com/5308029/buckets/44692882/messages/10216872798