### PR TITLE
Fix flaky debug metadata tests

### DIFF
--- a/test/plausible_web/controllers/api/external_stats_controller/debug_metadata_test.exs
+++ b/test/plausible_web/controllers/api/external_stats_controller/debug_metadata_test.exs
@@ -1,5 +1,4 @@
 defmodule PlausibleWeb.Api.ExternalController.DebugMetadataTest do
-  alias Plausible.{IngestRepo, ClickhouseRepo}
   use PlausibleWeb.ConnCase
 
   describe "Debug metadata" do
@@ -20,13 +19,11 @@ defmodule PlausibleWeb.Api.ExternalController.DebugMetadataTest do
 
       assert json_response(conn, 200)
 
-      IngestRepo.query!("SYSTEM FLUSH LOGS")
-
-      %{rows: [r1, r2]} =
-        ClickhouseRepo.query!(
-          "FROM system.query_log SELECT log_comment WHERE JSONExtractString(log_comment, 'site_domain') = {$0:String}",
-          [site.domain]
-        )
+      assert [r1, r2] =
+               eventually(fn ->
+                 rows = get_entries_from_query_log(site.domain)
+                 {length(rows) == 2, rows}
+               end)
 
       for [unparsed_log_comment] <- [r1, r2] do
         decoded = Jason.decode!(unparsed_log_comment)

--- a/test/plausible_web/controllers/api/stats_controller/debug_metadata_test.exs
+++ b/test/plausible_web/controllers/api/stats_controller/debug_metadata_test.exs
@@ -1,5 +1,4 @@
 defmodule PlausibleWeb.Api.StatsController.DebugMetadataTest do
-  alias Plausible.{IngestRepo, ClickhouseRepo}
   use PlausibleWeb.ConnCase
 
   describe "Debug metadata for logged in requests" do
@@ -17,13 +16,11 @@ defmodule PlausibleWeb.Api.StatsController.DebugMetadataTest do
 
       assert json_response(conn, 200)
 
-      IngestRepo.query!("SYSTEM FLUSH LOGS")
-
-      %{rows: [r1, r2]} =
-        ClickhouseRepo.query!(
-          "FROM system.query_log SELECT log_comment WHERE JSONExtractString(log_comment, 'site_domain') = {$0:String}",
-          [site.domain]
-        )
+      assert [r1, r2] =
+               eventually(fn ->
+                 rows = get_entries_from_query_log(site.domain)
+                 {length(rows) == 2, rows}
+               end)
 
       for [unparsed_log_comment] <- [r1, r2] do
         decoded = Jason.decode!(unparsed_log_comment)
@@ -89,13 +86,11 @@ defmodule PlausibleWeb.Api.StatsController.DebugMetadataTest do
 
         assert json_response(conn, 200)
 
-        IngestRepo.query!("SYSTEM FLUSH LOGS")
-
-        %{rows: [r1, r2]} =
-          ClickhouseRepo.query!(
-            "FROM system.query_log SELECT log_comment WHERE JSONExtractString(log_comment, 'site_domain') = {$0:String}",
-            [site.domain]
-          )
+        assert [r1, r2] =
+                 eventually(fn ->
+                   rows = get_entries_from_query_log(site.domain)
+                   {length(rows) == 2, rows}
+                 end)
 
         for [unparsed_log_comment] <- [r1, r2] do
           decoded = Jason.decode!(unparsed_log_comment)

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -267,6 +267,18 @@ defmodule Plausible.TestUtils do
     )
   end
 
+  def get_entries_from_query_log(site_domain) do
+    Plausible.IngestRepo.query!("SYSTEM FLUSH LOGS")
+
+    %{rows: rows} =
+      Plausible.ClickhouseRepo.query!(
+        "FROM system.query_log SELECT log_comment WHERE JSONExtractString(log_comment, 'site_domain') = {$0:String}",
+        [site_domain]
+      )
+
+    rows
+  end
+
   def random_ip() do
     Enum.map_join(1..4, ".", fn _ -> Enum.random(1..254) end)
   end


### PR DESCRIPTION
### Changes
Solves the flaky test below.

The issue is the test finding just the `QueryStart` row even after calling `SYSTEM FLUSH LOGS`. 

We need to keep flushing or waiting until both the QueryStart and QueryFinish rows are present. This PR handles that by using `eventually`.

```
  1) test Debug metadata for logged in requests for /api/stats/:domain/query (PlausibleWeb.Api.StatsController.DebugMetadataTest)
Error:      test/plausible_web/controllers/api/stats_controller/debug_metadata_test.exs:8
     ** (MatchError) no match of right hand side value:

         %Ch.Result{
           command: nil,
           num_rows: 1,
           columns: ["log_comment"],
           rows: [
             ["{\"params\":{\"date_range\":\"day\",\"domain\":\"Nr9h1Zbtg2CFptd_OjY52bRBUPs=\",\"metrics\":[\"visitors\"]},\"user_id\":540,\"request_path\":\"/api/stats/Nr9h1Zbtg2CFptd_OjY52bRBUPs=/query\",\"trace_id\":null,\"team_id\":391,\"site_id\":445,\"phoenix_action\":\"query\",\"phoenix_controller\":\"Elixir.PlausibleWeb.Api.StatsController\",\"request_method\":\"POST\",\"site_domain\":\"Nr9h1Zbtg2CFptd_OjY52bRBUPs=\"}"]
           ],
           headers: [
             {"x-clickhouse-summary",
              "{\"read_rows\":\"2188\",\"read_bytes\":\"88358\",\"written_rows\":\"0\",\"written_bytes\":\"0\",\"total_rows_to_read\":\"2188\",\"result_rows\":\"0\",\"result_bytes\":\"0\",\"elapsed_ns\":\"1663288\",\"memory_usage\":\"1169879\"}"},
             {"date", "Mon, 24 Aug 2026 13:21:43 GMT"},
             {"connection", "Keep-Alive"},
             {"content-type", "application/octet-stream"},
             {"access-control-expose-headers",
              "X-ClickHouse-Query-Id,X-ClickHouse-Summary,X-ClickHouse-Server-Display-Name,X-ClickHouse-Format,X-ClickHouse-Timezone,X-ClickHouse-Exception-Code,X-ClickHouse-Exception-Tag"},
             {"x-clickhouse-server-display-name", "ae75f30cd61b"},
             {"transfer-encoding", "chunked"},
             {"x-clickhouse-query-id", "343de6f3-05d0-44c1-8e69-e02a818400ba"},
             {"x-clickhouse-format", "RowBinaryWithNamesAndTypes"},
             {"x-clickhouse-timezone", "UTC"},
             {"keep-alive", "timeout=10, max=9978"},
             {"x-clickhouse-exception-tag", "jtmxfclehfyezqey"}
           ],
           data: nil
         }

     code: %{rows: [r1, r2]} =
     stacktrace:
       test/plausible_web/controllers/api/stats_controller/debug_metadata_test.exs:22: (test)
```
(From https://github.com/plausible/analytics/actions/runs/32732118382/job/97446452533)