### PR TITLE
Fix hourly bucket mapping across DST transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to this project will be documented in this file.
 - Fixed period arrow keys hijacking custom-range calendar
 - Fixed dashboard CSV export failing when the dashboard is filtered by entry page or exit page
 - Fixed entry page hostname breakdown crashing when revenue metrics are queried
+- Fixed hourly time labels on daylight saving time transition days, where the last hour of the day was missing from the graph in timezones that had just moved their clocks forward
 
 ## v3.2.0 - 2026-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ All notable changes to this project will be documented in this file.
 - Fixed period arrow keys hijacking custom-range calendar
 - Fixed dashboard CSV export failing when the dashboard is filtered by entry page or exit page
 - Fixed entry page hostname breakdown crashing when revenue metrics are queried
-- Fixed hourly time labels on daylight saving time transition days, where the last hour of the day was missing from the graph in timezones that had just moved their clocks forward
+- Fixed missing and duplicated hourly metrics across daylight saving time transitions in graphs, comparisons, CSV exports and Stats API timeseries
 
 ## v3.2.0 - 2026-01-16
 

--- a/lib/plausible/stats/dashboard/csv_export.ex
+++ b/lib/plausible/stats/dashboard/csv_export.ex
@@ -105,6 +105,7 @@ defmodule Plausible.Stats.Dashboard.CsvExport do
       query
       |> Query.set(order_by: [{Time.time_dimension(query), :asc}])
       |> Query.set_include(:time_labels, true)
+      |> Query.set_include(:time_label_result_indices, true)
       |> Query.set_include(:empty_metrics, true)
 
     QueryRunner.run(site, query) |> timeseries_query_result_to_csv()
@@ -134,21 +135,17 @@ defmodule Plausible.Stats.Dashboard.CsvExport do
   end
 
   defp timeseries_query_result_to_csv(%QueryResult{results: results, query: query, meta: meta}) do
-    meta[:time_labels]
-    |> Enum.reduce([csv_first_row(query)], fn timelabel, acc ->
-      if result_item = find_result_item_by_timelabel(results, timelabel) do
+    indexed_results = results |> Enum.with_index() |> Map.new(fn {row, i} -> {i, row} end)
+
+    Enum.zip(meta[:time_labels], meta[:time_label_result_indices])
+    |> Enum.reduce([csv_first_row(query)], fn {timelabel, index}, acc ->
+      if result_item = Map.get(indexed_results, index) do
         acc ++ [[timelabel | result_item.metrics]]
       else
         acc ++ [[timelabel | meta[:empty_metrics]]]
       end
     end)
     |> NimbleCSV.RFC4180.dump_to_iodata()
-  end
-
-  defp find_result_item_by_timelabel(results, timelabel) do
-    results
-    |> Map.new(fn entry -> {Enum.at(entry.dimensions, 0), entry} end)
-    |> Map.get(timelabel)
   end
 
   defp get_order_by(["event:goal"]), do: [{:visitors, :desc}]

--- a/lib/plausible/stats/legacy/timeseries.ex
+++ b/lib/plausible/stats/legacy/timeseries.ex
@@ -5,7 +5,7 @@ defmodule Plausible.Stats.Legacy.Timeseries do
 
   use Plausible
   use Plausible.ClickhouseRepo
-  alias Plausible.Stats.{Query, QueryRunner, Metrics, Time, QueryOptimizer}
+  alias Plausible.Stats.{Query, QueryRunner, Metrics, QueryOptimizer}
 
   def timeseries(site, query, metrics) do
     [time_dimension] = query.dimensions
@@ -17,6 +17,8 @@ defmodule Plausible.Stats.Legacy.Timeseries do
         order_by: [{time_dimension, :asc}]
       )
       |> Query.set_include(:drop_unavailable_revenue_metrics, true)
+      |> Query.set_include(:time_labels, true)
+      |> Query.set_include(:time_label_result_indices, true)
       |> QueryOptimizer.optimize()
 
     query_result = QueryRunner.run(site, query)
@@ -30,29 +32,15 @@ defmodule Plausible.Stats.Legacy.Timeseries do
   # Given a query result, build a legacy timeseries result
   # Format is %{ date => %{ date: date_string, [metric] => value } } with a bunch of special cases for the UI
   defp build_result(query_result, %Query{} = query) do
