### PR TITLE
Tighten spacing and typography on sites and settings pages

### DIFF
--- a/extra/lib/plausible_web/live/customer_support/components/layout.ex
+++ b/extra/lib/plausible_web/live/customer_support/components/layout.ex
@@ -91,8 +91,8 @@ defmodule PlausibleWeb.CustomerSupport.Components.Layout do
 
   defp header(assigns) do
     ~H"""
-    <div class="group mt-6 pb-5 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
-      <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate flex-shrink-0">
+    <div class="group py-4 border-b border-gray-200 dark:border-gray-500 flex items-center justify-between">
+      <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 sm:text-2xl sm:truncate flex-shrink-0">
         <.link
           replace
           patch={

--- a/extra/lib/plausible_web/live/customer_support/components/search.ex
+++ b/extra/lib/plausible_web/live/customer_support/components/search.ex
@@ -22,7 +22,7 @@ defmodule PlausibleWeb.CustomerSupport.Components.Search do
   def render(assigns) do
     ~H"""
     <div>
-      <ul :if={@results != []} class="my-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <ul :if={@results != []} class="my-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <li :for={r <- @results} class="group relative">
           <.link patch={r.path} data-test-type={r.type} data-test-id={r.id}>
             <div class="col-span-1 bg-white dark:bg-gray-800 rounded-lg shadow p-4 group-hover:shadow-lg cursor-pointer">

--- a/lib/plausible_web/components/layout.ex
+++ b/lib/plausible_web/components/layout.ex
@@ -3,7 +3,7 @@ defmodule PlausibleWeb.Components.Layout do
 
   use Phoenix.Component
 
-  attr :class, :string, default: "w-24 sm:w-30"
+  attr :class, :string, default: "w-24 sm:w-28"
 
   def logo(assigns) do
     ~H"""

--- a/lib/plausible_web/components/layouts/header.html.heex
+++ b/lib/plausible_web/components/layouts/header.html.heex
@@ -131,7 +131,7 @@
                   </:menu>
                 </.dropdown>
               </li>
-              <li :if={ee?()} id="changelog-notification" class="relative py-2"></li>
+              <li :if={ee?()} id="changelog-notification" class="relative py-2 empty:hidden"></li>
             </ul>
           <% Plausible.Auth.check_registration_enabled() != :ok -> %>
             <ul class="flex" x-show="!document.cookie.includes('logged_in=true')">

--- a/lib/plausible_web/live/sites.ex
+++ b/lib/plausible_web/live/sites.ex
@@ -115,8 +115,8 @@ defmodule PlausibleWeb.Live.Sites do
         @needs_to_upgrade == {:needs_to_upgrade, :no_active_trial_or_subscription}
       } />
 
-      <div class="group mt-6 pb-5 border-b border-gray-200 dark:border-gray-750 flex items-center gap-2">
-        <h2 class="text-xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-2xl md:text-3xl sm:leading-9 min-w-0 truncate">
+      <div class="group py-4 border-b border-gray-200 dark:border-gray-750 flex items-center gap-2">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 sm:text-2xl min-w-0 truncate">
           {Teams.name(@current_team)}
         </h2>
         <.unstyled_link
@@ -174,7 +174,7 @@ defmodule PlausibleWeb.Live.Sites do
         </div>
       </div>
 
-      <div class="flex flex-col gap-y-4 my-4">
+      <div class="flex flex-col gap-y-4 has-[*]:my-4">
         <PlausibleWeb.Team.Notice.team_invitations team_invitations={@team_invitations} />
         <PlausibleWeb.Team.Notice.site_ownership_invitations
           site_ownership_invitations={@site_ownership_invitations}
@@ -238,7 +238,7 @@ defmodule PlausibleWeb.Live.Sites do
       </div>
 
       <div :if={@has_sites?}>
-        <ul class="my-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <ul class="my-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           <.consolidated_view_card_cta
             :if={
               not @searching? and
@@ -325,7 +325,7 @@ defmodule PlausibleWeb.Live.Sites do
     ~H"""
     <li
       data-test-id="consolidated-view-card-cta"
-      class="relative col-span-1 flex flex-col justify-between bg-white p-6 dark:bg-gray-800 rounded-md shadow-lg dark:shadow-xl"
+      class="relative col-span-1 flex flex-col justify-between bg-white p-5 dark:bg-gray-800 rounded-md shadow-lg dark:shadow-xl"
     >
       <div class="flex flex-col">
         <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-400">
@@ -438,7 +438,7 @@ defmodule PlausibleWeb.Live.Sites do
     >
       <.unstyled_link
         href={Routes.stats_path(PlausibleWeb.Endpoint, :stats, @consolidated_view.domain, [])}
-        class="flex flex-col justify-between gap-6 h-full bg-white p-6 dark:bg-gray-900 rounded-md shadow-sm cursor-pointer hover:shadow-md transition-shadow duration-150"
+        class="flex flex-col justify-between gap-6 h-full bg-white p-5 dark:bg-gray-900 rounded-md shadow-sm cursor-pointer hover:shadow-md transition-shadow duration-150"
       >
         <div class="flex flex-col flex-1 justify-between gap-y-5">
           <div class="flex flex-col gap-y-2 mb-auto">
@@ -573,7 +573,7 @@ defmodule PlausibleWeb.Live.Sites do
         }
         class="block group-has-[.phx-click-loading]/sort:animate-pulse group-has-[.phx-click-loading]/sort:pointer-events-none"
       >
-        <div class="col-span-1 flex flex-col gap-y-5 bg-white dark:bg-gray-900 rounded-md shadow-sm p-6 group-hover:shadow-lg cursor-pointer transition duration-100">
+        <div class="col-span-1 flex flex-col gap-y-5 bg-white dark:bg-gray-900 rounded-md shadow-sm p-5 group-hover:shadow-lg cursor-pointer transition duration-100">
           <div class="w-full flex items-center justify-between gap-x-2.5">
             <.favicon domain={@site.domain} />
             <div class="flex-1 w-full">

--- a/lib/plausible_web/templates/layout/settings.html.heex
+++ b/lib/plausible_web/templates/layout/settings.html.heex
@@ -1,14 +1,14 @@
 <% options = account_settings_sidebar(assigns) %>
 <div class="container pt-6">
-  <.styled_link class="font-semibold text-sm" href="/sites">
+  <.styled_link class="font-medium text-sm" href="/sites">
     ← Back to sites
   </.styled_link>
-  <div class="pb-5 border-b border-gray-200 dark:border-gray-750">
-    <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate">
+  <div class="pt-0.5 pb-4 border-b border-gray-200 dark:border-gray-750">
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 sm:text-2xl sm:truncate">
       Settings
     </h2>
   </div>
-  <div class="lg:grid lg:grid-cols-12 lg:gap-x-5 lg:mt-4">
+  <div class="lg:grid lg:grid-cols-12 lg:gap-x-5 lg:mt-1.5">
     <div class="lg:col-span-3">
       <.mobile_nav_dropdown
         name="settings"
@@ -20,7 +20,7 @@
       <div class="hidden lg:flex flex-col gap-8 py-4 top-0 sticky">
         <div class="flex flex-col gap-4">
           <div>
-            <h3 class="text-gray-900 dark:text-gray-100 font-bold">Account</h3>
+            <h3 class="text-gray-900 dark:text-gray-100 font-semibold">Account</h3>
             <p class="text-sm text-gray-500 dark:text-gray-400 truncate">
               {@current_user.email}
             </p>
@@ -33,7 +33,7 @@
 
         <div :if={Plausible.Teams.setup?(@current_team)} class="flex flex-col gap-4">
           <div>
-            <h3 class="text-gray-900 dark:text-gray-100 font-bold">Team</h3>
+            <h3 class="text-gray-900 dark:text-gray-100 font-semibold">Team</h3>
             <p class="text-sm text-gray-500 dark:text-gray-400 truncate">
               {Plausible.Teams.name(@current_team)}
             </p>

--- a/lib/plausible_web/templates/layout/site_settings.html.heex
+++ b/lib/plausible_web/templates/layout/site_settings.html.heex
@@ -1,17 +1,17 @@
 <% options = site_settings_sidebar(@conn) %>
 <div class="container pt-6">
   <.styled_link
-    class="text-indigo-600 font-semibold text-sm"
+    class="text-indigo-600 font-medium text-sm"
     href={"/#{URI.encode_www_form(@site.domain)}"}
   >
     ← Back to stats
   </.styled_link>
-  <div class="pb-5 border-b border-gray-200 dark:border-gray-750">
-    <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:text-3xl sm:leading-9 sm:truncate">
+  <div class="pt-0.5 pb-4 border-b border-gray-200 dark:border-gray-750">
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 sm:text-2xl sm:truncate">
       Settings for {Plausible.Sites.display_name(@site)}
     </h2>
   </div>
-  <div class="lg:grid lg:grid-cols-12 lg:gap-x-5 lg:mt-4">
+  <div class="lg:grid lg:grid-cols-12 lg:gap-x-5 lg:mt-1.5">
     <div class="lg:col-span-3">
       <.mobile_nav_dropdown
         conn={@conn}


### PR DESCRIPTION
### Changes

- Hide changelog notification `li` if there are no updates, to avoid empty space
- Hide site ownership invitations `div` if there are no invitations, to avoid empty space
- Reduce spacing between header and content on sites and settings pages
- Reduce font size of page titles on sites and settings pages
- Slightly reduce logo size in header
- Reduce spacing between site cards on sites page

### Tests
- [x] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog

### Documentation
- [x] This change does not need a documentation update

### Dark mode
- [x] The UI has been tested both in dark and light mode