### PR TITLE
Move team setup name form into TeamManagement LiveView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed "Create Team" going through when the team name was rejected, creating the team under a name the user never entered
 - Improve team member removal/team role change
 - Validate empty filter clauses list in Stats API v2
 - Fixed Stats API timeseries returning time buckets falling outside the queried range

--- a/e2e/tests/dashboard/team-setup.spec.ts
+++ b/e2e/tests/dashboard/team-setup.spec.ts
@@ -33,3 +33,39 @@ test('submitting team name via Enter key does not crash', async ({
 
   await expect(nameInput2).toHaveValue('My New Team')
 })
+
+test('create team is blocked while the name is rejected', async ({
+  page,
+  request
+}) => {
+  await setupSite({ page, request })
+  await page.goto('/team/setup', { waitUntil: 'commit' })
+
+  await expectLiveViewConnected(page)
+
+  const createTeam = page.getByRole('button', { name: 'Create Team' })
+  const nameInput = page.locator('input[name="team[name]"]')
+
+  await expect(createTeam).toBeEnabled()
+
+  await nameInput.fill('My personal sites')
+
+  await expect(page.locator('#update-team-form')).toContainText('is reserved')
+  await expect(createTeam).toBeDisabled()
+
+  await test.step('recovers once the name is fixed', async () => {
+    await nameInput.fill('Fixed Team Name')
+
+    await expect(createTeam).toBeEnabled()
+  })
+
+  await createTeam.click()
+
+  await expect(page).toHaveURL(/\/settings\/team\/general/)
+
+  await expectLiveViewConnected(page)
+
+  await expect(page.locator('input[name="team[name]"]')).toHaveValue(
+    'Fixed Team Name'
+  )
+})

--- a/lib/plausible_web/live/team_management.ex
+++ b/lib/plausible_web/live/team_management.ex
@@ -18,7 +18,31 @@ defmodule PlausibleWeb.Live.TeamManagement do
         :team_management
       end
 
+    socket =
+      if mode == :team_setup do
+        setup_team_name(socket)
+      else
+        socket
+      end
+
     {:ok, socket |> assign(mode: mode) |> reset()}
+  end
+
+  # In team setup the name is part of this form, so that creating the team can
+  # only ever happen with a name this LiveView has accepted.
+  defp setup_team_name(
+         %{assigns: %{current_user: current_user, current_team: current_team}} = socket
+       ) do
+    current_team =
+      current_team
+      |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s team"})
+      |> Plausible.Repo.update!()
+
+    assign(socket,
+      current_team: current_team,
+      team_name_form: to_form(Teams.Team.name_changeset(current_team, %{})),
+      locked?: Plausible.Teams.Billing.solo?(current_team)
+    )
   end
 
   defp reset(%{assigns: %{current_user: current_user, current_team: current_team}} = socket) do
@@ -39,6 +63,32 @@ defmodule PlausibleWeb.Live.TeamManagement do
 
   def render(assigns) do
     ~H"""
+    <.form
+      :let={f}
+      :if={@mode == :team_setup}
+      for={@team_name_form}
+      method="post"
+      phx-change="update-team"
+      phx-submit="update-team"
+      phx-blur="update-team"
+      id="update-team-form"
+      class="mt-4 mb-8"
+    >
+      <.input
+        type="text"
+        placeholder={"#{@current_user.name}'s team"}
+        autofocus={not @locked?}
+        field={f[:name]}
+        label="Name"
+        width="w-full"
+        phx-debounce="500"
+      />
+    </.form>
+
+    <.label :if={@mode == :team_setup} class="mb-2">
+      Team members
+    </.label>
+
     <.flash_messages flash={@flash} />
 
     <PlausibleWeb.Components.Billing.Notice.limit_exceeded
@@ -158,6 +208,7 @@ defmodule PlausibleWeb.Live.TeamManagement do
         id="save-layout"
         type="submit"
         phx-click="save-team-layout"
+        disabled={not @team_name_form.source.valid?}
         class="mt-8 w-full"
       >
         Create Team
@@ -221,14 +272,31 @@ defmodule PlausibleWeb.Live.TeamManagement do
     {:noreply, socket}
   end
 
+  def handle_event("update-team", %{"team" => %{"name" => name}}, socket) do
+    changeset = Teams.Team.name_changeset(socket.assigns.current_team, %{name: name})
+
+    socket =
+      case Plausible.Repo.update(changeset) do
+        {:ok, team} ->
+          assign(socket, team_name_form: to_form(changeset), current_team: team)
+
+        {:error, changeset} ->
+          assign(socket, team_name_form: to_form(changeset))
+      end
+
+    {:noreply, socket}
+  end
+
   def handle_event(
         "save-team-layout",
         _params,
         socket
       ) do
-    socket = save_team_layout(socket)
-
-    {:noreply, socket}
+    if team_name_accepted?(socket) do
+      {:noreply, save_team_layout(socket)}
+    else
+      {:noreply, put_live_flash(socket, :error, "Please fix the team name first")}
+    end
   end
 
   def handle_event("remove-member", %{"email" => email}, %{assigns: %{layout: layout}} = socket) do
@@ -262,6 +330,12 @@ defmodule PlausibleWeb.Live.TeamManagement do
 
     {:noreply, socket}
   end
+
+  defp team_name_accepted?(%{assigns: %{mode: :team_setup}} = socket) do
+    socket.assigns.team_name_form.source.valid?
+  end
+
+  defp team_name_accepted?(_socket), do: true
 
   defp valid_email?(email) do
     String.contains?(email, "@") and String.contains?(email, ".")

--- a/lib/plausible_web/live/team_setup.ex
+++ b/lib/plausible_web/live/team_setup.ex
@@ -5,50 +5,24 @@ defmodule PlausibleWeb.Live.TeamSetup do
 
   use PlausibleWeb, :live_view
 
-  alias Plausible.Repo
   alias Plausible.Teams
-  alias Plausible.Teams.Management.Layout
   alias PlausibleWeb.Router.Helpers, as: Routes
 
   def mount(_params, _session, socket) do
-    current_user = socket.assigns.current_user
-    current_team = socket.assigns.current_team
-
     socket =
-      case current_team do
+      case socket.assigns.current_team do
         %Teams.Team{setup_complete: true} ->
           socket
           |> put_flash(:success, "Your team is now created")
           |> redirect(to: Routes.settings_path(socket, :team_general))
 
         %Teams.Team{} ->
-          team_name_form =
-            current_team
-            |> Teams.Team.name_changeset(%{name: "#{current_user.name}'s team"})
-            |> Repo.update!()
-            |> Teams.Team.name_changeset(%{})
-            |> to_form()
-
-          layout = Layout.init(current_team)
-
-          assign(socket,
-            team_name_form: team_name_form,
-            team_layout: layout,
-            current_team: current_team
-          )
+          socket
 
         _ ->
           socket
           |> put_flash(:error, "You cannot create any team just yet")
           |> redirect(to: Routes.site_path(socket, :index))
-      end
-
-    socket =
-      if current_team do
-        {:ok, my_role} = Teams.Memberships.team_role(current_team, current_user)
-        assign(socket, my_role: my_role)
-      else
-        socket
       end
 
     {:ok, socket}
@@ -79,30 +53,6 @@ defmodule PlausibleWeb.Live.TeamSetup do
           current_team={@current_team}
           locked?={@locked?}
         >
-          <.form
-            :let={f}
-            for={@team_name_form}
-            method="post"
-            phx-change="update-team"
-            phx-submit="update-team"
-            phx-blur="update-team"
-            id="update-team-form"
-            class="mt-4 mb-8"
-          >
-            <.input
-              type="text"
-              placeholder={"#{@current_user.name}'s team"}
-              autofocus={not @locked?}
-              field={f[:name]}
-              label="Name"
-              width="w-full"
-              phx-debounce="500"
-            />
-          </.form>
-
-          <.label class="mb-2">
-            Team members
-          </.label>
           {live_render(@socket, PlausibleWeb.Live.TeamManagement,
             id: "team-management-setup",
             container: {:div, id: "team-setup"},
@@ -114,20 +64,5 @@ defmodule PlausibleWeb.Live.TeamSetup do
       </div>
     </.focus_box>
     """
-  end
-
-  def handle_event("update-team", %{"team" => %{"name" => name}}, socket) do
-    changeset = Teams.Team.name_changeset(socket.assigns.current_team, %{name: name})
-
-    socket =
-      case Repo.update(changeset) do
-        {:ok, team} ->
-          assign(socket, team_name_form: to_form(changeset), current_team: team)
-
-        {:error, changeset} ->
-          assign(socket, team_name_form: to_form(changeset))
-      end
-
-    {:noreply, socket}
   end
 end

--- a/test/plausible_web/live/team_setup_test.exs
+++ b/test/plausible_web/live/team_setup_test.exs
@@ -58,7 +58,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
     end
 
     test "changing team name, updates team name in db", %{conn: conn, team: team} do
-      {:ok, lv, _html} = live(conn, @url)
+      lv = get_child_lv(conn)
       type_into_input(lv, "team[name]", "New Team Name")
       assert Repo.reload!(team).name == "New Team Name"
 
@@ -70,7 +70,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       team: team,
       user: user
     } do
