### PR TITLE
change cancel email copy

### DIFF
--- a/lib/plausible_web/email.ex
+++ b/lib/plausible_web/email.ex
@@ -253,7 +253,7 @@ defmodule PlausibleWeb.Email do
     base_email()
     |> to(user.email)
     |> tag("cancelled-email")
-    |> subject("Mind sharing your thoughts on Plausible?")
+    |> subject("Where did Plausible fall short?")
     |> render("cancellation_email.html", user: user)
   end
 

--- a/lib/plausible_web/templates/email/cancellation_email.html.heex
+++ b/lib/plausible_web/templates/email/cancellation_email.html.heex
@@ -1,1 +1,5 @@
-This is Marko, one of the co-founders of Plausible. I’d love to understand the reasons behind your decision to cancel your subscription. We’re solely funded by our subscribers so we genuinely value your feedback. Even a few words would be beneficial in helping us improve our product. Please respond to this email with any insights you can share. Thank you for your time!
+Thanks for supporting Plausible.
+<br /><br />
+If something about the product let you down, we’d like to understand what happened. Was something missing, confusing or more work than it should have been?
+<br /><br />
+We’re funded entirely by our subscribers, so your reply helps us decide what to fix or build next. Even a few words would help.

--- a/lib/plausible_web/templates/email/cancellation_email.html.heex
+++ b/lib/plausible_web/templates/email/cancellation_email.html.heex
@@ -1,5 +1,4 @@
-Thanks for supporting Plausible.
-<br /><br />
+Thanks for supporting Plausible.<br /><br />
 If something about the product let you down, we’d like to understand what happened. Was something missing, confusing or more work than it should have been?
 <br /><br />
 We’re funded entirely by our subscribers, so your reply helps us decide what to fix or build next. Even a few words would help.

--- a/test/plausible/billing/billing_test.exs
+++ b/test/plausible/billing/billing_test.exs
@@ -591,12 +591,12 @@ defmodule Plausible.BillingTest do
 
       assert_email_delivered_with(
         to: [nil: user.email],
-        subject: "Mind sharing your thoughts on Plausible?"
+        subject: "Where did Plausible fall short?"
       )
 
       assert_email_delivered_with(
         to: [nil: billing_member.email],
-        subject: "Mind sharing your thoughts on Plausible?"
+        subject: "Where did Plausible fall short?"
       )
     end
   end


### PR DESCRIPTION
trying to improve the cancellation email subject line and copy to see if we can change the type of replies we get