### PR TITLE
Fix flaky event / session insert test

### DIFF
--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1278,7 +1278,7 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
              }
     end
 
-    test "salts rotating once does not", %{conn: conn, site: site} do
+    test "salts rotating once keeps the same session", %{conn: conn, site: site} do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
       Plausible.Session.WriteBuffer.flush()
       Plausible.Session.Salts.rotate()

--- a/test/plausible_web/controllers/api/external_controller_test.exs
+++ b/test/plausible_web/controllers/api/external_controller_test.exs
@@ -1286,9 +1286,11 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       post(conn, "/api/event", %{n: "pageview", u: "https://test.com", d: site.domain})
 
       [event1, event2] = get_events(site)
-      [session1, session2] = get_sessions(site)
+      [session] = get_sessions_final(site)
 
-      records = [event1, event2, session1, session2]
+      assert session.pageviews == 2
+
+      records = [event1, event2, session]
 
       assert records |> Enum.map(& &1.user_id) |> Enum.uniq() |> Enum.count() == 1
       assert records |> Enum.map(& &1.session_id) |> Enum.uniq() |> Enum.count() == 1
@@ -2577,6 +2579,18 @@ defmodule PlausibleWeb.Api.ExternalControllerTest do
       from(e in Plausible.ClickhouseEventV2,
         where: e.site_id == ^site.id,
         order_by: [desc: e.timestamp]
+      )
+    )
+  end
+
+  defp get_sessions_final(site) do
+    Plausible.Session.WriteBuffer.flush()
+
+    ClickhouseRepo.all(
+      from(s in Plausible.ClickhouseSessionV2,
+        hints: "FINAL",
+        where: s.site_id == ^site.id,
+        order_by: [desc: s.timestamp]
       )
     )
   end


### PR DESCRIPTION
### Changes
Fixes a flaky test (exact flake log below) and updates its name. 

We expected two session rows with sign=1, but sometimes get just one. 
It depends on whether the `events 1, sign 1` and `events 1, sign -1` rows have collapsed or not due to automatic merge happening. 

Collapsing can be triggered by `OPTIMIZE TABLE sessions_v2 FINAL`: the test fails 100% by adding the statement `Plausible.IngestRepo.query!("OPTIMIZE TABLE sessions_v2 FINAL")` before `get_sessions` in the original test. 

The fix is to query sessions without sign with a final hint. 

```
  1) test POST /api/event salts rotating once does not (PlausibleWeb.Api.ExternalControllerTest)
Error:      test/plausible_web/controllers/api/external_controller_test.exs:1281
     ** (MatchError) no match of right hand side value:

         [
           %Plausible.ClickhouseSessionV2{
             __meta__: #Ecto.Schema.Metadata<:loaded, "sessions_v2">,
             hostname: "test.com",
             site_id: 781,
             user_id: 11313795110816714271,
             session_id: 12242475029645871076,
             start: ~N[2026-08-25 07:41:42],
             duration: 0,
             is_bounce: false,
             entry_page: "/",
             exit_page: "/",
             exit_page_hostname: "test.com",
             pageviews: 2,
             events: 2,
             sign: 1,
             "entry_meta.key": [],
             "entry_meta.value": [],
             utm_medium: "",
             utm_source: "",
             utm_campaign: "",
             utm_content: "",
             utm_term: "",
             referrer: "",
             referrer_source: "",
             click_id_param: "",
             country_code: <<0, 0>>,
             subdivision1_code: "",
             subdivision2_code: "",
             city_geoname_id: 0,
             screen_size: "",
             operating_system: "",
             operating_system_version: "",
             browser: "",
             browser_version: "",
             timestamp: ~N[2026-08-25 07:41:42],
             transferred_from: "",
             acquisition_channel: "Direct"
           }
         ]

     code: [session1, session2] = get_sessions(site)
     stacktrace:
       test/plausible_web/controllers/api/external_controller_test.exs:1289: (test)

--max-failures reached, aborting test suite
Finished in 18.7 seconds (3.5s async, 15.1s sync)

Result: 927/928 passed (2/2 doctests, 925/926 tests), 83 excluded
Failed: 1 test
Error: Process completed with exit code 2.
```

From https://github.com/plausible/analytics/actions/runs/32822733540/job/97724138133?pr=6621