-      {:ok, lv, html} = live(conn, @url)
+      {lv, html} = get_child_lv(conn, with_html?: true)
 
       assert text_of_attr(html, ~s|input#update-team-form_name[name="team[name]"]|, "value") ==
                "#{user.name}'s team"
@@ -80,6 +80,52 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       type_into_input(lv, "team[name]", "My personal sites")
       _ = render(lv)
       assert Repo.reload!(team).name == "Team Name 1"
+    end
+
+    test "reserved name is rejected on the very first edit", %{
+      conn: conn,
+      team: team,
+      user: user
+    } do
+      lv = get_child_lv(conn)
+
+      type_into_input(lv, "team[name]", "My personal sites")
+
+      assert render(lv) =~ "is reserved"
+      assert Repo.reload!(team).name == "#{user.name}'s team"
+    end
+
+    test "creating the team is blocked while the name is rejected", %{conn: conn, team: team} do
+      lv = get_child_lv(conn)
+
+      refute element_exists?(render(lv), "button#save-layout[disabled]")
+
+      type_into_input(lv, "team[name]", "My personal sites")
+
+      assert render(lv) =~ "is reserved"
+      assert element_exists?(render(lv), "button#save-layout[disabled]")
+
+      # the server refuses as well, not just the disabled button
+      assert render_click(lv, "save-team-layout", %{}) =~ "Please fix the team name first"
+
+      refute Repo.reload!(team).setup_complete
+    end
+
+    test "creating the team goes through once the name is accepted", %{conn: conn, team: team} do
+      lv = get_child_lv(conn)
+
+      type_into_input(lv, "team[name]", "My personal sites")
+      _ = render(lv)
+      type_into_input(lv, "team[name]", "Fixed Team Name")
+      _ = render(lv)
+
+      save_layout(lv)
+
+      assert_redirect(lv, "/settings/team/general?__team=" <> team.identifier)
+
+      team = Repo.reload!(team)
+      assert team.setup_complete
+      assert team.name == "Fixed Team Name"
     end
 
     @tag :ee_only
@@ -184,10 +230,9 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
       site = new_site(owner: user)
       add_guest(site, role: :viewer, user: new_user(name: "Mr Guest", email: "guest@example.com"))
 
-      {:ok, main_lv, _html} = live(conn, @url)
       lv = get_child_lv(conn)
 
-      type_into_input(main_lv, "team[name]", "A-Team!")
+      type_into_input(lv, "team[name]", "A-Team!")
 
       assert Repo.reload!(team).name == "A-Team!"
 
@@ -314,7 +359,7 @@ defmodule PlausibleWeb.Live.TeamSetupTest do
 
       refute html =~ "Invitation pending"
       refute html =~ "Invitation sent"
-      refute html =~ "Team member"
+      refute text_of_element(render(lv), "#member-list") =~ "Team member"
       refute html =~ "Guest"
 
       save_layout(lv)


### PR DESCRIPTION
This PR moves the name field to team management component (as a conditional field), fixing the following issue:

### Steps to reproduce
In team setup
- type invalid name, e.g. "My personal sites"
- name field error is shown

### Expected
- user can't submit, needs to update name to be valid

### Actual
- user can submit
- on submit, success flash is shown
- the chosen (invalid) name wasn't actually applied to team

The broader context is that once we introduce team name length limit, this scenario becomes a bit more common, so it needs to work properly.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode
