### PR TITLE
[Team Deletions] Clear stale stats regardless of deletion reason

### DIFF
--- a/lib/plausible/pending_stats_deletions.ex
+++ b/lib/plausible/pending_stats_deletions.ex
@@ -15,31 +15,29 @@ defmodule Plausible.PendingStatsDeletions do
     Repo.insert(%PendingStatsDeletion{site_id: site.id, reason: reason})
   end
 
-  @spec list(atom()) :: [pos_integer()]
-  def list(reason \\ :user_request) do
-    from(p in PendingStatsDeletion,
-      where: p.reason == ^reason,
-      distinct: true,
-      order_by: p.site_id,
-      select: p.site_id
-    )
+  @doc """
+  All pending deletions
+  """
+  @spec list() :: [pos_integer()]
+  def list() do
+    from(p in PendingStatsDeletion, distinct: true, order_by: p.site_id, select: p.site_id)
     |> Repo.all()
   end
 
-  @spec clear([pos_integer()], atom()) :: {non_neg_integer(), nil}
-  def clear(site_ids, reason \\ :user_request)
-  def clear([], _reason), do: {0, nil}
+  @doc """
+  Clears pending deletion records for the given site_ids
+  """
+  @spec clear([pos_integer()]) :: {non_neg_integer(), nil}
+  def clear([]), do: {0, nil}
 
-  def clear(site_ids, reason) do
-    Repo.delete_all(
-      from(p in PendingStatsDeletion, where: p.site_id in ^site_ids and p.reason == ^reason)
-    )
+  def clear(site_ids) do
+    Repo.delete_all(from(p in PendingStatsDeletion, where: p.site_id in ^site_ids))
   end
 
   # Temporary. Bridges sites deleted before pending stats deletion tracking
   # existed. Finds sites with orphaned ClickHouse data (no matching Postgres
   # site) and records a pending deletion for each, so `ClickhouseCleanSites`
-  # picks them up via `list/1`. Safe to run more than once. Remove
+  # picks them up via `list/0`. Safe to run more than once. Remove
   # once it's been run in every environment.
   @spec backfill_orphaned_sites() :: {:ok, non_neg_integer()}
   def backfill_orphaned_sites() do

--- a/test/plausible/pending_stats_deletions_test.exs
+++ b/test/plausible/pending_stats_deletions_test.exs
@@ -39,7 +39,7 @@ defmodule Plausible.PendingStatsDeletionsTest do
     end
   end
 
-  describe "list/1" do
+  describe "list/0" do
     test "returns an empty list when there are no pending stats deletions" do
       assert PendingStatsDeletions.list() == []
     end
@@ -52,21 +52,24 @@ defmodule Plausible.PendingStatsDeletionsTest do
       assert PendingStatsDeletions.list() == [1, 2]
     end
 
-    test "only considers records with the given reason" do
+    test "returns site_ids regardless of reason" do
       insert(:pending_stats_deletion, site_id: 1, reason: :user_request)
+      insert(:pending_stats_deletion, site_id: 2, reason: :expired_trial)
+      insert(:pending_stats_deletion, site_id: 3, reason: :churned_subscription)
 
-      assert PendingStatsDeletions.list(:user_request) == [1]
+      assert PendingStatsDeletions.list() == [1, 2, 3]
     end
   end
 
-  describe "clear/2" do
-    test "removes records for the given site_ids and reason" do
+  describe "clear/1" do
+    test "removes records for the given site_ids, regardless of reason" do
       insert(:pending_stats_deletion, site_id: 1, reason: :user_request)
-      insert(:pending_stats_deletion, site_id: 2, reason: :user_request)
+      insert(:pending_stats_deletion, site_id: 2, reason: :expired_trial)
+      insert(:pending_stats_deletion, site_id: 3, reason: :churned_subscription)
 
-      assert {1, nil} = PendingStatsDeletions.clear([1])
+      assert {2, nil} = PendingStatsDeletions.clear([1, 2])
 
-      assert PendingStatsDeletions.list() == [2]
+      assert PendingStatsDeletions.list() == [3]
     end
 
     test "removes all matching records regardless of how many accumulated for a site" do

--- a/test/workers/clickhouse_clean_sites_test.exs
+++ b/test/workers/clickhouse_clean_sites_test.exs
@@ -60,6 +60,30 @@ defmodule Plausible.Workers.ClickhouseCleanSitesTest do
   end
 
   @tag :slow
+  test "deletes data for sites pending deletion for a reason other than :user_request" do
+    expired_trial_site = new_site()
+    churned_subscription_site = new_site()
+
+    populate_stats(expired_trial_site, [build(:pageview)])
+    populate_stats(churned_subscription_site, [build(:pageview)])
+
+    assert {:ok, _} = Plausible.Site.Removal.run(expired_trial_site, reason: :expired_trial)
+
+    assert {:ok, _} =
+             Plausible.Site.Removal.run(churned_subscription_site,
+               reason: :churned_subscription
+             )
+
+    ClickhouseCleanSites.perform(nil)
+
+    assert_count(expired_trial_site, "events_v2", 0)
+    assert_count(churned_subscription_site, "events_v2", 0)
+
+    refute Repo.get_by(PendingStatsDeletion, site_id: expired_trial_site.id)
+    refute Repo.get_by(PendingStatsDeletion, site_id: churned_subscription_site.id)
+  end
+
+  @tag :slow
   test "deletes data spanning multiple monthly partitions" do
     deleted_site = new_site()
 


### PR DESCRIPTION
Currently, reason other than `:user_request` won't be picked up by the CleanSites worker. This PR renders the reason only a commentary column available for manual inspection.