-    query_result.results
-    |> Enum.map(fn
-      %{dimensions: [time_dimension_value], metrics: metrics} ->
-        metrics_map = Enum.zip(query.metrics, metrics) |> Map.new()
+    indexed_results =
+      query_result.results |> Enum.with_index() |> Map.new(fn {row, i} -> {i, row} end)
 
-        {
-          time_dimension_value,
-          Map.put(metrics_map, :date, time_dimension_value)
-        }
-    end)
-    |> Map.new()
-    |> add_labels(query)
-  end
-
-  defp add_labels(results_map, query) do
-    query
-    |> Time.time_labels()
-    |> Enum.map(fn key ->
-      Map.get(
-        results_map,
-        key,
-        empty_row(key, query.metrics, query)
-      )
+    Enum.zip(query_result.meta[:time_labels], query_result.meta[:time_label_result_indices])
+    |> Enum.map(fn {label, index} ->
+      case Map.get(indexed_results, index) do
+        nil -> empty_row(label, query.metrics, query)
+        row -> Enum.zip(query.metrics, row.metrics) |> Map.new() |> Map.put(:date, label)
+      end
     end)
     |> transform_realtime_labels(query)
     |> transform_keys(%{group_conversion_rate: :conversion_rate})

--- a/lib/plausible/stats/query_result.ex
+++ b/lib/plausible/stats/query_result.ex
@@ -47,11 +47,31 @@ defmodule Plausible.Stats.QueryResult do
   def from(%QueryRunner{results: results, comparison_results: comparison_results} = runner) do
     struct!(
       __MODULE__,
-      results: results,
-      comparison_results: comparison_results,
+      results: format_results(results, runner.main_query),
+      comparison_results: format_results(comparison_results, runner.comparison_query),
       meta: meta(runner) |> Jason.OrderedObject.new(),
       query: query(runner) |> Jason.OrderedObject.new()
     )
+  end
+
+  defp format_results(nil, _query), do: nil
+
+  defp format_results(results, query) do
+    Enum.map(results, fn row ->
+      dimensions =
+        Enum.zip_with(query.dimensions, row.dimensions, fn
+          "time:hour", key -> Plausible.Stats.Time.hour_label(key, query.timezone)
+          _dimension, value -> value
+        end)
+
+      case row do
+        %{comparison: comparison} ->
+          %{row | dimensions: dimensions, comparison: %{comparison | dimensions: dimensions}}
+
+        _ ->
+          %{row | dimensions: dimensions}
+      end
+    end)
   end
 
   defp meta(%QueryRunner{} = runner) do
@@ -133,7 +153,7 @@ defmodule Plausible.Stats.QueryResult do
       Map.put(
         meta,
         :time_label_result_indices,
-        result_indices_for_time_labels(time_labels, runner.main_results)
+        result_indices_for_time_labels(Plausible.Stats.Time.time_keys(query), runner.main_results)
       )
     else
       meta
@@ -150,7 +170,10 @@ defmodule Plausible.Stats.QueryResult do
       Map.put(
         meta,
         :comparison_time_label_result_indices,
-        result_indices_for_time_labels(comp_time_labels, runner.comparison_results)
+        result_indices_for_time_labels(
+          Plausible.Stats.Time.time_keys(runner.comparison_query),
+          runner.comparison_results
+        )
       )
     else
       meta

--- a/lib/plausible/stats/query_runner.ex
+++ b/lib/plausible/stats/query_runner.ex
@@ -130,13 +130,13 @@ defmodule Plausible.Stats.QueryRunner do
   defp build_comparison_results(%__MODULE__{main_query: query} = runner) do
     main_map = index_by_dimensions(runner.main_results)
 
-    comp_label_to_main_label =
-      Enum.zip(Time.time_labels(runner.comparison_query), Time.time_labels(query))
+    comp_key_to_main_key =
+      Enum.zip(Time.time_keys(runner.comparison_query), Time.time_keys(query))
       |> Map.new()
 
-    Enum.map(runner.comparison_results, fn %{dimensions: [comp_label]} = comp_row ->
-      main_label = Map.get(comp_label_to_main_label, comp_label)
-      main_metrics = main_label && Map.get(main_map, [main_label])
+    Enum.map(runner.comparison_results, fn %{dimensions: [comp_key]} = comp_row ->
+      main_key = Map.get(comp_key_to_main_key, comp_key)
+      main_metrics = main_key && Map.get(main_map, [main_key])
       change = calculate_metric_changes(query, main_metrics, comp_row.metrics)
 
       Map.put(comp_row, :change, change)

--- a/lib/plausible/stats/sparkline.ex
+++ b/lib/plausible/stats/sparkline.ex
@@ -145,21 +145,23 @@ defmodule Plausible.Stats.Sparkline do
         input_date_range: :"24h",
         dimensions: ["time:hour"],
         order_by: [{"time:hour", :asc}],
-        include: [time_labels: true]
+        include: [time_labels: true, time_label_result_indices: true]
       )
 
-    %Stats.QueryResult{results: results, meta: %{values: [time_labels: time_labels]}} =
+    %Stats.QueryResult{results: results, meta: meta} =
       Stats.query(view_or_site, graph_query)
 
-    visitors_by_timestamp =
-      Map.new(results, fn %{dimensions: [timestamp], metrics: [visitors]} ->
-        {timestamp, visitors}
+    visitors_by_index =
+      results
+      |> Enum.with_index()
+      |> Map.new(fn {%{metrics: [visitors]}, index} ->
+        {index, visitors}
       end)
 
     %{
       intervals:
-        Enum.map(time_labels, fn timestamp ->
-          %{interval: timestamp, visitors: Map.get(visitors_by_timestamp, timestamp, 0)}
+        Enum.zip_with(meta[:time_labels], meta[:time_label_result_indices], fn timestamp, index ->
+          %{interval: timestamp, visitors: Map.get(visitors_by_index, index, 0)}
         end)
     }
   end

--- a/lib/plausible/stats/sql/expression.ex
+++ b/lib/plausible/stats/sql/expression.ex
@@ -128,13 +128,14 @@ defmodule Plausible.Stats.SQL.Expression do
       on: true
     )
     |> select_merge_as([s, time_slot: time_slot], %{
-      key => fragment("toStartOfHour(?)", time_slot)
+      key => fragment("toUnixTimestamp(toStartOfHour(?))", time_slot)
     })
   end
 
   def select_dimension(q, key, "time:hour", _table, query) do
     select_merge_as(q, [t], %{
-      key => fragment("toStartOfHour(toTimeZone(?, ?))", t.timestamp, ^query.timezone)
+      key =>
+        fragment("toUnixTimestamp(toStartOfHour(toTimeZone(?, ?)))", t.timestamp, ^query.timezone)
     })
   end
 

--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -50,6 +50,18 @@ defmodule Plausible.Stats.Time do
     time_labels_for_dimension(time_dimension(query), query)
   end
 
+  def time_keys(query) do
+    if time_dimension(query) == "time:hour" do
+      Enum.map(hourly_buckets(query), &DateTime.to_unix(&1.first))
+    else
+      time_labels(query)
+    end
+  end
+
+  def hour_label(key, timezone) when is_integer(key) do
+    key |> DateTime.from_unix!() |> DateTime.shift_zone!(timezone) |> format_datetime()
+  end
+
   defp time_labels_for_dimension("time:month", query) do
     date_range = Query.date_range(query)
 
@@ -93,16 +105,7 @@ defmodule Plausible.Stats.Time do
   end
 
   defp time_labels_for_dimension("time:hour", query) do
-    time_range = query.utc_time_range |> DateTimeRange.to_timezone(query.timezone)
-
-    from_timestamp = beginning_of_hour(time_range.first)
-    to_timestamp = beginning_of_hour(time_range.last)
-
-    from_timestamp
-    |> Stream.iterate(&NaiveDateTime.shift(&1, hour: 1))
-    |> Enum.take_while(&(NaiveDateTime.compare(&1, to_timestamp) != :gt))
-    |> Enum.filter(&hour_occurs?(&1, query.timezone))
-    |> Enum.map(&format_datetime/1)
+    Enum.map(hourly_buckets(query), &format_datetime(&1.first))
   end
 
   defp time_labels_for_dimension("time:minute", query) do
@@ -120,16 +123,60 @@ defmodule Plausible.Stats.Time do
     |> Enum.map(&format_datetime/1)
   end
 
-  defp beginning_of_hour(%DateTime{} = datetime) do
-    datetime |> DateTime.to_naive() |> Map.merge(%{minute: 0, second: 0})
+  defp hourly_buckets(query) do
+    range = query.utc_time_range
+
+    range
+    |> DateTimeRange.to_date_range(query.timezone)
+    |> Enum.flat_map(fn date ->
+      day_start = start_of_day(date, query.timezone)
+      day_end = date |> Date.add(1) |> start_of_day(query.timezone) |> DateTime.add(-1)
+
+      # ClickHouse toStartOfHour rounds elapsed seconds from the local day start.
+      # Advancing wall-clock hours would collapse repeated hours at DST fall-back.
+      day_start
+      |> Stream.iterate(&DateTime.add(&1, 3600))
+      |> Enum.take_while(&(not DateTime.after?(&1, day_end)))
+      |> Enum.map(fn first ->
+        last = Enum.min([DateTime.add(first, 3599), day_end], DateTime)
+        %DateTimeRange{first: first, last: last}
+      end)
+    end)
+    |> Enum.filter(fn bucket ->
+      not DateTime.after?(bucket.first, range.last) and
+        not DateTime.before?(bucket.last, range.first)
+    end)
   end
 
-  defp hour_occurs?(naive_hour, timezone) do
-    [naive_hour, NaiveDateTime.add(naive_hour, 3599)]
-    |> Enum.any?(&(not match?({:gap, _, _}, DateTime.from_naive(&1, timezone))))
+  defp start_of_day(date, timezone) do
+    case DateTime.new(date, ~T[00:00:00], timezone) do
+      {:ok, datetime} -> datetime
+      {:ambiguous, first, _second} -> first
+      {:gap, _before, first} -> first
+    end
   end
 
   def partial_time_labels(time_labels, query) do
+    if time_dimension(query) == "time:hour" do
+      buckets = Enum.filter(hourly_buckets(query), &(format_datetime(&1.first) in time_labels))
+      first = List.first(buckets)
+      last = List.last(buckets)
+      cutoff = Enum.min([query.utc_time_range.last, query.now], DateTime)
+
+      [
+        if(first && DateTime.before?(first.first, query.utc_time_range.first),
+          do: format_datetime(first.first)
+        ),
+        if(last && DateTime.after?(last.last, cutoff), do: format_datetime(last.first))
+      ]
+      |> Enum.uniq()
+      |> Enum.reject(&is_nil/1)
+    else
+      partial_calendar_time_labels(time_labels, query)
+    end
+  end
+
+  defp partial_calendar_time_labels(time_labels, query) do
     time_dimension = time_dimension(query)
 
     range_start = to_naive_in_tz!(query.utc_time_range.first, query.timezone)
@@ -202,6 +249,17 @@ defmodule Plausible.Stats.Time do
   end
 
   def present_index(time_labels, query) do
+    if time_dimension(query) == "time:hour" do
+      Enum.find_index(hourly_buckets(query), fn bucket ->
+        not DateTime.before?(query.now, bucket.first) and
+          not DateTime.after?(query.now, bucket.last)
+      end)
+    else
+      calendar_present_index(time_labels, query)
+    end
+  end
+
+  defp calendar_present_index(time_labels, query) do
     now = DateTime.shift_zone!(query.now, query.timezone)
 
     current_label =
@@ -219,9 +277,6 @@ defmodule Plausible.Stats.Time do
         "time:day" ->
           DateTime.to_date(now)
           |> Date.to_string()
-
-        "time:hour" ->
-          Calendar.strftime(now, "%Y-%m-%d %H:00:00")
 
         "time:minute" ->
           Calendar.strftime(now, "%Y-%m-%d %H:%M:00")

--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -95,15 +95,14 @@ defmodule Plausible.Stats.Time do
   defp time_labels_for_dimension("time:hour", query) do
     time_range = query.utc_time_range |> DateTimeRange.to_timezone(query.timezone)
 
-    from_timestamp = time_range.first |> Map.merge(%{minute: 0, second: 0})
-    n_buckets = DateTime.diff(time_range.last, from_timestamp, :hour)
+    from_timestamp = beginning_of_hour(time_range.first)
+    to_timestamp = beginning_of_hour(time_range.last)
 
-    Enum.map(0..n_buckets, fn step ->
-      from_timestamp
-      |> DateTime.to_naive()
-      |> NaiveDateTime.shift(hour: step)
-      |> format_datetime()
-    end)
+    from_timestamp
+    |> Stream.iterate(&NaiveDateTime.shift(&1, hour: 1))
+    |> Enum.take_while(&(NaiveDateTime.compare(&1, to_timestamp) != :gt))
+    |> Enum.filter(&hour_occurs?(&1, query.timezone))
+    |> Enum.map(&format_datetime/1)
   end
 
   defp time_labels_for_dimension("time:minute", query) do
@@ -119,6 +118,15 @@ defmodule Plausible.Stats.Time do
         DateTime.before?(datetime, current_minute)
     end)
     |> Enum.map(&format_datetime/1)
+  end
+
+  defp beginning_of_hour(%DateTime{} = datetime) do
+    datetime |> DateTime.to_naive() |> Map.merge(%{minute: 0, second: 0})
+  end
+
+  defp hour_occurs?(naive_hour, timezone) do
+    [naive_hour, NaiveDateTime.add(naive_hour, 3599)]
+    |> Enum.any?(&(not match?({:gap, _, _}, DateTime.from_naive(&1, timezone))))
   end
 
   def partial_time_labels(time_labels, query) do

--- a/test/plausible/stats/hourly_dst_test.exs
+++ b/test/plausible/stats/hourly_dst_test.exs
@@ -1,0 +1,182 @@
+defmodule Plausible.Stats.HourlyDSTTest do
+  use Plausible.DataCase
+
+  alias Plausible.Stats
+  alias Plausible.Stats.{DateTimeRange, QueryBuilder, Time}
+
+  setup [:create_user, :create_site]
+
+  test "sparse fall-back rows map to the correct occurrence", %{site: site} do
+    site = Plausible.Repo.update!(Ecto.Changeset.change(site, timezone: "America/New_York"))
+    populate_stats(site, [build(:pageview, timestamp: ~N[2024-11-03 06:30:00])])
+
+    result = Stats.query(site, hourly_query(site, ~D[2024-11-03], ~D[2024-11-03]))
+
+    assert result.results == [%{dimensions: ["2024-11-03 01:00:00"], metrics: [1]}]
+    assert length(result.meta[:time_labels]) == 25
+    assert Enum.slice(result.meta[:time_label_result_indices], 1, 2) == [nil, 0]
+  end
+
+  test "legacy, sparkline and CSV responses preserve sparse repeated hours", %{site: site} do
+    site = Plausible.Repo.update!(Ecto.Changeset.change(site, timezone: "America/New_York"))
+    populate_stats(site, [build(:pageview, timestamp: ~N[2024-11-03 06:30:00])])
+
+    {legacy_rows, _meta} =
+      Stats.Legacy.Timeseries.timeseries(
+        site,
+        hourly_query(site, ~D[2024-11-03], ~D[2024-11-03]),
+        [:pageviews]
+      )
+
+    assert Enum.slice(legacy_rows, 1, 2) == [
+             %{date: "2024-11-03 01:00:00", pageviews: 0},
+             %{date: "2024-11-03 01:00:00", pageviews: 1}
+           ]
+
+    sparkline = Stats.Sparkline.overview_24h(site, ~N[2024-11-03 08:00:00])
+    repeated = Enum.filter(sparkline.intervals, &(&1.interval == "2024-11-03 01:00:00"))
+
+    assert repeated == [
+             %{interval: "2024-11-03 01:00:00", visitors: 0},
+             %{interval: "2024-11-03 01:00:00", visitors: 1}
+           ]
+
+    params = %{
+      "date_range" => "day",
+      "relative_date" => "2024-11-03",
+      "filters" => [],
+      "include" => %{},
+      "reports" => %{
+        "visitors.csv" => %{"dimensions" => ["time:hour"], "metrics" => ["pageviews"]}
+      }
+    }
+
+    assert {:ok, [{~c"visitors.csv", csv}]} =
+             Stats.Dashboard.CsvExport.get_csvs(site, params, %{})
+
+    assert Enum.slice(NimbleCSV.RFC4180.parse_string(csv), 1, 2) == [
+             ["2024-11-03 01:00:00", "0"],
+             ["2024-11-03 01:00:00", "1"]
+           ]
+  end
+
+  test "fall-back metrics remain distinct in events and smeared sessions", %{site: site} do
+    site = Plausible.Repo.update!(Ecto.Changeset.change(site, timezone: "America/New_York"))
+
+    populate_stats(site, [
+      build(:pageview, timestamp: ~N[2024-11-03 05:30:00]),
+      build(:pageview, timestamp: ~N[2024-11-03 06:30:00]),
+      build(:pageview, timestamp: ~N[2024-11-03 06:45:00])
+    ])
+
+    query = hourly_query(site, ~D[2024-11-03], ~D[2024-11-03])
+    query = Stats.Query.set(query, metrics: [:pageviews, :visits])
+    result = Stats.query(site, query)
+
+    assert result.results == [
+             %{dimensions: ["2024-11-03 01:00:00"], metrics: [1, 1]},
+             %{dimensions: ["2024-11-03 01:00:00"], metrics: [2, 2]}
+           ]
+
+    assert Enum.slice(result.meta[:time_label_result_indices], 1, 2) == [0, 1]
+  end
+
+  test "spring-forward retains the final hour without inventing a bucket", %{site: site} do
+    site = Plausible.Repo.update!(Ecto.Changeset.change(site, timezone: "America/New_York"))
+    populate_stats(site, [build(:pageview, timestamp: ~N[2024-03-11 03:30:00])])
+    result = Stats.query(site, hourly_query(site, ~D[2024-03-10], ~D[2024-03-10]))
+
+    assert length(result.meta[:time_labels]) == 23
+    refute "2024-03-10 02:00:00" in result.meta[:time_labels]
+    assert List.last(result.meta[:time_labels]) == "2024-03-10 23:00:00"
+    assert List.last(result.meta[:time_label_result_indices]) == 0
+    assert result.results == [%{dimensions: ["2024-03-10 23:00:00"], metrics: [1]}]
+  end
+
+  test "comparison aligns elapsed buckets and retains an unmatched final bucket", %{site: site} do
+    site = Plausible.Repo.update!(Ecto.Changeset.change(site, timezone: "America/New_York"))
+
+    populate_stats(site, [
+      build(:pageview, timestamp: ~N[2024-11-04 06:30:00]),
+      build(:pageview, timestamp: ~N[2024-11-04 07:30:00]),
+      build(:pageview, timestamp: ~N[2024-11-04 07:45:00]),
+      build(:pageview, timestamp: ~N[2024-11-03 05:30:00]),
+      build(:pageview, timestamp: ~N[2024-11-03 06:30:00]),
+      build(:pageview, timestamp: ~N[2024-11-04 04:30:00])
+    ])
+
+    query =
+      hourly_query(site, ~D[2024-11-04], ~D[2024-11-04])
+      |> Stats.Query.set_include(:compare, {:date_range, ~D[2024-11-03], ~D[2024-11-03]})
+      |> QueryBuilder.put_comparison_utc_time_range()
+
+    result = Stats.query(site, query)
+
+    assert length(result.meta[:time_labels]) == 24
+    assert length(result.meta[:comparison_time_labels]) == 25
+
+    assert result.comparison_results == [
+             %{dimensions: ["2024-11-03 01:00:00"], metrics: [1], change: [0]},
+             %{dimensions: ["2024-11-03 01:00:00"], metrics: [1], change: [100]},
+             %{dimensions: ["2024-11-03 23:00:00"], metrics: [1], change: nil}
+           ]
+
+    assert Enum.slice(result.meta[:comparison_time_label_result_indices], 1, 2) == [0, 1]
+    assert List.last(result.meta[:comparison_time_label_result_indices]) == 2
+  end
+
+  test "nested comparison dimensions do not expose internal hour keys", %{site: site} do
+    populate_stats(site, [build(:pageview, timestamp: ~N[2024-11-04 06:30:00])])
+
+    query =
+      hourly_query(site, ~D[2024-11-04], ~D[2024-11-04])
+      |> Stats.Query.set(dimensions: ["time:hour", "event:page"])
+      |> Stats.Query.set_include(:time_labels, false)
+      |> Stats.Query.set_include(:compare, {:date_range, ~D[2024-11-03], ~D[2024-11-03]})
+      |> QueryBuilder.put_comparison_utc_time_range()
+
+    assert [row] = Stats.query(site, query).results
+    assert ["2024-11-04 06:00:00", _page] = row.dimensions
+    assert row.comparison.dimensions == row.dimensions
+  end
+
+  for {timezone, first, last} <- [
+        {"America/New_York", ~D[2024-03-09], ~D[2024-03-11]},
+        {"America/New_York", ~D[2024-11-02], ~D[2024-11-04]},
+        {"Europe/Tallinn", ~D[2025-10-26], ~D[2025-10-26]},
+        {"Pacific/Chatham", ~D[2024-04-07], ~D[2024-04-07]},
+        {"Pacific/Chatham", ~D[2024-09-29], ~D[2024-09-29]},
+        {"Australia/Lord_Howe", ~D[2024-10-06], ~D[2024-10-07]},
+        {"Australia/Lord_Howe", ~D[2024-04-07], ~D[2024-04-08]},
+        {"Asia/Kathmandu", ~D[2024-01-01], ~D[2024-01-01]}
+      ] do
+    @timezone timezone
+    @first first
+    @last last
+    test "hourly spine matches ClickHouse buckets for #{timezone} #{@first}" do
+      range = DateTimeRange.new!(@first, @last, @timezone)
+      first = DateTime.to_unix(range.first)
+      count = div(DateTime.diff(range.last, range.first), 60) + 1
+
+      %{rows: rows} =
+        Plausible.ClickhouseRepo.query!("""
+        SELECT DISTINCT toUnixTimestamp(toStartOfHour(toTimeZone(
+          toDateTime(#{first}, 'UTC') + number * 60, '#{@timezone}'))) AS bucket
+        FROM numbers(#{count}) ORDER BY bucket
+        """)
+
+      query = %{dimensions: ["time:hour"], utc_time_range: range, timezone: @timezone}
+      assert Time.time_keys(query) == Enum.map(rows, &hd/1)
+    end
+  end
+
+  defp hourly_query(site, first, last) do
+    QueryBuilder.build!(site,
+      metrics: [:pageviews],
+      dimensions: ["time:hour"],
+      input_date_range: {:date_range, first, last},
+      order_by: [{"time:hour", :asc}],
+      include: [time_labels: true, time_label_result_indices: true]
+    )
+  end
+end

--- a/test/plausible/stats/time_test.exs
+++ b/test/plausible/stats/time_test.exs
@@ -388,6 +388,59 @@ defmodule Plausible.Stats.TimeTest do
              ]
     end
 
+    test "with time:hour dimension on a day that loses an hour to DST" do
+      # Clocks jump 02:00 -> 03:00, so the day has 23 hours and no 02:00 at all.
+      labels =
+        time_labels(%{
+          dimensions: ["time:hour"],
+          utc_time_range:
+            DateTimeRange.new!(~D[2024-03-10], ~D[2024-03-10], "America/New_York")
+            |> DateTimeRange.to_timezone("Etc/UTC"),
+          timezone: "America/New_York"
+        })
+
+      assert length(labels) == 23
+      assert List.first(labels) == "2024-03-10 00:00:00"
+      assert List.last(labels) == "2024-03-10 23:00:00"
+      refute "2024-03-10 02:00:00" in labels
+    end
+
+    test "with time:hour dimension on a day that repeats an hour due to DST" do
+      # Clocks fall back 02:00 -> 01:00, so the day has 25 hours but only 24 buckets.
+      labels =
+        time_labels(%{
+          dimensions: ["time:hour"],
+          utc_time_range:
+            DateTimeRange.new!(~D[2024-11-03], ~D[2024-11-03], "America/New_York")
+            |> DateTimeRange.to_timezone("Etc/UTC"),
+          timezone: "America/New_York"
+        })
+
+      assert length(labels) == 24
+      assert List.first(labels) == "2024-11-03 00:00:00"
+      assert List.last(labels) == "2024-11-03 23:00:00"
+      assert Enum.count(labels, &(&1 == "2024-11-03 01:00:00")) == 1
+    end
+
+    test "with time:hour dimension in a timezone whose DST transition is not on the hour" do
+      # Chatham switches at 02:45 local, so the 02:00 and 03:00 hours are cut short
+      # but both still exist.
+      for date <- [~D[2024-09-29], ~D[2024-04-07]] do
+        labels =
+          time_labels(%{
+            dimensions: ["time:hour"],
+            utc_time_range:
+              DateTimeRange.new!(date, date, "Pacific/Chatham")
+              |> DateTimeRange.to_timezone("Etc/UTC"),
+            timezone: "Pacific/Chatham"
+          })
+
+        assert length(labels) == 24
+        assert List.first(labels) == "#{date} 00:00:00"
+        assert List.last(labels) == "#{date} 23:00:00"
+      end
+    end
+
     test "with time:minute dimension" do
       now = DateTime.new!(~D[2024-01-01], ~T[12:30:57], "UTC")
 

--- a/test/plausible/stats/time_test.exs
+++ b/test/plausible/stats/time_test.exs
@@ -406,7 +406,7 @@ defmodule Plausible.Stats.TimeTest do
     end
 
     test "with time:hour dimension on a day that repeats an hour due to DST" do
-      # Clocks fall back 02:00 -> 01:00, so the day has 25 hours but only 24 buckets.
+      # Each occurrence of 01:00 has its own absolute bucket.
       labels =
         time_labels(%{
           dimensions: ["time:hour"],
@@ -416,16 +416,14 @@ defmodule Plausible.Stats.TimeTest do
           timezone: "America/New_York"
         })
 
-      assert length(labels) == 24
+      assert length(labels) == 25
       assert List.first(labels) == "2024-11-03 00:00:00"
       assert List.last(labels) == "2024-11-03 23:00:00"
-      assert Enum.count(labels, &(&1 == "2024-11-03 01:00:00")) == 1
+      assert Enum.count(labels, &(&1 == "2024-11-03 01:00:00")) == 2
     end
 
     test "with time:hour dimension in a timezone whose DST transition is not on the hour" do
-      # Chatham switches at 02:45 local, so the 02:00 and 03:00 hours are cut short
-      # but both still exist.
-      for date <- [~D[2024-09-29], ~D[2024-04-07]] do
+      for {date, count} <- [{~D[2024-09-29], 23}, {~D[2024-04-07], 25}] do
         labels =
           time_labels(%{
             dimensions: ["time:hour"],
@@ -435,10 +433,43 @@ defmodule Plausible.Stats.TimeTest do
             timezone: "Pacific/Chatham"
           })
 
-        assert length(labels) == 24
+        assert length(labels) == count
         assert List.first(labels) == "#{date} 00:00:00"
         assert List.last(labels) == "#{date} 23:00:00"
       end
+    end
+
+    test "hourly keys preserve a sub-day window across a backward transition" do
+      query = %{
+        dimensions: ["time:hour"],
+        utc_time_range: DateTimeRange.new!(~U[2024-04-06 13:30:00Z], ~U[2024-04-06 14:30:00Z]),
+        timezone: "Pacific/Chatham"
+      }
+
+      assert time_labels(query) == ["2024-04-07 03:00:00", "2024-04-07 03:00:00"]
+      assert time_keys(query) == [1_712_409_300, 1_712_412_900]
+    end
+
+    test "present index identifies the second occurrence of a repeated hour" do
+      query = %{
+        dimensions: ["time:hour"],
+        utc_time_range: DateTimeRange.new!(~D[2024-11-03], ~D[2024-11-03], "America/New_York"),
+        now: ~U[2024-11-03 06:30:00Z],
+        timezone: "America/New_York"
+      }
+
+      assert present_index(time_labels(query), query) == 2
+    end
+
+    test "explicit UTC range includes both occurrences of an ambiguous midnight" do
+      query = %{
+        dimensions: ["time:hour"],
+        utc_time_range: DateTimeRange.new!(~U[2023-11-05 04:30:00Z], ~U[2023-11-05 05:30:00Z]),
+        timezone: "America/Havana"
+      }
+
+      assert time_labels(query) == ["2023-11-05 00:00:00", "2023-11-05 00:00:00"]
+      assert time_keys(query) == [1_699_156_800, 1_699_160_400]
     end
 
     test "with time:minute dimension" do


### PR DESCRIPTION
### Changes

Fix hourly bucket identity and the response spine together, including sparse data on 23-hour and 25-hour days and multi-day ranges.

- Query ClickHouse's hourly bucket as a Unix timestamp in the existing dimension, for both events and smeared sessions.
- Keep that absolute key through result indexing and comparison matching; convert to a local display string only when constructing the response.
- Generate the hourly spine from each local day's start in elapsed-hour steps and filter by absolute overlap with the query range. This also covers partial-hour DST transitions and sub-day windows whose local endpoints run backward.
- Map legacy timeseries, sparklines and CSV rows through result indices, so two occurrences of the same local hour do not collapse or duplicate metrics.
- Compute the current-hour index using absolute bucket intervals.

### Comparison behavior

Preserve the existing positional alignment: bucket 0 compares with bucket 0, bucket 1 with bucket 1, and so on. This is elapsed-bucket alignment, not same-wall-clock-hour alignment after a DST transition. Both series keep their own length; an unmatched final comparison bucket retains its metrics and has `change: nil`. The frontend already uses the longer series length.

### Why not plain WITH FILL?

A single `WITH FILL STEP toIntervalHour(1)` over a multi-day range does not necessarily match `toStartOfHour` around half-hour offset changes. In a local ClickHouse 26.7.5.10 experiment spanning October 6-7, 2024 in Australia/Lord_Howe, a sparse fill produced 49 buckets, including 24 spurious half-hour buckets on October 7; aggregating minute samples produced 48 buckets and no such October 7 buckets.

This implementation leaves metric rows sparse and replaces the existing dimension value rather than adding a second timestamp column. It does not claim a production bandwidth benchmark or rule out a more elaborate ClickHouse-generated spine.

### Validation

Prepared with AI assistance; these are tool-run results, not a claim of independent human review.

- 41 focused time/DST tests pass, covering sparse repeated hours, events and sessions, legacy/sparkline/CSV mapping, comparisons, partial windows, and eight direct ClickHouse bucket/spine comparisons.
- Statistics tests plus main graph, dashboard CSV and external Stats API tests: **1,346 / 1,347 passed**, with two excluded tests.
- The one failure, `ExplorationTest` at `exploration_test.exs:781`, reproduces unchanged on the original PR head `c92fcfd` in the same environment.
- Formatting and `git diff --check` pass.
- Local environment: Elixir 1.20.4, PostgreSQL 17.11, ClickHouse 26.7.5.10. This is not validation against the project's ClickHouse 25.11 service image.

The earlier Tzdata-only exhaustive-sweep claim is not used as evidence for this revision: the relevant oracle is ClickHouse's actual bucket behavior.

### Tests
- [x] Automated tests have been added

### Changelog
- [x] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change UI styling
