### PR TITLE
Fix e2e TZ and add missing Tailwind compile

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -23,8 +23,10 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('')`. */
     baseURL,
 
-    // launchOptions: {slowMo: 500},
+    /* Sets single TZ for all envs where the tests run */
+    timezoneId: 'UTC',
 
+    // launchOptions: {slowMo: 500},
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry'
   },

--- a/mix.exs
+++ b/mix.exs
@@ -198,6 +198,7 @@ defmodule Plausible.MixProject do
       # mix test.e2e --ui
       # mix test.e2e --debug segments.spec.ts
       "test.e2e": [
+        "tailwind default",
         "esbuild default",
         "esbuild friendly_captcha",
         "ecto.create --quiet",


### PR DESCRIPTION
### Changes

Fixes two small e2e setup issues: 
- e2e tests failing on a local machine that is not in UTC timezone
- CSS not being compiled

The last one I discovered when making local changes to app.css: they didn't take effect when running e2e tests. After the PR, they do.