### PR TITLE
Disable CORS on /login/oauth/authorize

### DIFF
--- a/lib/plausible_web/endpoint.ex
+++ b/lib/plausible_web/endpoint.ex
@@ -85,7 +85,7 @@ defmodule PlausibleWeb.Endpoint do
 
   plug(:runtime_session)
 
-  plug(CORSPlug)
+  plug(:cors)
   plug(PlausibleWeb.Router)
 
   def secure_cookie?, do: config!(:secure_cookie)
@@ -93,6 +93,13 @@ defmodule PlausibleWeb.Endpoint do
   def websocket_url() do
     config!(:websocket_url)
   end
+
+  @authorization_endpoint_path "/login/oauth/authorize"
+  @cors_opts CORSPlug.init([])
+
+  # As per OAuth 2.1, section 3.1, CORS must not be supported at the authorization endpoint
+  def cors(%Plug.Conn{request_path: @authorization_endpoint_path} = conn, _opts), do: conn
+  def cors(conn, _opts), do: CORSPlug.call(conn, @cors_opts)
 
   def runtime_session(conn, _opts) do
     Plug.run(conn, [{Plug.Session, runtime_session_opts()}])


### PR DESCRIPTION
### Changes

This PR disables CORS at `/login/oauth/authorize`.
```
   Cross-Origin Resource Sharing [WHATWG.CORS] MUST NOT be supported at
   the Authorization Endpoint as the client does not access this
   endpoint directly, instead the client redirects the user agent to it.
```
From https://datatracker.ietf.org/doc/draft-ietf-oauth-v2-1/15/ (_section 3.1_)
 
### Tests
- [x] Not needed

### Changelog
- [x] This PR does not make a user-facing change

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] This PR does not change the UI
