### PR TITLE
Implement routes for discovering /mcp and the OAuth endpoints

### DIFF
--- a/lib/plausible/auth/scopes.ex
+++ b/lib/plausible/auth/scopes.ex
@@ -1,0 +1,12 @@
+defmodule Plausible.Auth.Scopes do
+  @moduledoc """
+  This module enumerates the scopes that any particular
+  authorization grant can be limited to.
+  """
+
+  @stats_read_star "stats:read:*"
+  def stats_read(), do: @stats_read_star
+
+  @sites_read_star "sites:read:*"
+  def sites_read(), do: @sites_read_star
+end

--- a/lib/plausible/auth/scopes.ex
+++ b/lib/plausible/auth/scopes.ex
@@ -4,9 +4,9 @@ defmodule Plausible.Auth.Scopes do
   authorization grant can be limited to.
   """
 
-  @stats_read_star "stats:read:*"
-  def stats_read(), do: @stats_read_star
+  @stats_read_all "stats:read:*"
+  def stats_read(), do: @stats_read_all
 
-  @sites_read_star "sites:read:*"
-  def sites_read(), do: @sites_read_star
+  @sites_read_all "sites:read:*"
+  def sites_read(), do: @sites_read_all
 end

--- a/lib/plausible/oauth/protected_resources.ex
+++ b/lib/plausible/oauth/protected_resources.ex
@@ -1,0 +1,12 @@
+defmodule Plausible.OAuth.ProtectedResources do
+  @moduledoc """
+  The protected resources the OAuth authorization server will issue tokens for.
+  Each authorization grant is associated with a particular resource.
+  """
+
+  def mcp(),
+    do: %{
+      resource_path: "/mcp",
+      scopes_supported: [Plausible.Auth.Scopes.sites_read()]
+    }
+end

--- a/lib/plausible_web/controllers/oauth/metadata_controller.ex
+++ b/lib/plausible_web/controllers/oauth/metadata_controller.ex
@@ -23,6 +23,9 @@ defmodule PlausibleWeb.OAuth.MetadataController do
     })
   end
 
+  @authorization_endpoint "/login/oauth/authorize"
+  @token_endpoint "/login/oauth/token"
+
   @doc """
   Serves the [RFC 8414 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414.html#section-2)
   advertising the authorize and token endpoints and the grants they accept.
@@ -30,8 +33,8 @@ defmodule PlausibleWeb.OAuth.MetadataController do
   def authorization_server(conn, _params) do
     json(conn, %{
       issuer: Endpoint.url(),
-      authorization_endpoint: Endpoint.url() <> authorization_endpoint(),
-      token_endpoint: Endpoint.url() <> token_endpoint(),
+      authorization_endpoint: Endpoint.url() <> @authorization_endpoint,
+      token_endpoint: Endpoint.url() <> @token_endpoint,
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code"],
       code_challenge_methods_supported: ["S256"],
@@ -40,7 +43,4 @@ defmodule PlausibleWeb.OAuth.MetadataController do
       client_id_metadata_document_supported: true
     })
   end
-
-  defp authorization_endpoint(), do: "/login/oauth/authorize"
-  defp token_endpoint(), do: "/login/oauth/token"
 end

--- a/lib/plausible_web/controllers/oauth/metadata_controller.ex
+++ b/lib/plausible_web/controllers/oauth/metadata_controller.ex
@@ -5,13 +5,22 @@ defmodule PlausibleWeb.OAuth.MetadataController do
 
   use PlausibleWeb, :controller
 
+  alias PlausibleWeb.Endpoint
+
+  @mcp Plausible.OAuth.ProtectedResources.mcp()
+
   @doc """
   Serves the [RFC 9728 Protected Resource Metadata](https://www.rfc-editor.org/rfc/rfc9728.html#name-protected-resource-metadata)
   naming `/mcp` as the resource and pointing at the authorization server that
   protects it.
   """
-  def protected_resource(conn, _params) do
-    not_implemented(conn)
+  def mcp_protected_resource(conn, _params) do
+    json(conn, %{
+      resource: Endpoint.url() <> @mcp.resource_path,
+      authorization_servers: [Endpoint.url()],
+      scopes_supported: @mcp.scopes_supported,
+      bearer_methods_supported: ["header"]
+    })
   end
 
   @doc """
@@ -19,12 +28,19 @@ defmodule PlausibleWeb.OAuth.MetadataController do
   advertising the authorize and token endpoints and the grants they accept.
   """
   def authorization_server(conn, _params) do
-    not_implemented(conn)
+    json(conn, %{
+      issuer: Endpoint.url(),
+      authorization_endpoint: Endpoint.url() <> authorization_endpoint(),
+      token_endpoint: Endpoint.url() <> token_endpoint(),
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["none"],
+      scopes_supported: @mcp.scopes_supported,
+      client_id_metadata_document_supported: true
+    })
   end
 
-  defp not_implemented(conn) do
-    conn
-    |> put_status(501)
-    |> json(%{error: "not_implemented"})
-  end
+  defp authorization_endpoint(), do: "/login/oauth/authorize"
+  defp token_endpoint(), do: "/login/oauth/token"
 end

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -113,8 +113,7 @@ defmodule PlausibleWeb.Router do
   scope "/.well-known", PlausibleWeb do
     pipe_through :external_api
 
-    get "/oauth-protected-resource", OAuth.MetadataController, :protected_resource
-    get "/oauth-protected-resource/mcp", OAuth.MetadataController, :protected_resource
+    get "/oauth-protected-resource/mcp", OAuth.MetadataController, :mcp_protected_resource
 
     get "/oauth-authorization-server", OAuth.MetadataController, :authorization_server
   end

--- a/test/plausible_web/controllers/oauth/metadata_controller_test.exs
+++ b/test/plausible_web/controllers/oauth/metadata_controller_test.exs
@@ -1,0 +1,38 @@
+defmodule PlausibleWeb.OAuth.MetadataControllerTest do
+  use PlausibleWeb.ConnCase, async: true
+
+  describe "GET /.well-known/oauth-authorization-server" do
+    test "advertises the endpoints, grants and CIMD support", %{conn: conn} do
+      issuer = PlausibleWeb.Endpoint.url()
+
+      resp = conn |> get("/.well-known/oauth-authorization-server") |> json_response(200)
+
+      assert_matches ^strict_map(%{
+                       "issuer" => ^issuer,
+                       "authorization_endpoint" => ^(issuer <> "/login/oauth/authorize"),
+                       "token_endpoint" => ^(issuer <> "/login/oauth/token"),
+                       "response_types_supported" => ["code"],
+                       "grant_types_supported" => ["authorization_code"],
+                       "code_challenge_methods_supported" => ["S256"],
+                       "token_endpoint_auth_methods_supported" => ["none"],
+                       "scopes_supported" => ["sites:read:*"],
+                       "client_id_metadata_document_supported" => true
+                     }) = resp
+    end
+  end
+
+  describe "GET /.well-known/oauth-protected-resource/mcp" do
+    test "names /mcp as the resource and points at the authorization server", %{conn: conn} do
+      issuer = PlausibleWeb.Endpoint.url()
+
+      resp = conn |> get("/.well-known/oauth-protected-resource/mcp") |> json_response(200)
+
+      assert_matches ^strict_map(%{
+                       "resource" => ^(issuer <> "/mcp"),
+                       "authorization_servers" => [^issuer],
+                       "bearer_methods_supported" => ["header"],
+                       "scopes_supported" => ["sites:read:*"]
+                     }) = resp
+    end
+  end
+end


### PR DESCRIPTION
### Changes

This adds the routes to discover the `/mcp` and OAuth endpoints. 

What we expect clients to do when wanting to request data at `#{server}/#{path}`:
1) add `/.well-known/oauth-protected-resource/` between `server` and `path` 
2) learn on that path how to auth.
I've removed the fallback route get "/.well-known/oauth-protected-resource" for now. If it turns out to be necessary, can always be added back in.

It also proposes a general `Plausible.Auth.Scopes` module, to be used to centralize scope names, descriptions. Adopting the general module means refactoring some code related to API keys as well. The alternative is to redeclare the same `stats:read:*` etc scopes separately for OAuth. 

In anticipation of more than one resource protected by OAuth (maybe Plugins API as well), this adds the `ProtectedResources` module.


### Tests
- [x] Automated tests have been added

### Changelog
- [x] Will be documented together with /mcp release

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
